### PR TITLE
Use merge instead of head commit for governance workflow

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -30,8 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
      
       - name: Check Changes
         id: changes


### PR DESCRIPTION
This PR changes the ref for the governance workflow from the head of the feature branch back to the merge commit.