### PR TITLE
MarketplaceOffer technical committee feedback

### DIFF
--- a/io.catenax.market_place_offer/1.4.0/MarketplaceOffer.ttl
+++ b/io.catenax.market_place_offer/1.4.0/MarketplaceOffer.ttl
@@ -1,0 +1,344 @@
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.market_place_offer:1.4.0#>.
+
+:MarketplaceOffer a bamm:Aspect;
+    bamm:preferredName "Marketplace Offer"@en;
+    bamm:description "Description of all needed information to place a market place offer on the marketplace."@en;
+    bamm:properties ([
+  bamm:property :sku;
+  bamm:optional "true"^^xsd:boolean
+] :quantity :unitOfMeasure [
+  bamm:property :condition;
+  bamm:optional "true"^^xsd:boolean
+] :pickupLocation [
+  bamm:property :incoterms;
+  bamm:optional "true"^^xsd:boolean
+] :price [
+  bamm:property :image;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :attachment;
+  bamm:optional "true"^^xsd:boolean
+] :bundleOffer :marketplaceProduct [
+  bamm:property :missingParts;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :dismantled;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :mechanicalDamage;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :corroded;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :discolored;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :availabilityDate;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :mileage;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :burned;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :catenaXId;
+  bamm:optional "true"^^xsd:boolean
+]);
+    bamm:operations ();
+    bamm:events ().
+:sku a bamm:Property;
+    bamm:description "Stock Keeping Unit is an unique identifier of the dealer providing the product"@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "1002090, xYz.09, ABcXYZ".
+:quantity a bamm:Property;
+    bamm:description "The available quantity of an offered product."@en;
+    bamm:characteristic :QuantityCharacteristic;
+    bamm:exampleValue "50"^^xsd:double.
+:unitOfMeasure a bamm:Property;
+    bamm:description "The unit of measure (related to quantity)."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "each";
+    bamm:see <file:///C:/Program%20Files/Bosch_BAMM/https%253A%252F%252Fresources.gs1us.org%252FGS1-US-Data-Hub-Help-Center%252FArtMID%252F3451%252FArticleID%252F116%252FUnit-of-Measure-Codes>.
+:condition a bamm:Property;
+    bamm:description "The condition of the offered product."@en;
+    bamm:characteristic :ConditionCharacteristic;
+    bamm:exampleValue "used".
+:pickupLocation a bamm:Property;
+    bamm:description "The pickup location for the offered item."@en;
+    bamm:characteristic :GeographicalCoordinates.
+:incoterms a bamm:Property;
+    bamm:description "The incoterms."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "DAP (Delivered at Place)";
+    bamm:see <file:///C:/Program%20Files/Bosch_BAMM/https%2525253A%2525252F%2525252Ficcwbo.org%2525252Fpublication%2525252Fincoterms-2020-introduction%2525252F>.
+:price a bamm:Property;
+    bamm:description "The price of the product."@en;
+    bamm:characteristic :Price.
+:image a bamm:Property;
+    bamm:description "Images of the product."@en;
+    bamm:characteristic :ImageFile.
+:attachment a bamm:Property;
+    bamm:description "Attachments related to the product."@en;
+    bamm:characteristic :Attachment.
+:bundleOffer a bamm:Property;
+    bamm:preferredName "bundle Offer"@en;
+    bamm:description "If this is a single product or a lot of products (group) not being necessarly of the same part number."@en;
+    bamm:characteristic :BundleOffer.
+:marketplaceProduct a bamm:Property;
+    bamm:preferredName "marketplace product"@en;
+    bamm:description "The description of the product within the marketplace that might differ from the digital twin."@en;
+    bamm:characteristic :ProductCharacteristic.
+:missingParts a bamm:Property;
+    bamm:preferredName "missing parts"@en;
+    bamm:description "Completeness of the product, e.g. missing parts are not acceptable."@en;
+    bamm:characteristic :Boolean;
+    bamm:exampleValue "true"^^xsd:boolean.
+:dismantled a bamm:Property;
+    bamm:preferredName "dismantled"@en;
+    bamm:description "Information on whether the product has been dismantled."@en;
+    bamm:characteristic :Boolean;
+    bamm:exampleValue "true"^^xsd:boolean.
+:mechanicalDamage a bamm:Property;
+    bamm:preferredName "mechanical damage"@en;
+    bamm:description "Information on mechanical damage to the part, e.g. two broken ribs or part deformation indicate mechanical damage."@en;
+    bamm:characteristic :Boolean;
+    bamm:exampleValue "true"^^xsd:boolean.
+:corroded a bamm:Property;
+    bamm:preferredName "corroded"@en;
+    bamm:description "Information on whether the product has corrosion."@en;
+    bamm:characteristic :Boolean;
+    bamm:exampleValue "true"^^xsd:boolean.
+:discolored a bamm:Property;
+    bamm:preferredName "discolored"@en;
+    bamm:description "Information on whether the product has been discoloured."@en;
+    bamm:characteristic :Boolean;
+    bamm:exampleValue "true"^^xsd:boolean.
+:availabilityDate a bamm:Property;
+    bamm:preferredName "availability date"@en;
+    bamm:description "The availability date when the product is in stock."@en;
+    bamm:characteristic :AvailabilityDateCharacteristic;
+    bamm:exampleValue "2022-03-11"^^xsd:date.
+:mileage a bamm:Property;
+    bamm:preferredName "mileage"@en;
+    bamm:description "The mileage the item was ins use."@en;
+    bamm:characteristic :MileageCharacteristic;
+    bamm:exampleValue "120000.06"^^xsd:decimal.
+:burned a bamm:Property;
+    bamm:preferredName "burned"@en;
+    bamm:description "Information on whether the product has been fired and suffered damage from heat."@en;
+    bamm:characteristic :Boolean;
+    bamm:exampleValue "true"^^xsd:boolean.
+:catenaXId a bamm:Property;
+    bamm:preferredName "Catena-X Identifier"@en;
+    bamm:description "The fully anonymous Catena-X ID of the offer, valid for the Catena-X dataspace."@en;
+    bamm:characteristic :CatenaXIdTrait;
+    bamm:exampleValue "580d3adf-1981-44a0-a214-13d6ceed9379".
+:ConditionCharacteristic a bamm-c:Enumeration;
+    bamm:preferredName "Condition Characteristic"@en;
+    bamm:description "Condition of the article as enumeration."@en;
+    bamm:dataType xsd:string;
+    bamm-c:values ("New" "Used" "Refurbished" "Other").
+:GeographicalCoordinates a bamm:Characteristic;
+    bamm:preferredName "geographical coordinates"@en;
+    bamm:see <file:///C:/Program%20Files/Bosch_BAMM/https%2525253A%2525252F%2525252Fen.wikipedia.org%2525252Fwiki%2525252FGeographic_coordinate_system>;
+    bamm:dataType :GeographicalCoordinate.
+:Price a bamm:Characteristic;
+    bamm:preferredName "price"@en;
+    bamm:dataType :PriceEntity.
+:ImageFile a bamm:Characteristic;
+    bamm:preferredName "ImageFile"@en;
+    bamm:description "Image of the object."@en;
+    bamm:dataType :File.
+:Attachment a bamm-c:Set;
+    bamm:preferredName "Attachment"@en;
+    bamm:description "Links the referenced attachment."@en;
+    bamm:dataType :AttachmentEntity.
+:BundleOffer a bamm:Characteristic;
+    bamm:preferredName "bundleOffer"@en;
+    bamm:dataType xsd:boolean.
+:ProductCharacteristic a bamm:Characteristic;
+    bamm:preferredName "product characteristic"@en;
+    bamm:dataType :ProductEntity.
+:Boolean a bamm:Characteristic;
+    bamm:preferredName "boolean"@en;
+    bamm:dataType xsd:boolean.
+:AvailabilityDateCharacteristic a bamm:Characteristic;
+    bamm:preferredName "availability date characteristic"@en;
+    bamm:description "The availability date when the product is in stock."@en;
+    bamm:dataType xsd:date.
+:MileageCharacteristic a bamm-c:Measurement;
+    bamm:preferredName "mileage characteristic"@en;
+    bamm:description "The value describing the mileage of the item."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:kilometre.
+:CatenaXIdTrait a bamm-c:Trait;
+    bamm:preferredName "Catena-X ID Trait"@en;
+    bamm:description "Trait to ensure data format for Catena-X ID."@en;
+    bamm-c:baseCharacteristic :UUIDv4;
+    bamm-c:constraint :UUIDv4RegularExpression.
+:GeographicalCoordinate a bamm:Entity;
+    bamm:preferredName "geographical coordinate"@en;
+    bamm:properties (:longitude :latitude).
+:PriceEntity a bamm:Entity;
+    bamm:preferredName "price"@en;
+    bamm:properties (:value :currency).
+:File a bamm:Entity;
+    bamm:preferredName "File"@en;
+    bamm:description "Image file of the object."@en;
+    bamm:properties (:name :location).
+:AttachmentEntity a bamm:Entity;
+    bamm:preferredName "AttachmentEntity"@en;
+    bamm:description "attachment for the article."@en;
+    bamm:properties (:name :location).
+:ProductEntity a bamm:Entity;
+    bamm:preferredName "product entity"@en;
+    bamm:properties (:productDescription :brand :category [
+  bamm:property :originalManufacturer;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :manufacturerPartNumber;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :productLink;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :oeNumber;
+  bamm:optional "true"^^xsd:boolean
+] :technicalSpecification).
+:UUIDv4 a bamm:Characteristic;
+    bamm:preferredName "UUIDv4"@en;
+    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    bamm:dataType xsd:string.
+:UUIDv4RegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "Catena-X Id Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens)."@en;
+    bamm:value "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$".
+:longitude a bamm:Property;
+    bamm:preferredName "longitude"@en;
+    bamm:description "The longitude of the 2D sphere coordinates."@en;
+    bamm:characteristic :LongitudeCharacteristic;
+    bamm:exampleValue "-117.283333"^^xsd:float.
+:latitude a bamm:Property;
+    bamm:preferredName "latitude"@en;
+    bamm:description "The latitude of the 2D sphere coordinates."@en;
+    bamm:characteristic :LatitudeCharacteristic;
+    bamm:exampleValue "48.137154"^^xsd:float.
+:value a bamm:Property;
+    bamm:preferredName "value"@en;
+    bamm:description "The absolute value of the price"@en;
+    bamm:characteristic :Value;
+    bamm:exampleValue "250.00"^^xsd:float.
+:currency a bamm:Property;
+    bamm:description "The currency of the price."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "EUR";
+    bamm:see <file:///C:/Program%20Files/Bosch_BAMM/https%2525253A%2525252F%2525252Fwww.iso.org%2525252Fiso-4217-currency-codes.html>.
+:name a bamm:Property;
+    bamm:preferredName "name"@en;
+    bamm:description "Name or title of the object."@en;
+    bamm:characteristic bamm-c:Text.
+:location a bamm:Property;
+    bamm:preferredName "location"@en;
+    bamm:description "Location of the object."@en;
+    bamm:characteristic :LocationCharacteristic.
+:productDescription a bamm:Property;
+    bamm:preferredName "product description"@en;
+    bamm:description "The description of the product on the marketplace."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "BMW 3er (E36) BJ: 1996".
+:brand a bamm:Property;
+    bamm:preferredName "brand"@en;
+    bamm:description "The brandname of the offered product."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "ZF".
+:category a bamm:Property;
+    bamm:preferredName "category"@en;
+    bamm:description "Category within the marketplace for classification of listings."@en;
+    bamm:characteristic :CategoryCharacteristic.
+:originalManufacturer a bamm:Property;
+    bamm:preferredName "original manufacturer"@en;
+    bamm:description "The original manufacturer of a product."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "BMW".
+:manufacturerPartNumber a bamm:Property;
+    bamm:preferredName "manufacturer part number"@en;
+    bamm:description "The unique identifier of the product from the manufacturer."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "4S7R7002DB".
+:productLink a bamm:Property;
+    bamm:preferredName "product link"@en;
+    bamm:description "A link to either the product on the original marketplace/webshop or a link to the product specifications document."@en;
+    bamm:characteristic :ProductLinkCharacteristic.
+:oeNumber a bamm:Property;
+    bamm:preferredName "original equipment number"@en;
+    bamm:description "The original equipment number."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "4B0905851C".
+:technicalSpecification a bamm:Property;
+    bamm:preferredName "technical specification"@en;
+    bamm:description "Further technical specifications."@en;
+    bamm:characteristic :TechnicalSpecification.
+:LongitudeCharacteristic a bamm:Characteristic;
+    bamm:preferredName "longitude characteristic"@en;
+    bamm:dataType xsd:float.
+:LatitudeCharacteristic a bamm:Characteristic;
+    bamm:preferredName "latitude characteristic"@en;
+    bamm:dataType xsd:float.
+:Value a bamm:Characteristic;
+    bamm:preferredName "value"@en;
+    bamm:dataType xsd:float.
+:LocationCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Location characteristic"@en;
+    bamm:description "Location with an URI."@en;
+    bamm:dataType xsd:anyURI.
+:CategoryCharacteristic a bamm:Characteristic;
+    bamm:preferredName "category characteristic"@en;
+    bamm:description "The category of the listing within the marketplace."@en;
+    bamm:dataType :CategoryEntity.
+:ProductLinkCharacteristic a bamm:Characteristic;
+    bamm:preferredName "product link characteristic"@en;
+    bamm:dataType xsd:anyURI.
+:TechnicalSpecification a bamm-c:Set;
+    bamm:preferredName "technical specification"@en;
+    bamm:dataType :TechnicalSpecificationEntity.
+:CategoryEntity a bamm:Entity;
+    bamm:preferredName "category entity"@en;
+    bamm:properties (:mainCategory :subCategory).
+:TechnicalSpecificationEntity a bamm:Entity;
+    bamm:preferredName "technical specification"@en;
+    bamm:properties (:key :technicalValue).
+:mainCategory a bamm:Property;
+    bamm:preferredName "main category"@en;
+    bamm:characteristic :MainCategory;
+    bamm:exampleValue "Audio, video, navigation".
+:subCategory a bamm:Property;
+    bamm:preferredName "sub category"@en;
+    bamm:characteristic :SubCategory;
+    bamm:exampleValue "Amplifiers, subwoofers, etc".
+:key a bamm:Property;
+    bamm:preferredName "key"@en;
+    bamm:description "The key of the key value pair"@en;
+    bamm:characteristic bamm-c:Text.
+:technicalValue a bamm:Property;
+    bamm:preferredName "technical value"@en;
+    bamm:description "The value of the key value pair."@en;
+    bamm:characteristic bamm-c:Text.
+:MainCategory a bamm-c:List;
+    bamm:preferredName "main category"@en;
+    bamm:dataType xsd:string.
+:SubCategory a bamm-c:List;
+    bamm:preferredName "sub category"@en;
+    bamm:dataType xsd:string.
+:QuantityCharacteristic a bamm:Characteristic;
+    bamm:preferredName "quantity characteristic"@en;
+    bamm:description "Describes a quantity as decimal number."@en;
+    bamm:dataType xsd:double.

--- a/io.catenax.market_place_offer/1.4.0/MarketplaceOffer.ttl
+++ b/io.catenax.market_place_offer/1.4.0/MarketplaceOffer.ttl
@@ -88,7 +88,7 @@
     bamm:description "The unit of measure (related to quantity)."@en;
     bamm:characteristic bamm-c:Text;
     bamm:exampleValue "each";
-    bamm:see <file:///C:/Program%20Files/Bosch_BAMM/https%253A%252F%252Fresources.gs1us.org%252FGS1-US-Data-Hub-Help-Center%252FArtMID%252F3451%252FArticleID%252F116%252FUnit-of-Measure-Codes>.
+    bamm:see <https%253A%252F%252Fresources.gs1us.org%252FGS1-US-Data-Hub-Help-Center%252FArtMID%252F3451%252FArticleID%252F116%252FUnit-of-Measure-Codes>.
 :condition a bamm:Property;
     bamm:description "The condition of the offered product."@en;
     bamm:characteristic :ConditionCharacteristic;
@@ -100,7 +100,7 @@
     bamm:description "The incoterms."@en;
     bamm:characteristic bamm-c:Text;
     bamm:exampleValue "DAP (Delivered at Place)";
-    bamm:see <file:///C:/Program%20Files/Bosch_BAMM/https%2525253A%2525252F%2525252Ficcwbo.org%2525252Fpublication%2525252Fincoterms-2020-introduction%2525252F>.
+    bamm:see <https%2525253A%2525252F%2525252Ficcwbo.org%2525252Fpublication%2525252Fincoterms-2020-introduction%2525252F>.
 :price a bamm:Property;
     bamm:description "The price of the product."@en;
     bamm:characteristic :Price.
@@ -111,7 +111,7 @@
     bamm:description "Attachments related to the product."@en;
     bamm:characteristic :Attachment.
 :bundleOffer a bamm:Property;
-    bamm:preferredName "bundle Offer"@en;
+    bamm:preferredName "Bundle Offer"@en;
     bamm:description "If this is a single product or a lot of products (group) not being necessarly of the same part number."@en;
     bamm:characteristic :BundleOffer.
 :marketplaceProduct a bamm:Property;
@@ -170,7 +170,7 @@
     bamm-c:values ("New" "Used" "Refurbished" "Other").
 :GeographicalCoordinates a bamm:Characteristic;
     bamm:preferredName "geographical coordinates"@en;
-    bamm:see <file:///C:/Program%20Files/Bosch_BAMM/https%2525253A%2525252F%2525252Fen.wikipedia.org%2525252Fwiki%2525252FGeographic_coordinate_system>;
+    bamm:see <https%2525253A%2525252F%2525252Fen.wikipedia.org%2525252Fwiki%2525252FGeographic_coordinate_system>;
     bamm:dataType :GeographicalCoordinate.
 :Price a bamm:Characteristic;
     bamm:preferredName "price"@en;
@@ -217,7 +217,7 @@
     bamm:description "Image file of the object."@en;
     bamm:properties (:name :location).
 :AttachmentEntity a bamm:Entity;
-    bamm:preferredName "AttachmentEntity"@en;
+    bamm:preferredName "attachment entity"@en;
     bamm:description "attachment for the article."@en;
     bamm:properties (:name :location).
 :ProductEntity a bamm:Entity;
@@ -262,7 +262,7 @@
     bamm:description "The currency of the price."@en;
     bamm:characteristic bamm-c:Text;
     bamm:exampleValue "EUR";
-    bamm:see <file:///C:/Program%20Files/Bosch_BAMM/https%2525253A%2525252F%2525252Fwww.iso.org%2525252Fiso-4217-currency-codes.html>.
+    bamm:see <https%2525253A%2525252F%2525252Fwww.iso.org%2525252Fiso-4217-currency-codes.html>.
 :name a bamm:Property;
     bamm:preferredName "name"@en;
     bamm:description "Name or title of the object."@en;

--- a/io.catenax.market_place_offer/1.4.0/MarketplaceOffer.ttl
+++ b/io.catenax.market_place_offer/1.4.0/MarketplaceOffer.ttl
@@ -1,3 +1,24 @@
+#######################################################################
+# Copyright (c) 2022 T-Systems International GmbH
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft
+# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022 Henkel AG & Co. KGaA
+# Copyright (c) 2022 LRP Autorecycling Leipzig GmbH
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022 Circular Economy Solutions GmbH (C-ECO)
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
 @prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
 @prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
 @prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.

--- a/io.catenax.market_place_offer/1.4.0/metadata.json
+++ b/io.catenax.market_place_offer/1.4.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.market_place_offer/RELEASE_NOTES.md
+++ b/io.catenax.market_place_offer/RELEASE_NOTES.md
@@ -1,7 +1,17 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
-## [Unreleased]
+## [1.4.0] - 2023-01-30
+### Added
+n/a
+
+### Changed
+- attachment changed to set already
+- quantity description changed
+
+### Removed
+- status
+- certificate
 
 ## [1.3.0] - 2022-10-28
 ### Added
@@ -12,4 +22,4 @@ All notable changes to this model will be documented in this file.
 n/a
 
 ### Removed
-
+n/a


### PR DESCRIPTION
new Version of MarketplaceOffer with sounded feedback from technical committee

## Description
Attachment won't be changed due to semantic standards. Nevertheless, characteristics will be changed in the future to cover upload of multiple attachments -> DONE: changed to set already (we agreed to change it if there were already more changes to the model)
Quantity will be changed as in the comment above from Marcel. In addition the description will be changed to "The available quantity of an offered product". -> DONE
Status will be excluded as above -> DONE
Certificate will be excluded as above -> DONE
GeographicalCoordinate: Add description to: Location coordinates -> Description already included in longitude and latitude, therefore description of geographical coordinates given


Closes #

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "name" and "description"** in English language. 
- [ ] **no duplicate names or preferredNames** within an Aspect (e.g. a Property and the referenced Characteristic should not have the same name)
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the BAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
