### PR TITLE
CX release 3: Transfer QAX aspect  models from internal githup to TractusX

### DIFF
--- a/io.catenax.fleet.claim_data/1.0.0/ClaimData.ttl
+++ b/io.catenax.fleet.claim_data/1.0.0/ClaimData.ttl
@@ -1,0 +1,232 @@
+#######################################################################
+# Copyright (c) 2022 BASF SE
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright (c) 2022 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2022 Henkel AG & Co. KGaA
+# Copyright (c) 2022 Mercedes Benz AG
+# Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022 T-Systems International GmbH
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.fleet.claim_data:1.0.0#>.
+
+:ClaimData a bamm:Aspect;
+    bamm:preferredName "ClaimData"@en;
+    bamm:description "Claim data from a fleet"@en;
+    bamm:properties (:listOfClaims);
+    bamm:operations ();
+    bamm:events ().
+:listOfClaims a bamm:Property;
+    bamm:preferredName "listOfClaims"@en;
+    bamm:description "List of Claims"@en;
+    bamm:characteristic :ListOfClaims.
+:ListOfClaims a bamm-c:List;
+    bamm:preferredName "ListOfClaims"@en;
+    bamm:description "List of Claims"@en;
+    bamm:dataType :Claim.
+:Claim a bamm:Entity;
+    bamm:preferredName "Text"@en;
+    bamm:description "everything to describe a claim"@en;
+    bamm:properties ([
+  bamm:property :listOfDiagnosticSessionId;
+  bamm:optional "true"^^xsd:boolean
+] :repairMileage :repairDate :technicianComment [
+  bamm:property :customerComment;
+  bamm:optional "true"^^xsd:boolean
+] :claimId :vehicleIdentifiers :listOfParts :qualityTaskId [
+  bamm:property :damageCode;
+  bamm:optional "true"^^xsd:boolean
+]).
+:listOfDiagnosticSessionId a bamm:Property;
+    bamm:preferredName "ListOfDiagnosticSessionId"@en;
+    bamm:description "references to a list of diagnostic session IDs"@en;
+    bamm:characteristic :ListOfDiagnosticSessions;
+    bamm:exampleValue "20221205-04".
+:repairMileage a bamm:Property;
+    bamm:preferredName "Repair mileage"@en;
+    bamm:description "mileage of the car when the claim was reported"@en;
+    bamm:characteristic :Mileage;
+    bamm:exampleValue "10251"^^xsd:positiveInteger.
+:repairDate a bamm:Property;
+    bamm:preferredName "RepairDate"@en;
+    bamm:description "references the date when claim was initially reported"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:exampleValue "2022-02-04T14:48:54"^^xsd:dateTime.
+:technicianComment a bamm:Property;
+    bamm:preferredName "TechnicianComment"@en;
+    bamm:description "short description of the claim from the technicians"@en;
+    bamm:characteristic bamm-c:MultiLanguageText;
+    bamm:exampleValue "Lenkung ist defekt"^^rdf:langString.
+:customerComment a bamm:Property;
+    bamm:preferredName "CustomerComment"@en;
+    bamm:description "short description of the claim from customer view"@en;
+    bamm:characteristic bamm-c:MultiLanguageText;
+    bamm:exampleValue "Lenkung ist defekt"^^rdf:langString.
+:claimId a bamm:Property;
+    bamm:preferredName "ClaimID"@en;
+    bamm:description "Claim ID: Unique for each OEM"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "a214-13d6".
+:vehicleIdentifiers a bamm:Property;
+    bamm:preferredName "vehicle identifiers"@en;
+    bamm:description "one single vehicle"@en;
+    bamm:characteristic :VehicleIdentifiersCharacteristic.
+:listOfParts a bamm:Property;
+    bamm:preferredName "ListOfParts"@en;
+    bamm:description "a list of parts which will be replaced or repaired"@en;
+    bamm:characteristic :ListOfPartsCharacteristic.
+:damageCode a bamm:Property;
+    bamm:preferredName "DamageCode"@en;
+    bamm:description "OEM-specific damage code"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Lenkmuffe".
+:ListOfDiagnosticSessions a bamm-c:List;
+    bamm:preferredName "List of diagnostic Sessions"@en;
+    bamm:description "references to a list of diagnostic session IDs - only present if matching between diag session and claim is possible"@en;
+    bamm-c:elementCharacteristic bamm-c:Text.
+:Mileage a bamm-c:Measurement;
+    bamm:preferredName "Mileage"@en;
+    bamm:dataType xsd:positiveInteger;
+    bamm-c:unit unit:kilometre.
+:VehicleIdentifiersCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Vehicle"@en;
+    bamm:description "one single vehicle"@en;
+    bamm:dataType :VehicleIdentifiers.
+:ListOfPartsCharacteristic a bamm-c:SingleEntity;
+    bamm:preferredName "ListOfPartsCharacteristic"@en;
+    bamm:description "a list of parts"@en;
+    bamm:dataType :ClaimedPart.
+:VehicleIdentifiers a bamm:Entity;
+    bamm:preferredName "Vehicle identifiers"@en;
+    bamm:description "one single vehicle"@en;
+    bamm:properties ([
+  bamm:property :vehicleCatenaXId;
+  bamm:optional "true"^^xsd:boolean
+] :anonymizedVIN).
+:ClaimedPart a bamm:Entity;
+    bamm:preferredName "Part"@en;
+    bamm:description "one specific part"@en;
+    bamm:properties (:isPartReplaced :isPartCausal [
+  bamm:property :amountOfReplacedParts;
+  bamm:optional "true"^^xsd:boolean
+] :replacedPart :sparePart).
+:vehicleCatenaXId a bamm:Property;
+    bamm:preferredName "vehicleCatenaXId"@en;
+    bamm:description "Catena-X car ID /digital twin of car"@en;
+    bamm:characteristic :CatenaXIdTrait;
+    bamm:exampleValue "580d3adf-1981-44a0-a214".
+:anonymizedVIN a bamm:Property;
+    bamm:preferredName "Anonymized Vin"@en;
+    bamm:description "OEM-specific hashed VIN; link to car data over pseydomized/hashed VIN or Catena-X unique digital twin identifier"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "ABC20654378784512".
+:isPartReplaced a bamm:Property;
+    bamm:preferredName "IsPartReplaced"@en;
+    bamm:description "flag is set if part was replaced\nTrue: replaced\nFalse: not replaced"@en;
+    bamm:characteristic bamm-c:Boolean;
+    bamm:exampleValue "True"^^xsd:boolean.
+:isPartCausal a bamm:Property;
+    bamm:preferredName "IsPartCausal"@en;
+    bamm:description "flag set to True if part was causing the problem\nTrue: part caused the problem\nFalse: part didn't cause the problem\n"@en;
+    bamm:characteristic bamm-c:Boolean;
+    bamm:exampleValue "True"^^xsd:boolean.
+:amountOfReplacedParts a bamm:Property;
+    bamm:preferredName "AmountOfReplacedParts"@en;
+    bamm:description "counter for non-serial parts which have been replaced"@en;
+    bamm:characteristic :AmountOfReplacedPartsCharacteristic;
+    bamm:exampleValue "2"^^xsd:nonNegativeInteger.
+:replacedPart a bamm:Property;
+    bamm:preferredName "ReplacedPart"@en;
+    bamm:description "the part which was affected and replaced"@en;
+    bamm:characteristic :PartCharacteristic.
+:sparePart a bamm:Property;
+    bamm:preferredName "Spare Part"@en;
+    bamm:description "the part which has been built in"@en;
+    bamm:characteristic :PartCharacteristic.
+:CatenaXIdTrait a bamm-c:Trait;
+    bamm:preferredName "Catena-X ID Trait"@en;
+    bamm:description "Trait to ensure data format for Catena-X ID"@en;
+    bamm-c:baseCharacteristic :UUIDv4;
+    bamm-c:constraint :UUIDv4RegularExpression.
+:AmountOfReplacedPartsCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Amount of replaced Parts"@en;
+    bamm:description "counter for non-serial parts"@en;
+    bamm:dataType xsd:nonNegativeInteger.
+:PartCharacteristic a bamm-c:SingleEntity;
+    bamm:preferredName "Part Characteristic"@en;
+    bamm:description "the characteristics of a part"@en;
+    bamm:dataType :Part.
+:Part a bamm:Entity;
+    bamm:preferredName "Part"@en;
+    bamm:description "a generic description of part of the car"@en;
+    bamm:properties (:number :name [
+  bamm:property :serialNumber;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :catenaXId;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :supplierId;
+  bamm:optional "true"^^xsd:boolean
+]).
+:number a bamm:Property;
+    bamm:preferredName "Number"@en;
+    bamm:description "OEM specific partnumber"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "FZ206460050202212".
+:name a bamm:Property;
+    bamm:preferredName "Name"@en;
+    bamm:description "OEM specific name of the part"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Getriebe".
+:serialNumber a bamm:Property;
+    bamm:preferredName "SerialNumber"@en;
+    bamm:description "OEM serial part number of the part - only available for serial parts"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "ECU20646005020221".
+:catenaXId a bamm:Property;
+    bamm:preferredName "Catena-X Identifier"@en;
+    bamm:description "The fully anonymous Catena-X ID of the part, valid for the Catena-X dataspace."@en;
+    bamm:characteristic :CatenaXIdTrait;
+    bamm:exampleValue "580d3adf-1981-44a0-a214-13d6ceed9379".
+:supplierId a bamm:Property;
+    bamm:preferredName "SupplierID"@en;
+    bamm:description "OEM-specific ID of the supplier that manufactured the part that was put out - available if known"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "ZF2064600502".
+:UUIDv4 a bamm:Characteristic;
+    bamm:preferredName "UUIDv4"@en;
+    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    bamm:dataType xsd:string.
+:UUIDv4RegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "Catena-X Id Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \\\"urn:uuid:\\\" to make it an IRI."@en;
+    bamm:see <https://datatracker.ietf.org/doc/html/rfc4122>;
+    bamm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)".
+:qualityTaskId a bamm:Property;
+    bamm:preferredName "QualityTaskID"@en;
+    bamm:description "Reference to  Quality Task: A unique identifier. The company creating this quality task sets this identifer. The identifier should contain the BPN to make it unique inside CX network"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "BPN-811_2022_000001".

--- a/io.catenax.fleet.claim_data/1.0.0/metadata.json
+++ b/io.catenax.fleet.claim_data/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.fleet.claim_data/RELEASE_NOTES.md
+++ b/io.catenax.fleet.claim_data/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [Unreleased]
+
+## [1.0.0] - 2022-12-13
+### Added
+- initial version of this model
+
+### Changed
+n/a
+
+### Removed
+

--- a/io.catenax.fleet.diagnostic_data/1.0.0/DiagnosticData.ttl
+++ b/io.catenax.fleet.diagnostic_data/1.0.0/DiagnosticData.ttl
@@ -1,0 +1,467 @@
+#######################################################################
+# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022 Mercedes Benz AG
+# Copyright (c) 2022 Volkswagen AG
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.fleet.diagnostic_data:1.0.0#>.
+
+:DiagnosticData a bamm:Aspect;
+    bamm:description "data model for vehicle diagnostic data suitable for mass data transfer"@en;
+    bamm:properties (:diagnosticSessions);
+    bamm:operations ();
+    bamm:events ().
+:diagnosticSessions a bamm:Property;
+    bamm:description "list of diagnostic sessions, e.g. from a list of vehicles/fleet"@en;
+    bamm:characteristic :DiagnosticSessions;
+    bamm:preferredName "Diagnostic sessions"@en.
+:DiagnosticSessions a bamm-c:List;
+    bamm:description "A list of diagnostic sessions coming from several vehicles"@en;
+    bamm:preferredName "Diagnostic sessions"@en;
+    bamm:dataType :DiagnosticSession.
+:DiagnosticSession a bamm:Entity;
+    bamm:description "One diagnostic session of one vehicle: Depending on the diagnostic software used in either workshops or over-the-air diagnostics one session can be defined differently:\n- Workshop diagnostic: Normally for each command to the diagnostic tester is a session diagnostic file created that is later send to the OEM backend system. Examples for one command: Read-out all ECUs with its DTCs or do a Software upgrade of one ECU\n- Over-the-air: E.g. one diagnostic snapshot is taken after ignition-on\n\nIn addition a list of environment conditions can be placed as well as a list of AdditionalInfos.\n\nBoth lists are on DiagnosticDataSession level because they can be valid for the whole vehicle(e.g. environment temperature) or only for a specific ECU (e.g. wheel speed sensor at ABS ECU)"@en;
+    bamm:properties (:creationDate :sessionId [
+  bamm:property :qualityTaskId;
+  bamm:optional "true"^^xsd:boolean
+] :countryCode :mileage :vehicle [
+  bamm:property :workshop;
+  bamm:optional "true"^^xsd:boolean
+] :ecuList [
+  bamm:property :dtcList;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :envConditionList;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :eventList;
+  bamm:optional "true"^^xsd:boolean
+]).
+:creationDate a bamm:Property;
+    bamm:description "date-timestamp for this session according ISO 8601 when this session was created. Depending on OEM this attribute reflects the start or end date of one diag session"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:preferredName "Creationdate"@en;
+    bamm:exampleValue "2022-02-04T14:48:54"^^xsd:dateTime.
+:sessionId a bamm:Property;
+    bamm:description "Format OEM-specific: A unique session identifier within one OEM."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "Session identifier"@en;
+    bamm:exampleValue "3747429FGH382923974682".
+:qualityTaskId a bamm:Property;
+    bamm:description "A unique quality task identifier where these list of session data belongs to. Optional to ensure that also Diagnostic Data without assigned qTask can be exchanged."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "Quality Task ID"@en;
+    bamm:exampleValue "BPN-811_2022_000001".
+:countryCode a bamm:Property;
+    bamm:description "country code in  ISO 3166-1 alpha-3 codes where this session took place"@en;
+    bamm:characteristic :CountryCodeTrait;
+    bamm:preferredName "Country Code"@en;
+    bamm:exampleValue "DEU".
+:mileage a bamm:Property;
+    bamm:description "current mileage counter of the car during the diagnostic session"@en;
+    bamm:characteristic :Mileage;
+    bamm:preferredName "Session mileage"@en;
+    bamm:exampleValue "23500"^^xsd:positiveInteger.
+:vehicle a bamm:Property;
+    bamm:description "vehicle that was present in the diagnostic session"@en;
+    bamm:characteristic :VehicleCharacteristic.
+:workshop a bamm:Property;
+    bamm:description "due to the fact that diagnostic over the air is also possible a Workshop Entity is optional "@en;
+    bamm:characteristic :WorkshopCharacteristic.
+:ecuList a bamm:Property;
+    bamm:description "list of ECUs that had an entry in its internal failure memory during the diagnostic session"@en;
+    bamm:characteristic :Ecus;
+    bamm:preferredName "ECU list"@en.
+:dtcList a bamm:Property;
+    bamm:description "list of diagnostic trouble codes"@en;
+    bamm:characteristic :DTCList.
+:envConditionList a bamm:Property;
+    bamm:description "A list of environment conditions: E.g. outside temperature measured by the vehicle, a specific value measured by on ECU, ...."@en;
+    bamm:characteristic :EnvironmentConditions;
+    bamm:preferredName "Environment Conditions"@en.
+:eventList a bamm:Property;
+    bamm:description "A list of additional events that were performed during one diagnostic session: Calibration event, SW update event"@en;
+    bamm:characteristic :Events;
+    bamm:preferredName "Events"@en.
+:CountryCodeTrait a bamm-c:Trait;
+    bamm-c:baseCharacteristic :CountryCodeCharacteristic;
+    bamm-c:constraint :CountryCodeRegularExpression.
+:Mileage a bamm-c:Measurement;
+    bamm:description "mileage counter of the car"@en;
+    bamm:dataType xsd:positiveInteger;
+    bamm-c:unit unit:kilometre.
+:VehicleCharacteristic a bamm:Characteristic;
+    bamm:description "describes the vehicle during the diagnostic session"@en;
+    bamm:dataType :Vehicle.
+:WorkshopCharacteristic a bamm:Characteristic;
+    bamm:description "describes the workshop in which this diagnostic session took place"@en;
+    bamm:dataType :Workshop.
+:Ecus a bamm-c:List;
+    bamm:description "A list of ECUs that have a DTC set in this diagnostic session"@en;
+    bamm:dataType :ECU.
+:DTCList a bamm-c:List;
+    bamm:description "list of DTCs"@en;
+    bamm:dataType :DiagnosticTroubleCode.
+:EnvironmentConditions a bamm-c:List;
+    bamm:description "A list of environment conditions, like surrounding temperature, rpm, ..."@en;
+    bamm:preferredName "Environment Conditions"@en;
+    bamm:dataType :EnvironmentCondition.
+:Events a bamm-c:List;
+    bamm:description "A list of additional events that were performed during one diagnostic session: Calibration event, SW update event. Here you can store all kind of events that does not belong to environment conditions or dtcs"@en;
+    bamm:dataType :Event.
+:CountryCodeCharacteristic a bamm:Characteristic;
+    bamm:description "ISO 3166-1 alpha-3 – three-letter country codes "@en;
+    bamm:preferredName "Country Code Characteristic"@en;
+    bamm:dataType xsd:string;
+    bamm:see <https://www.iso.org/iso-3166-country-codes.html>.
+:CountryCodeRegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:description "Regular Expression that ensures a three-letter code "@en;
+    bamm:preferredName "Country Code Regular Expression"@en;
+    bamm:value "^[A-Z][A-Z][A-Z]$".
+:Vehicle a bamm:Entity;
+    bamm:description "all attributes to clearly identify the vehicle during this diagnostic session"@en;
+    bamm:properties (:anonymizedVIN [
+  bamm:property :catenaXId;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :softwareCategory;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :softwareVersion;
+  bamm:optional "true"^^xsd:boolean
+]);
+    bamm:preferredName "Vehicle"@en.
+:Workshop a bamm:Entity;
+    bamm:description "all attributes to clearly identify this workshop"@en;
+    bamm:properties (:workShopId [
+  bamm:property :catenaXId;
+  bamm:optional "true"^^xsd:boolean
+] :latitude :longitude);
+    bamm:preferredName "Workshop"@en.
+:ECU a bamm:Entity;
+    bamm:description "A single ECU that is present/has a DTC set in the diagnostic session"@en;
+    bamm:properties ([
+  bamm:property :catenaXId;
+  bamm:optional "true"^^xsd:boolean
+] :ecuSerialPartNumber :name :description :hwPartNumber :hwVersion :swPartNumber :swVersion [
+  bamm:property :assemblyPartNumber;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :assemblyPartNumberVersion;
+  bamm:optional "true"^^xsd:boolean
+] :readOutDate);
+    bamm:preferredName "ECU"@en.
+:DiagnosticTroubleCode a bamm:Entity;
+    bamm:description "diagnostic trouble codes or short DTCs are used inside ECUs to monitor failures. They were introduced for measuring vehicle emissions. Major DTCs for emissions are standardized by ISO standard ISO 15031-6:2015 - so called OBD2 standard. Over time DTCs were also introduced in other ECUs also besides engine and emission control. Many DTCs are vehicle manufacturer specific.\n"@en;
+    bamm:properties (:ecuSerialPartNumber [
+  bamm:property :dtcHexValue;
+  bamm:optional "true"^^xsd:boolean
+] :fullName :fullDescription :occurenceDateTime :state [
+  bamm:property :isMilOn;
+  bamm:optional "true"^^xsd:boolean
+] :occurenceMileage :faultPath :faultPathDescription [
+  bamm:property :type;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :occurenceCounterTotal;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :freezeFrame;
+  bamm:optional "true"^^xsd:boolean
+]);
+    bamm:preferredName "DTC"@en;
+    bamm:see <https://www.iso.org/standard/66369.html>.
+:EnvironmentCondition a bamm:Entity;
+    bamm:description "One environment condition like temperature, rpm,...\nIf the environment condition was measured on vehicle level -> ecuSerialPartNumber is empty"@en;
+    bamm:properties (:conditionId :conditionCreationDate :conditionDescription :conditionValue :measurementUnit [
+  bamm:property :ecuSerialPartNumber;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :dtcHexValue;
+  bamm:optional "true"^^xsd:boolean
+]);
+    bamm:preferredName "Environment Condition"@en.
+:Event a bamm:Entity;
+    bamm:description "If additional information/events are available during this session: This object can be used for calibration information, software updates, ...\nIf this event was measured on vehicle level -> ecuSerialPartNumber is empty"@en;
+    bamm:properties (:eventId :eventCreationDate :eventDescription :eventValue [
+  bamm:property :ecuSerialPartNumber;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :dtcHexValue;
+  bamm:optional "true"^^xsd:boolean
+]);
+    bamm:preferredName "Event"@en.
+:anonymizedVIN a bamm:Property;
+    bamm:description "OEM-specific hashed VIN; link to car data over pseydomized/hashed VIN or Catena-X unique digital twin identifier"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "Anonymized VIN"@en;
+    bamm:exampleValue "3747429FGH382923974682".
+:catenaXId a bamm:Property;
+    bamm:description "A fully anonymous Catena-X identifier that is registered in C-X Digital twin registry. This proprty be used for vehicles, parts, workshops, .....\nOptional: Not always available "@en;
+    bamm:characteristic :CatenaXIdTrait;
+    bamm:preferredName "Catena-X Identifier"@en;
+    bamm:exampleValue "urn:uuid:580d3adf-1981-44a0-a214-13d6ceed9379".
+:softwareCategory a bamm:Property;
+    bamm:description "Software category of this car during the session - only available for OEMs that have a software category on vehicle level."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "Vehicle software category"@en;
+    bamm:exampleValue "TZGH64738".
+:softwareVersion a bamm:Property;
+    bamm:description "Software version of this car during the session - only available for OEMs that have a software category on vehicle level."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "Vehicle software version"@en;
+    bamm:exampleValue "3.5.0001.001".
+:workShopId a bamm:Property;
+    bamm:description "OEM internal workshop ID"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "OEM Workshop ID"@en;
+    bamm:exampleValue "4563328".
+:latitude a bamm:Property;
+    bamm:description "Latitude of this workshop"@en;
+    bamm:characteristic :LatitudeTrait;
+    bamm:preferredName "Latitude"@en;
+    bamm:exampleValue "9.19968"^^xsd:float.
+:longitude a bamm:Property;
+    bamm:description "Longitude of this workshop"@en;
+    bamm:characteristic :LongitudeTrait;
+    bamm:preferredName "Longitude"@en;
+    bamm:exampleValue "48.77765"^^xsd:float.
+:ecuSerialPartNumber a bamm:Property;
+    bamm:description "serial number of ECU"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "ECU serial  part number"@en;
+    bamm:exampleValue "74343070GHKER73727".
+:name a bamm:Property;
+    bamm:description "name of ecu"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "ECU name"@en;
+    bamm:exampleValue "ABS".
+:description a bamm:Property;
+    bamm:description "long name of ecu"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "ECU description"@en;
+    bamm:exampleValue "Anti blocking control unit".
+:hwPartNumber a bamm:Property;
+    bamm:description "hardware part number of ECU"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "ECU HW part number"@en;
+    bamm:exampleValue "04C907309AE".
+:hwVersion a bamm:Property;
+    bamm:description "hardware version of ECU"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "ECU HW version"@en;
+    bamm:exampleValue "0556A".
+:swPartNumber a bamm:Property;
+    bamm:description "SW part number of this ecu"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "ECU SW part number"@en;
+    bamm:exampleValue "04C906026BH".
+:swVersion a bamm:Property;
+    bamm:description "current version of the software on this ecu"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "ECU SW version"@en;
+    bamm:exampleValue "0001".
+:assemblyPartNumber a bamm:Property;
+    bamm:description "OEM-sepcific ecu assembly from hardware and software"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "ECU assembly part number"@en;
+    bamm:exampleValue "V03935278E".
+:assemblyPartNumberVersion a bamm:Property;
+    bamm:description "OEM-sepcific ecu assembly version"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "ECU assembly part number version"@en;
+    bamm:exampleValue "0001".
+:readOutDate a bamm:Property;
+    bamm:description "Date when this ECU information was read out from the diagnostic session"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:preferredName "Read out date"@en;
+    bamm:exampleValue "2022-01-30T14:45:54"^^xsd:dateTime.
+:dtcHexValue a bamm:Property;
+    bamm:description "Hex value of this DTC"@en;
+    bamm:characteristic :FreezeFrameTrait;
+    bamm:preferredName "Hex"@en;
+    bamm:exampleValue "4337499FF".
+:fullName a bamm:Property;
+    bamm:description "combined string of DTC name  plus the so called DTC sub type or DTC failure byte. Both string values are concatenated using a \"-\" as separator.\nDTC name is: B|C|P|U + 4 hex chars\nDTC failure byte: 2 hex chars\n\nIn some rare cases this could be just a hex string"@en;
+    bamm:characteristic :FullNameTrait;
+    bamm:preferredName "DTC full name:"@en;
+    bamm:exampleValue "P0573-00".
+:fullDescription a bamm:Property;
+    bamm:description "description of DTC and failure byte. Both description strings are concatenated using a \"-\" as separator"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "DTC description"@en;
+    bamm:exampleValue "Brake Switch \"A\" Circuit High-no sub type information".
+:occurenceDateTime a bamm:Property;
+    bamm:description "date and time when the DTC occured the first time/was recorded the first time in the ECU"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:preferredName "DTC first occurence"@en;
+    bamm:exampleValue "2022-01-30T14:48:54"^^xsd:dateTime.
+:state a bamm:Property;
+    bamm:description "OEM-specific state of DTC: 0;1 (permanent/temporary/intermediate), could also be a string with permanent, temporary, intermediate, ...."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "DTC state"@en;
+    bamm:exampleValue "permanent".
+:isMilOn a bamm:Property;
+    bamm:description "describes whether this DTC set the MIL (malfunction indicator light)  in the dashboard"@en;
+    bamm:characteristic bamm-c:Boolean;
+    bamm:preferredName "Is MIL On"@en;
+    bamm:exampleValue "true"^^xsd:boolean.
+:occurenceMileage a bamm:Property;
+    bamm:description "mileage in km when the DTC occurred the first time "@en;
+    bamm:characteristic :Mileage;
+    bamm:preferredName "DTC first occurence mileage"@en;
+    bamm:exampleValue "15000"^^xsd:positiveInteger.
+:faultPath a bamm:Property;
+    bamm:description "OEM-specific: Fault path for this DTC. Allows further analysis"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "DTC fault path"@en;
+    bamm:exampleValue "1000761".
+:faultPathDescription a bamm:Property;
+    bamm:description "OEM-specific description of DTC fault path"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "DTC fault path description"@en;
+    bamm:exampleValue "shortage to plus".
+:type a bamm:Property;
+    bamm:description "Indicator whether this DTC was stored as Error or Info"@en;
+    bamm:characteristic :TypeEnum;
+    bamm:preferredName "Type"@en;
+    bamm:exampleValue "Error".
+:occurenceCounterTotal a bamm:Property;
+    bamm:description "Counter how often this DTC was set in total"@en;
+    bamm:characteristic :Long;
+    bamm:preferredName "Occurence counter"@en;
+    bamm:exampleValue "10"^^xsd:long.
+:freezeFrame a bamm:Property;
+    bamm:description "freeze frame from ecu. The freeze frame records many parameters of the DTC and surrounding parameters like outside temperature when the DTC was set. It is a very long HEX string with many OEM-specific and ECU-specific content in"@en;
+    bamm:characteristic :FreezeFrameTrait;
+    bamm:preferredName "DTC freeze frame"@en;
+    bamm:exampleValue "100148340349340".
+:conditionId a bamm:Property;
+    bamm:description "OEM-specific: Primary key for this condition consists of unique identifier of env. condition and DTC"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "Id"@en;
+    bamm:exampleValue "DTC1_EnvCond1".
+:conditionCreationDate a bamm:Property;
+    bamm:description "Date and time when this condition/information was created."@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:preferredName "Creation Date"@en;
+    bamm:exampleValue "2022-01-28T14:48:54"^^xsd:dateTime.
+:conditionDescription a bamm:Property;
+    bamm:description "The description of the environment condition/information"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "Description"@en;
+    bamm:exampleValue "RPM".
+:conditionValue a bamm:Property;
+    bamm:description "The numeric value (if applicable) of the stored environment condition at the time of the DTC."@en;
+    bamm:characteristic :Double;
+    bamm:preferredName "Value"@en;
+    bamm:exampleValue "2000.0"^^xsd:double.
+:measurementUnit a bamm:Property;
+    bamm:description "The unit of measurement for the environment condition value."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "DTC fault path"@en;
+    bamm:exampleValue "rpm".
+:eventId a bamm:Property;
+    bamm:description "OEM-specific: Primary key for this event"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "Id"@en;
+    bamm:exampleValue "ABS_CAL1234".
+:eventCreationDate a bamm:Property;
+    bamm:description "Date and time when this event was created."@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:preferredName "Creation Date"@en;
+    bamm:exampleValue "2022-01-30T14:00:00"^^xsd:dateTime.
+:eventDescription a bamm:Property;
+    bamm:description "The description of the event"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "Description"@en;
+    bamm:exampleValue "Calibration of ABS ecu with calib file - see value".
+:eventValue a bamm:Property;
+    bamm:description "The value of this event."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:preferredName "Value"@en;
+    bamm:exampleValue "CAL366474-4848".
+:CatenaXIdTrait a bamm-c:Trait;
+    bamm:description "Trait to ensure data format for Catena-X ID"@en;
+    bamm:preferredName "Catena-X ID Trait"@en;
+    bamm-c:baseCharacteristic :UUIDv4;
+    bamm-c:constraint :UUIDv4RegularExpression.
+:UUIDv4 a bamm:Characteristic;
+    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    bamm:preferredName "UUIDv4"@en;
+    bamm:dataType xsd:string.
+:UUIDv4RegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), prefixed by \"urn:uuid:\" to make it an IRI."@en;
+    bamm:preferredName "Catena-X Id Regular Expression"@en;
+    bamm:see <https://datatracker.ietf.org/doc/html/rfc4122>;
+    bamm:value "^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$".
+:LatitudeTrait a bamm-c:Trait;
+    bamm-c:baseCharacteristic :Latitude;
+    bamm-c:constraint :ConstraintLatitude.
+:LongitudeTrait a bamm-c:Trait;
+    bamm-c:baseCharacteristic :Longitude;
+    bamm-c:constraint :ConstraintLongitude.
+:Latitude a bamm:Characteristic;
+    bamm:description "Latitude of this workshop"@en;
+    bamm:dataType xsd:float.
+:ConstraintLatitude a bamm-c:RangeConstraint;
+    bamm-c:minValue "-90.0"^^xsd:float;
+    bamm-c:maxValue "90.0"^^xsd:float;
+    bamm-c:lowerBoundDefinition bamm-c:AT_LEAST;
+    bamm-c:upperBoundDefinition bamm-c:AT_MOST.
+:Longitude a bamm:Characteristic;
+    bamm:dataType xsd:float.
+:ConstraintLongitude a bamm-c:RangeConstraint;
+    bamm-c:minValue "-180.0"^^xsd:float;
+    bamm-c:maxValue "180.0"^^xsd:float;
+    bamm-c:lowerBoundDefinition bamm-c:AT_LEAST;
+    bamm-c:upperBoundDefinition bamm-c:AT_MOST.
+:Double a bamm:Characteristic;
+    bamm:description "Double"@en;
+    bamm:preferredName "Double"@en;
+    bamm:dataType xsd:double.
+:FreezeFrameTrait a bamm-c:Trait;
+    bamm-c:baseCharacteristic :HEXString;
+    bamm-c:constraint :HexRegex.
+:HEXString a bamm:Characteristic;
+    bamm:description "allows characters \"A\"-\"F\", \"a\"-\"f\" and \"0\"-\"9\" in this string"@en;
+    bamm:dataType xsd:string.
+:HexRegex a bamm-c:RegularExpressionConstraint;
+    bamm:description "a freeze frame contains only hex chars 0-9, A-F, a-f. Restricted to 8000 chars\n"@en;
+    bamm:value "^[0-9,A-F,a-f]$".
+:FullNameTrait a bamm-c:Trait;
+    bamm-c:baseCharacteristic :FullDTCCharacteristic;
+    bamm-c:constraint :FullDTCRegEx.
+:TypeEnum a bamm-c:Enumeration;
+    bamm:dataType xsd:string;
+    bamm-c:values ("Error" "Info").
+:Long a bamm:Characteristic;
+    bamm:dataType xsd:long.
+:FullDTCCharacteristic a bamm:Characteristic;
+    bamm:description "DTC-FaultByte like P0573-00"@en;
+    bamm:dataType xsd:string.
+:FullDTCRegEx a bamm-c:RegularExpressionConstraint;
+    bamm:description "DTC regular expression to ensure B|C|U|P followed by 4 hex chars followed by \"-\" followed by 2 hex chars"@en;
+    bamm:value "^[B|C|P|U]{1}[0-9,A-F,a-f]{4}[-]{1}[0-9,A-F,a-f]{2}$".

--- a/io.catenax.fleet.diagnostic_data/1.0.0/metadata.json
+++ b/io.catenax.fleet.diagnostic_data/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.fleet.diagnostic_data/RELEASE_NOTES.md
+++ b/io.catenax.fleet.diagnostic_data/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [Unreleased]
+
+## [1.0.0] - 2022-12-13
+### Added
+- initial version of this model
+
+### Changed
+n/a
+
+### Removed
+

--- a/io.catenax.manufactured_parts_quality_information/1.0.0/ManufacturedPartsQualityInformation.ttl
+++ b/io.catenax.manufactured_parts_quality_information/1.0.0/ManufacturedPartsQualityInformation.ttl
@@ -1,0 +1,197 @@
+#######################################################################
+# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022 Mercedes Benz AG
+# Copyright (c) 2022 Volkswagen AG
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.manufactured_parts_quality_information:1.0.0#>.
+
+:ProductionCountryCodeTrait a bamm-c:Trait;
+    bamm:preferredName "Production Country Code Trait"@en;
+    bamm:description "Trait to ensure standard data format for country code"@en;
+    bamm-c:constraint :CountryCodeRegularExpression;
+    bamm-c:baseCharacteristic :CountryCodeCharacteristic.
+:CountryCodeRegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "Country Code Regular Expression"@en;
+    bamm:description "Regular Expression that ensures a three-letter code "@en;
+    bamm:value "^[A-Z][A-Z][A-Z]$".
+:CountryCodeCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Country Code Characteristic"@en;
+    bamm:description "ISO 3166-1 alpha-3 – three-letter country codes "@en;
+    bamm:dataType xsd:string;
+    bamm:see <https://www.iso.org/iso-3166-country-codes.html>.
+:UUIDv4RegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "Catena-X Id Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en;
+    bamm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)";
+    bamm:see <https://datatracker.ietf.org/doc/html/rfc4122>.
+:UUIDv4 a bamm:Characteristic;
+    bamm:preferredName "UUIDv4"@en;
+    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    bamm:dataType xsd:string.
+:CatenaXIdTrait a bamm-c:Trait;
+    bamm:preferredName "Catena-X ID Trait"@en;
+    bamm:description "Trait to ensure data format for Catena-X ID"@en;
+    bamm-c:constraint :UUIDv4RegularExpression;
+    bamm-c:baseCharacteristic :UUIDv4.
+:manufacturerSerialPartNumber a bamm:Property;
+    bamm:preferredName "Manufacturer serial part number"@en;
+    bamm:description "Serial part number given by  the manufacturer. Not available for common parts."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "436347347.4343884384.FTG.538348".
+:nameAtManufacturer a bamm:Property;
+    bamm:preferredName "Manufacturer part name"@en;
+    bamm:description "Name of the manufactured part as given by the manufacturer."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Steering assembly".
+:ManufacturedPartsQualityInformation a bamm:Aspect;
+    bamm:preferredName "Quality information for parts"@en;
+    bamm:description "This aspect model is used to exchange manufacturing-oriented information of several parts, e.g. for quality tasks"@en;
+    bamm:properties (:listOfManufacturedParts);
+    bamm:operations ();
+    bamm:events ().
+:listOfManufacturedParts a bamm:Property;
+    bamm:preferredName "Manufactured parts"@en;
+    bamm:description "A list of manufactured parts and their porperties"@en;
+    bamm:characteristic :ListOfManufacturedParts.
+:ListOfManufacturedParts a bamm-c:List;
+    bamm:preferredName "Manufactured  Parts"@en;
+    bamm:description "A list of manufactured parts"@en;
+    bamm:dataType :ManufacturedPart.
+:catenaXId a bamm:Property;
+    bamm:preferredName "Catena-X ID"@en;
+    bamm:description "The fully anonymous Catena-X ID of the manufactured part - only available after digital twin registry is fully operational"@en;
+    bamm:characteristic :CatenaXIdTrait;
+    bamm:exampleValue "urn:uuid:580d3adf-1981-44a0-a214-13d6ceed9001".
+:qualityTaskId a bamm:Property;
+    bamm:preferredName "Quality Task ID"@en;
+    bamm:description "A unique quality task identifier where this manufacturing information belongs to. Optional to ensure that also data exchange without having a quality task."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "BPN-811_2022_000001".
+:manufacturingInformation a bamm:Property;
+    bamm:preferredName "Manufacturing information"@en;
+    bamm:description "Collection of defined manufacturing-related properties for this part"@en;
+    bamm:characteristic :ManufacturingCharacteristic.
+:ManufacturingCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Manufacturing Characteristic"@en;
+    bamm:description "Collection of defined manufacturing-related properties for this part"@en;
+    bamm:dataType :Manufacturing.
+:Manufacturing a bamm:Entity;
+    bamm:preferredName "Manufacturing"@en;
+    bamm:description "Collection of defined manufacturing-related properties for this part"@en;
+    bamm:properties (:date :country :plantId :plantDescription :batchId [
+  bamm:property :productionLine;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :hasBeenReworked;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :numberOfConductedEOLTests;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :addtionalInformation;
+  bamm:optional "true"^^xsd:boolean
+]).
+:date a bamm:Property;
+    bamm:preferredName "Production Date"@en;
+    bamm:description "Date of manufacturing"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:exampleValue "2022-02-04T14:48:54"^^xsd:dateTime.
+:country a bamm:Property;
+    bamm:preferredName "Country code"@en;
+    bamm:description "Country code where the part was manufactured"@en;
+    bamm:characteristic :ProductionCountryCodeTrait;
+    bamm:exampleValue "DEU".
+:plantId a bamm:Property;
+    bamm:preferredName "Plant id"@en;
+    bamm:description "Manufacturer-specific identifier of a the production plant of this part"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "00001".
+:plantDescription a bamm:Property;
+    bamm:preferredName "Plant description"@en;
+    bamm:description "Manufacturer-specific description of the production plant of this part"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Feuerbach Plant".
+:batchId a bamm:Property;
+    bamm:preferredName "Batch number"@en;
+    bamm:description "Manufacturer-specific batch identifier: In which batch was this part manufactured"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "20220204_466".
+:productionLine a bamm:Property;
+    bamm:preferredName "Production line"@en;
+    bamm:description "On which production line was this part produced"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Line_1".
+:hasBeenReworked a bamm:Property;
+    bamm:preferredName "Reworked"@en;
+    bamm:description "Indicator whether this part was reworked during manufacturing"@en;
+    bamm:characteristic bamm-c:Boolean;
+    bamm:exampleValue "false"^^xsd:boolean.
+:numberOfConductedEOLTests a bamm:Property;
+    bamm:preferredName "Conducted EOL test"@en;
+    bamm:description "Number how often this part went through the EOL test"@en;
+    bamm:characteristic :PositiveNumber;
+    bamm:exampleValue "1"^^xsd:positiveInteger.
+:addtionalInformation a bamm:Property;
+    bamm:preferredName "Additional information"@en;
+    bamm:description "You can use this key:value list for additional properties that were not defined in this aspect model."@en;
+    bamm:characteristic :ListOfAdditionalInformation.
+:PositiveNumber a bamm:Characteristic;
+    bamm:dataType xsd:positiveInteger.
+:ListOfAdditionalInformation a bamm-c:List;
+    bamm:preferredName "Additional information list"@en;
+    bamm:dataType :AdditionalInformation.
+:AdditionalInformation a bamm:Entity;
+    bamm:preferredName "Additional information"@en;
+    bamm:description "One key:value information pair"@en;
+    bamm:properties (:key :value).
+:key a bamm:Property;
+    bamm:preferredName "Key id"@en;
+    bamm:description "Key identifier for this additional information"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Steel quality".
+:value a bamm:Property;
+    bamm:preferredName "Value"@en;
+    bamm:description "Value for this additional information"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Stainless steel".
+:ManufacturedPart a bamm:Entity;
+    bamm:preferredName "Manufactured part"@en;
+    bamm:description "Manufacturing information for one part. Important properties are standardized. Besides that there is a key:value list to exchange further non-standardized properties for this part"@en;
+    bamm:properties ([
+  bamm:property :catenaXId;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :qualityTaskId;
+  bamm:optional "true"^^xsd:boolean
+] :manufacturerId [
+  bamm:property :manufacturerSerialPartNumber;
+  bamm:optional "true"^^xsd:boolean
+] :nameAtManufacturer :manufacturingInformation).
+:manufacturerId a bamm:Property;
+    bamm:preferredName "Manufacturer ID"@en;
+    bamm:description "Identifier assigned by the manufacturer for this specific part. In case of common parts: This identifier is not unique."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "123-0.740-3434-A".

--- a/io.catenax.manufactured_parts_quality_information/1.0.0/metadata.json
+++ b/io.catenax.manufactured_parts_quality_information/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.manufactured_parts_quality_information/RELEASE_NOTES.md
+++ b/io.catenax.manufactured_parts_quality_information/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [Unreleased]
+
+## [1.0.0] - 2022-12-13
+### Added
+- initial version of this model
+
+### Changed
+n/a
+
+### Removed
+

--- a/io.catenax.parts_analyses/1.0.0/PartsAnalyses.ttl
+++ b/io.catenax.parts_analyses/1.0.0/PartsAnalyses.ttl
@@ -1,0 +1,121 @@
+#######################################################################
+# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022 Mercedes Benz AG
+# Copyright (c) 2022 Volkswagen AG
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.parts_analyses:1.0.0#>.
+
+:UUIDv4RegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "Catena-X Id Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en;
+    bamm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)";
+    bamm:see <https://datatracker.ietf.org/doc/html/rfc4122>.
+:UUIDv4 a bamm:Characteristic;
+    bamm:preferredName "UUIDv4"@en;
+    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    bamm:dataType xsd:string.
+:CatenaXIdTrait a bamm-c:Trait;
+    bamm:preferredName "Catena-X ID Trait"@en;
+    bamm:description "Trait to ensure data format for Catena-X ID"@en;
+    bamm-c:constraint :UUIDv4RegularExpression;
+    bamm-c:baseCharacteristic :UUIDv4.
+:PartAnalysis a bamm:Entity;
+    bamm:preferredName "Part Analysis"@en;
+    bamm:description "The analysis results of ONE part"@en;
+    bamm:properties ([
+  bamm:property :catenaXIdentifier;
+  bamm:optional "true"^^xsd:boolean
+] :manufacturerPartIdentifier [
+  bamm:property :manufacturerSerialPartNumber;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :customerPartIdentifier;
+  bamm:optional "true"^^xsd:boolean
+] :nameAtManufacturer :status :isDefect :resultsDescription :qualityTaskId).
+:catenaXIdentifier a bamm:Property;
+    bamm:preferredName "Catena-X ID"@en;
+    bamm:description "The fully anonymous Catena-X ID of the analyzed part - only available after digital twin registry is fully operational"@en;
+    bamm:characteristic :CatenaXIdTrait;
+    bamm:exampleValue "urn:uuid:580d3adf-1981-44a0-a214-13d6ceed9000".
+:manufacturerPartIdentifier a bamm:Property;
+    bamm:preferredName "Manufacturer Part ID"@en;
+    bamm:description "Part Id of the analyzed part as assigned by the manufacturer of the part. The Part Id identifies the part type and is not unique for each serial part"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "123-0.740-3434-A".
+:manufacturerSerialPartNumber a bamm:Property;
+    bamm:preferredName "Manufacturer serial part identifier ID"@en;
+    bamm:description "Serial Part Number of the analyzed part as assigned by the manufacturer of the part. The serial part number is unique for each serial part. Not available for all kinds of parts."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "436347347.4343884384.FTG.538348".
+:customerPartIdentifier a bamm:Property;
+    bamm:preferredName "Customer part identifier"@en;
+    bamm:description "Part ID as assigned by Original Equipment Manaufacturer."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "PRT-12345".
+:nameAtManufacturer a bamm:Property;
+    bamm:preferredName "Manufacturer part name ID"@en;
+    bamm:description "Name of the analyzed part as assigned by the manufacturer of the part."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Steering assembly".
+:status a bamm:Property;
+    bamm:preferredName "Status"@en;
+    bamm:description "Status of this part analysis"@en;
+    bamm:characteristic :StatusCharacteristic;
+    bamm:exampleValue "new".
+:isDefect a bamm:Property;
+    bamm:preferredName "Part defect flag"@en;
+    bamm:description "True: Analysis turned out that analyzed part is defect accroding part's specification."@en;
+    bamm:characteristic bamm-c:Boolean;
+    bamm:exampleValue "true"^^xsd:boolean.
+:resultsDescription a bamm:Property;
+    bamm:preferredName "Several results of analysis"@en;
+    bamm:description "Detailed description of part analysis results."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Corrossion on component xyz in steering motor".
+:qualityTaskId a bamm:Property;
+    bamm:preferredName "Quality Task ID"@en;
+    bamm:description "A unique quality task identifier where these list of parts analysis belong to."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "BPN-811_2022_000001".
+:StatusCharacteristic a bamm-c:Enumeration;
+    bamm:preferredName "StatusCharacteristic"@en;
+    bamm:description "Enumeration of the different status values"@en;
+    bamm:dataType xsd:string;
+    bamm-c:values ("new" "in progress" "completed" "closed").
+:PartsAnalyses a bamm:Aspect;
+    bamm:preferredName "Part Analysis"@en;
+    bamm:description "List of part analysis for one quality task"@en;
+    bamm:properties (:listOfPartAnalyses);
+    bamm:operations ();
+    bamm:events ().
+:listOfPartAnalyses a bamm:Property;
+    bamm:preferredName "List Of several Part Analyses"@en;
+    bamm:description "A list of several part analyses"@en;
+    bamm:characteristic :ListOfPartsAnalyses.
+:ListOfPartsAnalyses a bamm-c:List;
+    bamm:preferredName "Parts Analyses"@en;
+    bamm:description "A list for all parts analyses"@en;
+    bamm:dataType :PartAnalysis.

--- a/io.catenax.parts_analyses/1.0.0/metadata.json
+++ b/io.catenax.parts_analyses/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.parts_analyses/RELEASE_NOTES.md
+++ b/io.catenax.parts_analyses/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [Unreleased]
+
+## [1.0.0] - 2022-12-13
+### Added
+- initial version of this model
+
+### Changed
+n/a
+
+### Removed
+

--- a/io.catenax.quality_task/1.0.0/QualityTask.ttl
+++ b/io.catenax.quality_task/1.0.0/QualityTask.ttl
@@ -1,0 +1,117 @@
+#######################################################################
+# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022 Mercedes Benz AG
+# Copyright (c) 2022 Volkswagen AG
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.quality_task:1.0.0#>.
+
+:QualityTask a bamm:Aspect;
+    bamm:preferredName "QualityTask"@en;
+    bamm:description "A quality task (qTask) defines why data is exchanged between 2 or more companies and what insights should be generated out of the transferred data. In addition there is a flag, what happens with the transferred data when this qTask is closed"@en;
+    bamm:properties (:qualityTaskId :status :creationDate :title :description :component :dataDeletion :listOfCompanies);
+    bamm:operations ();
+    bamm:events ().
+:qualityTaskId a bamm:Property;
+    bamm:preferredName "q-Task ID"@en;
+    bamm:description "A unique quality task identifier where these list of parts analysis belong to."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "BPN-811_2022_000001".
+:status a bamm:Property;
+    bamm:preferredName "Status"@en;
+    bamm:description "Status of this quality task"@en;
+    bamm:characteristic :StatusCharacteristic;
+    bamm:exampleValue "new".
+:creationDate a bamm:Property;
+    bamm:preferredName "Creation Date"@en;
+    bamm:description "Timestamp when this qTask was created"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:exampleValue "2022-11-11"^^xsd:dateTime.
+:title a bamm:Property;
+    bamm:preferredName "Title"@en;
+    bamm:description "Working title for this qTask"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Evaluation of ComponentA in CarmodelB in country DE".
+:description a bamm:Property;
+    bamm:preferredName "Description"@en;
+    bamm:description "Description what should be done in this qTask"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Please evaluate why there is a high number of customer complaints with ComponentA if the vehicle is between 10000-30000km.".
+:component a bamm:Property;
+    bamm:preferredName "Component"@en;
+    bamm:description "The component that should be investigated in this qTask."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "ComponentA".
+:dataDeletion a bamm:Property;
+    bamm:preferredName "Deletion policy"@en;
+    bamm:description "What should be done with the data after this qTask is closed"@en;
+    bamm:characteristic :DataDeletionEnumeration;
+    bamm:exampleValue "delete-data-after-closing".
+:listOfCompanies a bamm:Property;
+    bamm:preferredName "List of companies"@en;
+    bamm:description "A list of companies involved in this quality task"@en;
+    bamm:characteristic :ListOfCompanies.
+:DataDeletionEnumeration a bamm-c:Enumeration;
+    bamm:preferredName "Data deletion"@en;
+    bamm:description "Enumeration of possible data deletions entries."@en;
+    bamm:dataType xsd:string;
+    bamm-c:values ("delete-data-after-closing" "no-deletion-after-closing").
+:ListOfCompanies a bamm-c:List;
+    bamm:preferredName "Companies"@en;
+    bamm:description "A list of all companies involved in this qTask"@en;
+    bamm:dataType :Company.
+:Company a bamm:Entity;
+    bamm:preferredName "Company"@en;
+    bamm:description "One company involved in this qTask"@en;
+    bamm:properties (:cxBPN :name :email).
+:cxBPN a bamm:Property;
+    bamm:preferredName "CX Business partner number"@en;
+    bamm:description "Catena-X business partner number of this company"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "BPN-811".
+:name a bamm:Property;
+    bamm:preferredName "Company name"@en;
+    bamm:description "Name of the comapny"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Company A".
+:StatusCharacteristic a bamm-c:Enumeration;
+    bamm:preferredName "Status Characteristic"@en;
+    bamm:description "Enumeration of the different status values"@en;
+    bamm:dataType xsd:string;
+    bamm-c:values ("new" "in progress" "completed" "closed").
+:email a bamm:Property;
+    bamm:name "email";
+    bamm:preferredName "email"@en;
+    bamm:description "An email address"@en;
+    bamm:characteristic :EMailTrait;
+    bamm:exampleValue "test.mail@example.com".
+:EMailTrait a bamm-c:Trait;
+     bamm:name "SupplierMailTrait";
+     bamm-c:baseCharacteristic bamm-c:Text;
+     bamm-c:constraint :EMailConstraint.
+:EMailConstraint a bamm-c:RegularExpressionConstraint;
+     bamm:name "EMailConstraint";
+     bamm:value "^[a-zA-Z0-9.!#$%&’*+\\/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$";
+     bamm:description "Regular expression for mail address as defined in W3C (see https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address)"@en.

--- a/io.catenax.quality_task/1.0.0/metadata.json
+++ b/io.catenax.quality_task/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.quality_task/RELEASE_NOTES.md
+++ b/io.catenax.quality_task/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [Unreleased]
+
+## [1.0.0] - 2022-12-13
+### Added
+- initial version of this model
+
+### Changed
+n/a
+
+### Removed
+

--- a/io.catenax.vehicle.product_description/2.0.0/ProductDescription.ttl
+++ b/io.catenax.vehicle.product_description/2.0.0/ProductDescription.ttl
@@ -1,0 +1,462 @@
+#######################################################################
+# Copyright (c) 2022 Allgemeine Deutsche Automobil-Club (ADAC) e.V
+# Copyright (c) 2022 Badische Anilin und Sodafabrik societates Europaea
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022 Deutsches Zentrum für Luft- und Raumfahrt e. V. (DLR)
+# Copyright (c) 2022 Henkel AG & Co. KGaA
+# Copyright (c) 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. für ihre Institute IPK und IPK
+# Copyright (c) 2022 LRP Autorecycling Leipzig GmbH
+# Copyright (c) 2022 Mercedes Benz AG
+# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022 T-Systems International GmbH
+# Copyright (c) 2022 Volkswagen AG
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the 
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license, 
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.vehicle.product_description:2.0.0#>.
+
+:ProductDescription a bamm:Aspect;
+    bamm:preferredName "Vehicle master data"@en;
+    bamm:description "Master data of one vehicle - from an end customer view. So this model represents the vehicle as it was sold to the customer. All entities and properties are immutable over the lifetime of the vehicle."@en;
+    bamm:properties (:oem :vehicle :body :equipments :production :sale :engines :fuel);
+    bamm:operations ();
+    bamm:events ().
+:oem a bamm:Property;
+    bamm:preferredName "OEM"@en;
+    bamm:description "original equipment manufacturer"@en;
+    bamm:characteristic :OEMCharacteristic.
+:vehicle a bamm:Property;
+    bamm:preferredName "vehicle"@en;
+    bamm:description "vehicle: can be a car, bus, truck..."@en;
+    bamm:characteristic :VehicleCharacteristic.
+:body a bamm:Property;
+    bamm:preferredName "vehicle body"@en;
+    bamm:description "vehicle body"@en;
+    bamm:characteristic :BodyCharacteristic.
+:equipments a bamm:Property;
+    bamm:preferredName "Equipments"@en;
+    bamm:description "Equipments"@en;
+    bamm:characteristic :Equipments.
+:production a bamm:Property;
+    bamm:preferredName "Production"@en;
+    bamm:description "bundles production-related information"@en;
+    bamm:characteristic :ProductionCharacteristic.
+:sale a bamm:Property;
+    bamm:preferredName "Sale"@en;
+    bamm:description "bundles all sales related information"@en;
+    bamm:characteristic :SaleCharacteristic.
+:engines a bamm:Property;
+    bamm:preferredName "Engines"@en;
+    bamm:description "List of installed engines in the vehicle"@en;
+    bamm:characteristic :Engines.
+:fuel a bamm:Property;
+    bamm:preferredName "Fuel"@en;
+    bamm:description "the fuel type of the vehicle"@en;
+    bamm:characteristic :FuelCharacteristic.
+:OEMCharacteristic a bamm:Characteristic;
+    bamm:preferredName "OEM Characteristic"@en;
+    bamm:description "OEMCharacteristic"@en;
+    bamm:dataType :OriginalEquipmentManufacturer.
+:VehicleCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Vehicle Characteristic"@en;
+    bamm:description "bundles all general vehicle data"@en;
+    bamm:dataType :Vehicle.
+:BodyCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Body Characteristic"@en;
+    bamm:description "bundles all body-related information"@en;
+    bamm:dataType :Body.
+:Equipments a bamm-c:List;
+    bamm:preferredName "Equipment List"@en;
+    bamm:description "list of equipments installed in the vehicle"@en;
+    bamm:dataType :Equipment.
+:ProductionCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Production Characteristic"@en;
+    bamm:description "Production Characteristic"@en;
+    bamm:dataType :Production.
+:SaleCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Sale Characteristic"@en;
+    bamm:description "Sale Characteristic"@en;
+    bamm:dataType :Sale.
+:Engines a bamm-c:List;
+    bamm:preferredName "Engines"@en;
+    bamm:description "A list of all installed engines in the vehicle"@en;
+    bamm:dataType :Engine.
+:FuelCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Fuel Characteristic"@en;
+    bamm:description "FuelCharacteristic"@en;
+    bamm:dataType :Fuel.
+:OriginalEquipmentManufacturer a bamm:Entity;
+    bamm:preferredName "OEM"@en;
+    bamm:description "describes one OEM to which this vehicle belongs to"@en;
+    bamm:properties (:wmiCode :wmiDescription :cxBPN).
+:Vehicle a bamm:Entity;
+    bamm:preferredName "Vehicle"@en;
+    bamm:description "Vehicle data"@en;
+    bamm:properties (:anonymizedVin [
+  bamm:property :catenaXId;
+  bamm:optional "true"^^xsd:boolean
+] :vehicleSeries :modelDescription :modelIdentifier :class :steeringPos :emptyWeight :driveType :systemPower [
+  bamm:property :hybridizationType;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :softwareCategory;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :softwareVersion;
+  bamm:optional "true"^^xsd:boolean
+]).
+:Body a bamm:Entity;
+    bamm:preferredName "Body"@en;
+    bamm:description "body related data"@en;
+    bamm:properties (:numberOfDoors :colorId :colorDescription [
+  bamm:property :kbaBody;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :nhtsaBody;
+  bamm:optional "true"^^xsd:boolean
+]).
+:Equipment a bamm:Entity;
+    bamm:preferredName "Equipment"@en;
+    bamm:description "one optional equipment in car"@en;
+    bamm:properties (:equipmentIdentifier :equipmentDescription :group).
+:Production a bamm:Entity;
+    bamm:preferredName "Production"@en;
+    bamm:description "production-related data"@en;
+    bamm:properties (:productionDate :plantIdentifier :plantDescription).
+:Sale a bamm:Entity;
+    bamm:preferredName "Sale"@en;
+    bamm:description "all sale-related data"@en;
+    bamm:properties (:soldDate :countryCode :countryGroup).
+:Fuel a bamm:Entity;
+    bamm:preferredName "Fuel"@en;
+    bamm:description "fuel-related data"@en;
+    bamm:properties ([
+  bamm:property :kbaFuelType;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :nhtsaFuelType;
+  bamm:optional "true"^^xsd:boolean
+]).
+:wmiCode a bamm:Property;
+    bamm:preferredName "WMI Code"@en;
+    bamm:description "short name/code of vehicle manufacturer according  to world manufacturer information(wmi). The wmiCode are the first 3 chars of the vehicle identification number.\nA list of in NHTSA registered wmiCodes can be found in attribute Wmi in table [vPICList_lite].[dbo].[Wmi] "@en;
+    bamm:characteristic :OemShortNameTrait;
+    bamm:exampleValue "WBA";
+    bamm:see <https://vpic.nhtsa.dot.gov/>.
+:wmiDescription a bamm:Property;
+    bamm:preferredName "OEM name"@en;
+    bamm:description "name of OEM according NHTSA or other authorities. Has to be compliant with/linked wmiCode attribute.\nFor NHTSA: name of table [vPICList_lite].[dbo].[Manufacturer]"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "BMW AG";
+    bamm:see <https://vpic.nhtsa.dot.gov/>.
+:cxBPN a bamm:Property;
+    bamm:preferredName "CX Business partner number"@en;
+    bamm:description "Catena-X business partner number of this company"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "BPN-811".
+:anonymizedVin a bamm:Property;
+    bamm:preferredName "Anonymized VIN"@en;
+    bamm:description "OEM-specific hashed VIN; link to car data over pseydomized/hashed VIN or Catena-X unique digital twin identifier"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "3747429FGH382923974682".
+:catenaXId a bamm:Property;
+    bamm:preferredName "Vehicle Catena-X Identifier"@en;
+    bamm:description "A fully anonymous Catena-X identifier that is registered in C-X Digital twin registry. Can be used for vehicles, parts, workshops, ....."@en;
+    bamm:characteristic :CatenaXIdTrait;
+    bamm:exampleValue "urn:uuid:580d3adf-1981-44a0-a214-13d6ceed9379".
+:vehicleSeries a bamm:Property;
+    bamm:preferredName "Vehicle series"@en;
+    bamm:description "vehicle series, normally one level above model. E.g. vehicle series =\"Golf\", vehicle model=\"Golf VIII\""@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Golf".
+:modelDescription a bamm:Property;
+    bamm:preferredName "Vehicle model"@en;
+    bamm:description "Detail vehicle model like \"Golf VIII\""@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Golf VIII".
+:modelIdentifier a bamm:Property;
+    bamm:preferredName "Model identifier"@en;
+    bamm:description "OEM-specific model identifier or OEM-specific project name"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "689-G8".
+:class a bamm:Property;
+    bamm:preferredName "Vehicle class"@en;
+    bamm:description "class of the vehicle"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "A".
+:steeringPos a bamm:Property;
+    bamm:preferredName "Vehicle steering pos"@en;
+    bamm:description "position of vehicle steering wheel, Left or right"@en;
+    bamm:characteristic :VehicleSteeringPos;
+    bamm:exampleValue "Left-Hand Drive(LHD)".
+:emptyWeight a bamm:Property;
+    bamm:preferredName "vehicle empty weight"@en;
+    bamm:description "The empty weight of the vehicle in kg as specified"@en;
+    bamm:characteristic :Weight;
+    bamm:exampleValue "2000"^^xsd:double.
+:driveType a bamm:Property;
+    bamm:preferredName "Drive type"@en;
+    bamm:description "drive type of a vehicle according enumeration"@en;
+    bamm:characteristic :DriveTypeNHTSA;
+    bamm:exampleValue "Front-Wheel Drive(FWD)".
+:systemPower a bamm:Property;
+    bamm:preferredName "Complete system power"@en;
+    bamm:description "Complete power of this vehicle in KW"@en;
+    bamm:characteristic :EnginePower;
+    bamm:exampleValue "110"^^xsd:integer.
+:hybridizationType a bamm:Property;
+    bamm:preferredName "Hybridization"@en;
+    bamm:description "Kind of the hybridization in this vehicle"@en;
+    bamm:characteristic :Hybridization;
+    bamm:exampleValue "no hybrid".
+:softwareCategory a bamm:Property;
+    bamm:preferredName "Software category"@en;
+    bamm:description "Some OEMs brings in the software as complete package for all systems:\nTo identify this software: software category and software version is needed.\nSoftware category when this car was built"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "TZGH64738".
+:softwareVersion a bamm:Property;
+    bamm:preferredName "Software version"@en;
+    bamm:description "Some OEMs brings in the software as complete package for all systems:\nTo identify this software: software category and software version is needed.\nSoftware version when this car was built\n"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "3.4.9837.567".
+:numberOfDoors a bamm:Property;
+    bamm:preferredName "Number of doors"@en;
+    bamm:description "describes the number of doors of a vehicle"@en;
+    bamm:characteristic :PositiveNumber;
+    bamm:exampleValue "5"^^xsd:positiveInteger.
+:colorId a bamm:Property;
+    bamm:preferredName "Color identifier"@en;
+    bamm:description "Colour code describes the code of a specific colour of one vehicle."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "LY7W ".
+:colorDescription a bamm:Property;
+    bamm:preferredName "Color description"@en;
+    bamm:description "Colour name describes the colour of the colour code as a written word."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Light grey".
+:kbaBody a bamm:Property;
+    bamm:preferredName "Body variant(KBA)"@en;
+    bamm:description "vehicle variant - Body shapes according German KBA"@en;
+    bamm:characteristic :KbaVariant;
+    bamm:exampleValue "SUV".
+:nhtsaBody a bamm:Property;
+    bamm:preferredName "Body variant(NHTSA)"@en;
+    bamm:description "vehicle variant - Body shapes according US NHTSA"@en;
+    bamm:characteristic :NhtsaVariant;
+    bamm:exampleValue "Sedan".
+:equipmentIdentifier a bamm:Property;
+    bamm:preferredName "Equipment Id"@en;
+    bamm:description "The identifier of a specific equipment"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "S248A".
+:equipmentDescription a bamm:Property;
+    bamm:preferredName "Equipment description"@en;
+    bamm:description "The equipment variants description"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Seat heating front".
+:group a bamm:Property;
+    bamm:preferredName "Equipment group"@en;
+    bamm:description "grouping the special equipments into categories like Interior"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Interior".
+:productionDate a bamm:Property;
+    bamm:preferredName "Vehicle production Date"@en;
+    bamm:description "production date of the vehicle"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:exampleValue "2018-01-15"^^xsd:dateTime.
+:plantIdentifier a bamm:Property;
+    bamm:preferredName "Production plant id"@en;
+    bamm:description "plant id of the final assembly of the vehicle"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "4711".
+:plantDescription a bamm:Property;
+    bamm:preferredName "Vehicle production plant name"@en;
+    bamm:description "long name of the production plant of the vehicle"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Wolfsburg".
+:soldDate a bamm:Property;
+    bamm:preferredName "Vehicle sold date:"@en;
+    bamm:description "Sold date of the vehicle = warranty start date for this vehicle"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:exampleValue "2018-02-03"^^xsd:dateTime.
+:countryCode a bamm:Property;
+    bamm:preferredName "Vehicle sold country"@en;
+    bamm:description "vehicle sold country in ISO 8601 alpha 3"@en;
+    bamm:characteristic :CountryCodeTrait;
+    bamm:exampleValue "DEU".
+:countryGroup a bamm:Property;
+    bamm:preferredName "Vehicle sold region"@en;
+    bamm:description "region where this car was sold"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Europe".
+:kbaFuelType a bamm:Property;
+    bamm:preferredName "Fuel type(KBA)"@en;
+    bamm:description "description of the fuel according german KBA"@en;
+    bamm:characteristic :FuelKBA;
+    bamm:exampleValue "Diesel".
+:nhtsaFuelType a bamm:Property;
+    bamm:preferredName "Fuel type(NHTSA)"@en;
+    bamm:description "description of the fuel according US NHTSA"@en;
+    bamm:characteristic :FuelNHTSA;
+    bamm:exampleValue "Diesel".
+:OemShortNameTrait a bamm-c:Trait;
+    bamm-c:baseCharacteristic :WorldManufacturerInformation;
+    bamm-c:constraint :WorldManufacturerInformationCodeLength.
+:CatenaXIdTrait a bamm-c:Trait;
+    bamm:preferredName "Catena-X ID Trait"@en;
+    bamm:description "Trait to ensure data format for Catena-X ID"@en;
+    bamm-c:baseCharacteristic :UUIDv4;
+    bamm-c:constraint :UUIDv4RegularExpression.
+:VehicleSteeringPos a bamm-c:Enumeration;
+    bamm:preferredName "Vehicle steering position(NHTSA)"@en;
+    bamm:description "vehicle steering position enumeration from NHTSA, see table [vPICList_lite].[dbo].[Steering]"@en;
+    bamm:dataType xsd:string;
+    bamm:see <https://vpic.nhtsa.dot.gov/api/>;
+    bamm-c:values ("Left-Hand Drive (LHD)" "Right-Hand Drive (RHD)").
+:Weight a bamm-c:Measurement;
+    bamm:preferredName "Weight"@en;
+    bamm:description "weight of an object"@en;
+    bamm:dataType xsd:double;
+    bamm-c:unit unit:kilogram.
+:DriveTypeNHTSA a bamm-c:Enumeration;
+    bamm:preferredName "Drive type(NHTSA)"@en;
+    bamm:description "enumeration of drive type according NHTSA, table [vPICList_lite].[dbo].[DriveType]"@en;
+    bamm:dataType xsd:string;
+    bamm:see <https://vpic.nhtsa.dot.gov/api/>;
+    bamm-c:values ("All-Wheel Drive(AWD)" "Front-Wheel Drive(FWD)" "Rear-Wheel Drive(RWD)").
+:EnginePower a bamm-c:Measurement;
+    bamm:preferredName "Engine Power"@en;
+    bamm:description "engine power expressed in kilowatt"@en;
+    bamm:dataType xsd:integer;
+    bamm-c:unit unit:kilowatt.
+:Hybridization a bamm-c:Enumeration;
+    bamm:preferredName "Hybridization"@en;
+    bamm:description "Enum of possible hybridization values"@en;
+    bamm:dataType xsd:string;
+    bamm-c:values ("battery electric vehicle" "hybrid electric vehicle" "no hybrid" "plugin hybrid electric vehicle" "range extender").
+:PositiveNumber a bamm:Characteristic;
+    bamm:dataType xsd:positiveInteger.
+:KbaVariant a bamm-c:Enumeration;
+    bamm:preferredName "KBA Variant"@en;
+    bamm:description "Current version of the Enumeration is sub-set of list defined from the German Federal Office for motor vehicles. "@en;
+    bamm:dataType xsd:string;
+    bamm-c:values ("Limousine" "Schräghecklimousine" "Kombilimousine" "Coupé" "Kabrio-Limousine" "Cabrio-Limousine" "Mehrzweckfahrzeug" "Pkw-Pick-up" "Van" "Pick-up").
+:NhtsaVariant a bamm-c:Enumeration;
+    bamm:preferredName "NHTSA Variant"@en;
+    bamm:description "Enumeration comming from NHTSA offline database vpic, table [vPICList_lite].[dbo].[BodyStyle]"@en;
+    bamm:dataType xsd:string;
+    bamm:see <https://vpic.nhtsa.dot.gov/api/>;
+    bamm-c:values ("Cargo Van" "Convertible" "Cabriolet" "Coupe" "Crossover Utility Vehicle(CUV)" "Hatchback" "Liftback" "Notchback" "Limousine" "Low Speed Vehicle(LSV)" "Neighborhood Electric Vehicle(NEV)" "Minivan" "Pickup" "Roadster" "Sedan" "Saloon" "Sport Utility Truck(SUT)" "Sport Utility Vehicle(SUV)" "Multi-Purpose Vehicle(MPV)" "Van" "Wagon").
+:CountryCodeTrait a bamm-c:Trait;
+    bamm-c:baseCharacteristic :CountryCodeCharacteristic;
+    bamm-c:constraint :CountryCodeRegularExpression.
+:Engine a bamm:Entity;
+    bamm:preferredName "Engine Entity"@en;
+    bamm:description "Describing one installed engine"@en;
+    bamm:properties (:engineId :engineDescription :engineSeries :serialNumber [
+  bamm:property :size;
+  bamm:optional "true"^^xsd:boolean
+] :power :engineProductionDate :installDate).
+:engineId a bamm:Property;
+    bamm:preferredName "Engine ID:"@en;
+    bamm:description "OEM-specific identifier/type of the installed engine"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "CKBY".
+:engineDescription a bamm:Property;
+    bamm:preferredName "Engine Description"@en;
+    bamm:description "description of the engine"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "2.0 TDI".
+:engineSeries a bamm:Property;
+    bamm:preferredName "Vehicle engine series"@en;
+    bamm:description "engine series"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "EA189".
+:serialNumber a bamm:Property;
+    bamm:preferredName "Engine serial number"@en;
+    bamm:description "serial number of the installed engine"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "3434937GJJG3738".
+:size a bamm:Property;
+    bamm:preferredName "Engine size"@en;
+    bamm:description "Cubic capacity in a combustion engine  - not available in battery-electric vehicles"@en;
+    bamm:characteristic :CubicCapacity;
+    bamm:exampleValue "1968"^^xsd:integer.
+:power a bamm:Property;
+    bamm:preferredName "Engine power"@en;
+    bamm:description "engine power is the power that an engine can put out"@en;
+    bamm:characteristic :EnginePower;
+    bamm:exampleValue "110"^^xsd:integer.
+:engineProductionDate a bamm:Property;
+    bamm:preferredName "Engine production date"@en;
+    bamm:description "date when the engine was produced"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:exampleValue "2017-10-20"^^xsd:dateTime.
+:installDate a bamm:Property;
+    bamm:preferredName "Engine install date"@en;
+    bamm:description "date when the engine was installed"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:exampleValue "2018-01-10"^^xsd:dateTime.
+:CubicCapacity a bamm-c:Measurement;
+    bamm:preferredName "Cubic Capacity"@en;
+    bamm:description "cubic capacity of the engine"@en;
+    bamm:dataType xsd:integer;
+    bamm-c:unit unit:cubicCentimetre.
+:FuelKBA a bamm-c:Enumeration;
+    bamm:preferredName "Fuel type (KBA)"@en;
+    bamm:description "enumeration of possible fuel types of a vehicle according german KBA"@en;
+    bamm:dataType xsd:string;
+    bamm:see <https://www.kba.de/SharedDocs/Downloads/DE/SV/sv221_m1_schad_pdf.pdf>;
+    bamm-c:values ("Unbekannt" "Diesel" "Benzin" "Vielstoff" "Elektro" "Flüssiggas" "Benzin/Flüssiggas" "Benzin/komp.Erdgas" "Hybr.Benzin/E" "Erdgas NG" "Hybr.Diesel/E" "Wasserstoff" "Hybr.Wasserst./E" "Wasserstoff/Benzin" "Wasserst./Benzin/E" "BZ/Wasserstoff" "BZ/Benzin" "BZ/Methanol" "BZ/Ethanol" "Hybr.Vielstoff/E" "Methan" "Benzin/Methan" "Hybr.Erdgas/E" "Benzin/Ethanol" "Hybr.Flüssiggas/E" "Hybr.B/E ext.aufl." "Hybr.D/E ext.aufl." "Hybr.LPG/E ext.aufl." "Hybr.W/E ext.aufl." "Hybr.V/E ext.aufl." "Hybr.NG/E ext.aufl." "Hybr.Wod.B/Eext.aufl" "Wasserstoff/NG" "Hybr.W/NG/E ext.aufl" "Ethanol" "Hybr.BZ/W/E" "Hybr.BZ/W/E ext. aufl." "Zweistoff LNG/Diesel" "Verflüssigtes Erdgas (LNG)" "Andere").
+:FuelNHTSA a bamm-c:Enumeration;
+    bamm:preferredName "Fuel type (NHTSA)"@en;
+    bamm:description "enumeration from NHTSA vpic database, table [vPICList_lite].[dbo].[FuelType]"@en;
+    bamm:dataType xsd:string;
+    bamm:see <https://vpic.nhtsa.dot.gov/api/>;
+    bamm-c:values ("Compressed Hydrogen/Hydrogen" "Compressed Natural Gas(CNG)" "Diesel" "Electric" "Ethanol(E85)" "Flexible Fuel Vehicle(FFV)" "Fuel Cell" "Gasoline" "Liquefied Natural Gas(LNG)" "Liquefied Petroleum Gas(propane or LPG)" "Methanol(M85)" "Natural Gas" "Neat Ethanol(E100)" "Neat Methanol(M100)" "Unknown").
+:WorldManufacturerInformation a bamm:Characteristic;
+    bamm:description "The wmiCode are the first 2 or 3 chars of a vehicle identification number (VIN)"@en;
+    bamm:dataType xsd:string.
+:WorldManufacturerInformationCodeLength a bamm-c:LengthConstraint;
+    bamm:description "Restricts the length of wmiCode to exactly 3 chars"@en;
+    bamm:see <https://vpic.nhtsa.dot.gov/>;
+    bamm-c:minValue "3"^^xsd:nonNegativeInteger;
+    bamm-c:maxValue "3"^^xsd:nonNegativeInteger.
+:CountryCodeCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Country Code Characteristic"@en;
+    bamm:description "ISO 3166-1 alpha-3 – three-letter country codes "@en;
+    bamm:dataType xsd:string.
+:CountryCodeRegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "Country Code Regular Expression"@en;
+    bamm:description "Regular Expression that ensures a three-letter code "@en;
+    bamm:see <https://www.iso.org/iso-3166-country-codes.html>;
+    bamm:value "^[A-Z][A-Z][A-Z]$".
+:UUIDv4 a bamm:Characteristic;
+    bamm:preferredName "UUIDv4"@en;
+    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    bamm:dataType xsd:string.
+:UUIDv4RegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "Catena-X Id Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), prefixed by \"urn:uuid:\" to make it an IRI."@en;
+    bamm:see <https://datatracker.ietf.org/doc/html/rfc4122>;
+    bamm:value "^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$".

--- a/io.catenax.vehicle.product_description/2.0.0/metadata.json
+++ b/io.catenax.vehicle.product_description/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.vehicle.product_description/RELEASE_NOTES.md
+++ b/io.catenax.vehicle.product_description/RELEASE_NOTES.md
@@ -3,6 +3,13 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0] - 2022-12-13
+### Added
+The new aspect model enhances the version 1.0.0 with
+- model now uses BAMM 2.0
+- model now uses entites OEM, Vehicle, Body, Equipment, Production, Sale, Engine and Fuel to group similar properties
+- current mileage is removed from aspect model (was available in 1.x.x): The aspect model presents the vehicle when it was handed over to the end-customer
+
 ## [1.0.0] - 2022-03-30
 ### Added
 - initial version of model


### PR DESCRIPTION
I transferred the QAX models from internal CX githup to open TractusX githup - Initial commit for CX release 3

## Description
6 aspect models from live quality use case(QAX) for CX release 3.
5 aspect models are new, Vehicle.ProductDescription is now available in Version 2.0.0

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
MS2 and MS3 criteria copied over from internal githup repository
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "name" and "description"** in English language. 
- [x] **no duplicate names or preferredNames** within an Aspect (e.g. a Property and the referenced Characteristic should not have the same name)
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
