### PR TITLE
[Model Update]: Solve issues and update BatteryPass to version 3.0.1

### DIFF
--- a/io.catenax.battery.battery_pass/3.0.0/BatteryPass.ttl
+++ b/io.catenax.battery.battery_pass/3.0.0/BatteryPass.ttl
@@ -1,0 +1,937 @@
+#######################################################################
+# Copyright (c) 2022 Badische Anilin und Sodafabrik societates Europaea
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft
+# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2022 Henkel AG & Co. KGaA
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 T-Systems International GmbH
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the 
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license, 
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:1.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:1.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:1.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:1.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.battery.battery_pass:3.0.0#>.
+@prefix address-c: <urn:bamm:io.catenax.shared.address_characteristic:1.0.1#>.
+@prefix contact-c: <urn:bamm:io.catenax.shared.contact_information:1.0.0#>.
+
+:BatteryPass a bamm:Aspect;
+    bamm:name "BatteryPass";
+    bamm:properties ([
+  bamm:property :document;
+  bamm:optional "true"^^xsd:boolean
+] :manufacturer :electrochemicalProperties :physicalDimensions :stateOfBattery :batteryIdentification :manufacturing :datePlacedOnMarket :cellChemistry :composition :cO2FootprintTotal :temperatureRangeIdleState :warrantyPeriod :batteryCycleLife);
+    bamm:operations ();
+    bamm:preferredName "battery pass"@en;
+    bamm:description "The battery pass describes information collected during the lifecycle of a battery"@en;
+    bamm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52020PC0798>;
+    bamm:events ().
+:document a bamm:Property;
+    bamm:name "document";
+    bamm:preferredName "document"@en;
+    bamm:description "Set of documents containing the description of battery components"@en;
+    bamm:characteristic :DocumentCharacteristic.
+:manufacturer a bamm:Property;
+    bamm:name "manufacturer";
+    bamm:preferredName "manufacturer"@en;
+    bamm:description "Legal entity which sells and invoices the battery"@en;
+    bamm:characteristic :ManufacturerCharacteristic.
+:electrochemicalProperties a bamm:Property;
+    bamm:name "electrochemicalProperties";
+    bamm:preferredName "electrochemical properties"@en;
+    bamm:description "Electrochemical properties of an electrochemical energy storage"@en;
+    bamm:characteristic :ElectrochemicalPropertiesCharacteristic.
+:physicalDimensions a bamm:Property;
+    bamm:name "physicalDimensions";
+    bamm:preferredName "physical dimensions"@en;
+    bamm:description "Geometrical properties of the battery"@en;
+    bamm:characteristic :PhysicalDimensionsCharacteristic.
+:stateOfBattery a bamm:Property;
+    bamm:name "stateOfBattery";
+    bamm:preferredName "state of battery"@en;
+    bamm:description "The condition of the battery at the end of life i.e. when entering recycling scheme"@en;
+    bamm:characteristic :StateOfBatteryCharacteristic.
+:batteryIdentification a bamm:Property;
+    bamm:name "batteryIdentification";
+    bamm:preferredName "battery identification"@en;
+    bamm:description "Information to identify a specific battery."@en;
+    bamm:characteristic :BatteryIdentificationCharacteristic.
+:manufacturing a bamm:Property;
+    bamm:name "manufacturing";
+    bamm:preferredName "manufacturing"@en;
+    bamm:description "Information about the manufacturing process of a battery"@en;
+    bamm:characteristic :ManufacturingCharacteristic.
+:datePlacedOnMarket a bamm:Property;
+    bamm:name "datePlacedOnMarket";
+    bamm:preferredName "date placed on market"@en;
+    bamm:description "Date on which vehicle is produced i.e. when battery is put in the market or production date of the vehicle is describing a regulatory requirement."@en;
+    bamm:characteristic :Datestamp.
+:cellChemistry a bamm:Property;
+    bamm:name "cellChemistry";
+    bamm:preferredName "cell chemistry"@en;
+    bamm:description "Information about the cell chemistry of a battery cell"@en;
+    bamm:characteristic :CellChemistryCharacteristic.
+:composition a bamm:Property;
+    bamm:name "composition";
+    bamm:preferredName "composition"@en;
+    bamm:description "Information about the composition of a battery and the combination of materials is describing a business requirement."@en;
+    bamm:characteristic :CompositionCharacteristic.
+:cO2FootprintTotal a bamm:Property;
+    bamm:name "cO2FootprintTotal";
+    bamm:preferredName "CO2 footprint total"@en;
+    bamm:description "The total carbon footprint of the battery, calculated as kg of carbon dioxide equivalent is describing a regulatory requirement."@en;
+    bamm:characteristic :CO2FootprintTotalCharacteristic;
+    bamm:exampleValue "124.00"^^xsd:double.
+:temperatureRangeIdleState a bamm:Property;
+    bamm:name "temperatureRangeIdleState";
+    bamm:preferredName "temperature range idle state"@en;
+    bamm:description "The range of temperature the battery can withstand when not in use is describing a regulatory requirement."@en;
+    bamm:characteristic :TemperatureRangeIdleStateCharacterisitic.
+:warrantyPeriod a bamm:Property;
+    bamm:name "warrantyPeriod";
+    bamm:preferredName "warranty period"@en;
+    bamm:description "Commercial warranty period of the battery is describing a regulatory requirement."@en;
+    bamm:characteristic :WarrantyPeriodCharacterisitic;
+    bamm:exampleValue "60"^^xsd:positiveInteger.
+:batteryCycleLife a bamm:Property;
+    bamm:name "batteryCycleLife";
+    bamm:preferredName "battery cycle life"@en;
+    bamm:description "Property describing the cycle life of a battery"@en;
+    bamm:characteristic :BatteryCycleLifeCharacteristic.
+:DocumentCharacteristic a bamm:Characteristic;
+    bamm:name "DocumentCharacteristic";
+    bamm:preferredName "document characteristic"@en;
+    bamm:description "Set of documents containing the description of battery components"@en;
+    bamm:dataType :DocumentEntity.
+:ManufacturerCharacteristic a bamm:Characteristic;
+    bamm:name "ManufacturerCharacteristic";
+    bamm:preferredName "manufacturer characteristic"@en;
+    bamm:description "A manufacturer of goods"@en;
+    bamm:dataType :ManufacturerEntity.
+:ElectrochemicalPropertiesCharacteristic a bamm:Characteristic;
+    bamm:name "ElectrochemicalPropertiesCharacteristic";
+    bamm:preferredName "electrochemical properties characteristic"@en;
+    bamm:description "Electrochemical characteristics to describe a battery"@en;
+    bamm:dataType :ElectrochemicalPropertiesEntity.
+:PhysicalDimensionsCharacteristic a bamm:Characteristic;
+    bamm:name "PhysicalDimensionsCharacteristic";
+    bamm:preferredName "physical dimensions characteristic"@en;
+    bamm:description "Geometrical properties of the battery"@en;
+    bamm:dataType :PhysicalDimensionsEntity.
+:StateOfBatteryCharacteristic a bamm:Characteristic;
+    bamm:name "StateOfBatteryCharacteristic";
+    bamm:preferredName "state of battery characteristic"@en;
+    bamm:description "The condition of the battery at the end of life i.e. when entering recycling scheme"@en;
+    bamm:dataType :StateOfBatteryEntity.
+:BatteryIdentificationCharacteristic a bamm:Characteristic;
+    bamm:name "BatteryIdentificationCharacteristic";
+    bamm:preferredName "battery identification characteristic"@en;
+    bamm:description "Information to identify a specific battery."@en;
+    bamm:dataType :BatteryIdentificationEntity.
+:ManufacturingCharacteristic a bamm:Characteristic;
+    bamm:name "ManufacturingCharacteristic";
+    bamm:preferredName "manufacturing characteristic"@en;
+    bamm:description "Information about the manufacturing process of a battery"@en;
+    bamm:dataType :ManufacturingEntity.
+:Datestamp a bamm:Characteristic;
+    bamm:name "Datestamp";
+    bamm:preferredName "datestamp"@en;
+    bamm:description "Describes a Property which contains the date and time with an optional timezone."@en;
+    bamm:dataType xsd:date.
+:CellChemistryCharacteristic a bamm:Characteristic;
+    bamm:name "CellChemistryCharacteristic";
+    bamm:preferredName "cell chemistry"@en;
+    bamm:description "Information about the the cell chemistry of a battery cell"@en;
+    bamm:dataType :CellChemistryEntity.
+:CompositionCharacteristic a bamm:Characteristic;
+    bamm:name "CompositionCharacteristic";
+    bamm:preferredName "composition"@en;
+    bamm:description "Information about the composition of a battery and the combination of materials is describing a business requirement."@en;
+    bamm:dataType :CompositionEntity.
+:CO2FootprintTotalCharacteristic a bamm-c:Measurement;
+    bamm:name "CO2FootprintTotalCharacteristic";
+    bamm:preferredName "co2 footprint total"@en;
+    bamm:description "The total carbon footprint of the battery, calculated as kg of carbon dioxide equivalent is describing a regulatory requirement."@en;
+    bamm:dataType xsd:double;
+    bamm-c:unit unit:kilogram.
+:TemperatureRangeIdleStateCharacterisitic a bamm:Characteristic;
+    bamm:name "TemperatureRangeIdleStateCharacterisitic";
+    bamm:preferredName "temperature range idle state"@en;
+    bamm:description "The range of temperature the battery can withstand when not in use is describing a regulatory requirement."@en;
+    bamm:dataType :TemperatureRangeIdleStateEntity.
+:WarrantyPeriodCharacterisitic a bamm-c:Measurement;
+    bamm:name "WarrantyPeriodCharacterisitic";
+    bamm:preferredName "warranty period"@en;
+    bamm:description "Commercial warranty period of the battery is describing a regulatory requirement."@en;
+    bamm:dataType xsd:positiveInteger;
+    bamm-c:unit unit:month.
+:BatteryCycleLifeCharacteristic a bamm:Characteristic;
+    bamm:name "BatteryCycleLifeCharacteristic";
+    bamm:preferredName "battery cycle life"@en;
+    bamm:description "Characterisitic describing the cycle life of a battery"@en;
+    bamm:dataType :BatteryCycleLifeEntity.
+:DocumentEntity a bamm:Entity;
+    bamm:name "DocumentEntity";
+    bamm:properties ([
+  bamm:property :packagingInstructions;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :transportationInstructions;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :vehicleDismantlingProcedure;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :batteryDismantlingProcedure;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :safetyMeasures;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :testReportsResults;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :declarationOfConformity;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :responsibleSourcing;
+  bamm:optional "true"^^xsd:boolean
+]);
+    bamm:preferredName "document entity"@en;
+    bamm:description "Entity encapsulating the details of a attachment for the battery"@en.
+:ManufacturerEntity a bamm:Entity;
+    bamm:name "ManufacturerEntity";
+    bamm:properties (:name :contact :address);
+    bamm:preferredName "manufacturer"@en;
+    bamm:description "Entity encapsulating the details of a manufacturer of goods"@en.
+:ElectrochemicalPropertiesEntity a bamm:Entity;
+    bamm:name "ElectrochemicalPropertiesEntity";
+    bamm:properties (:batteryPower :batteryVoltage :ratedCapacity :capacityFade :internalResistance :capacityThresholdExhaustion :batteryEnergy :ratioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergy);
+    bamm:preferredName "electrochemical properties entity"@en;
+    bamm:description "Entity encapsulating the electrochemical details of a battery"@en.
+:PhysicalDimensionsEntity a bamm:Entity;
+    bamm:name "PhysicalDimensionsEntity";
+    bamm:properties (:length :width :height :diameter :weight);
+    bamm:preferredName "physical dimensions entity"@en;
+    bamm:description "Entity to bundle the characterisitics describing the physical dimensions"@en.
+:StateOfBatteryEntity a bamm:Entity;
+    bamm:name "StateOfBatteryEntity";
+    bamm:properties (:stateOfHealth :stateOfCharge :statusBattery);
+    bamm:preferredName "state of battery entity"@en;
+    bamm:description "Entity to bundle the characterisitics describing the state of a battery"@en.
+:BatteryIdentificationEntity a bamm:Entity;
+    bamm:name "BatteryIdentificationEntity";
+    bamm:properties (:batteryType :batteryModel :batteryIDDMCCode);
+    bamm:preferredName "battery identification entity"@en;
+    bamm:description "Entity to bundle the characterisitics describing the identification of a battery"@en.
+:ManufacturingEntity a bamm:Entity;
+    bamm:name "ManufacturingEntity";
+    bamm:properties (:dateOfManufacturing :address);
+    bamm:preferredName "manufacturing entity"@en;
+    bamm:description "Entity to bundle the characterisitics describing the manufacturing (place and date of manufacture)"@en.
+:CellChemistryEntity a bamm:Entity;
+    bamm:name "CellChemistryEntity";
+    bamm:properties (:cathodeActiveMaterials :recyclateContentActiveMaterials :anodeActiveMaterials :cathodeCompositionOther :anodeCompositionOther :electrolyteComposition);
+    bamm:preferredName "cell chemistry"@en;
+    bamm:description "Entity to bundle the characterisitics describing a battery's cell chemistry"@en.
+:CompositionEntity a bamm:Entity;
+    bamm:name "CompositionEntity";
+    bamm:properties (:components :compositionOfBattery :criticalRawMaterials);
+    bamm:preferredName "composition"@en;
+    bamm:description "Entity to bundle the characterisitics describing a battery's composition"@en.
+:TemperatureRangeIdleStateEntity a bamm:Entity;
+    bamm:name "TemperatureRangeIdleStateEntity";
+    bamm:properties (:temperatureRangeIdleStateLowerLimit :temperatureRangeIdleStateUpperLimit);
+    bamm:preferredName "temperature range idle state"@en;
+    bamm:description "Entity to bundle the characterisitics describing the battery's temperature range"@en.
+:BatteryCycleLifeEntity a bamm:Entity;
+    bamm:name "BatteryCycleLifeEntity";
+    bamm:properties (:cycleLifeTestCRate :cycleLifeTestDepthOfDischarge :expectedLifetime);
+    bamm:preferredName "battery cycle life entity"@en;
+    bamm:description "Entity to bundle the characterisitics describing the cycle life of a battery"@en.
+:packagingInstructions a bamm:Property;
+    bamm:name "packagingInstructions";
+    bamm:preferredName "packaging instructions"@en;
+    bamm:description "Instructions for safely packaging\nbatteries is describing a business requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:transportationInstructions a bamm:Property;
+    bamm:name "transportationInstructions";
+    bamm:preferredName "transportation instructions"@en;
+    bamm:description "Instructions for safely transporting\nbatteries is describing a business requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:vehicleDismantlingProcedure a bamm:Property;
+    bamm:name "vehicleDismantlingProcedure";
+    bamm:preferredName "vehicle dismantling procedure"@en;
+    bamm:description "Document containing the vehicle dismantling procedure is describing a regulatory requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:batteryDismantlingProcedure a bamm:Property;
+    bamm:name "batteryDismantlingProcedure";
+    bamm:preferredName "battery dismantling procedure"@en;
+    bamm:description "Document containing the battery dismantling procedure is describing a regulatory requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:safetyMeasures a bamm:Property;
+    bamm:name "safetyMeasures";
+    bamm:preferredName "safety measures"@en;
+    bamm:description "Safety measures document(s) is describing a regulatory requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:testReportsResults a bamm:Property;
+    bamm:name "testReportsResults";
+    bamm:preferredName "test reports results"@en;
+    bamm:description "Results of test reports which prove that the battery fulfills this regulation and its delegated regulations is describing a regulatory requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:declarationOfConformity a bamm:Property;
+    bamm:name "declarationOfConformity";
+    bamm:preferredName "declaration of conformity"@en;
+    bamm:description "Declaration of conformity (CE) is describing a regulatory requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:responsibleSourcing a bamm:Property;
+    bamm:name "responsibleSourcing";
+    bamm:preferredName "responsible sourcing"@en;
+    bamm:description "Document/Certificates on organizations compliance to ethical business practices"@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:name a bamm:Property;
+    bamm:name "name";
+    bamm:preferredName "name"@en;
+    bamm:description "Name of the manufacturer is describing a regulatory requirement."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Samsung".
+:contact a bamm:Property;
+    bamm:name "contact";
+    bamm:preferredName "contact"@en;
+    bamm:description "Contact details of the manufacturer"@en;
+    bamm:characteristic contact-c:ContactCharacteristic.
+:address a bamm:Property;
+    bamm:name "address";
+    bamm:preferredName "address"@en;
+    bamm:description "An postal address"@en;
+    bamm:characteristic address-c:PostalAddress.
+:batteryPower a bamm:Property;
+    bamm:name "batteryPower";
+    bamm:preferredName "attachment"@en;
+    bamm:description "Characterisitic to describe the power (W) properties of the batterie."@en;
+    bamm:characteristic :BatteryPowerCharacteristic.
+:batteryVoltage a bamm:Property;
+    bamm:name "batteryVoltage";
+    bamm:preferredName "battery voltage"@en;
+    bamm:description "Voltage (V) of the battery."@en;
+    bamm:characteristic :BatteryVoltageCharacteristiC.
+:ratedCapacity a bamm:Property;
+    bamm:name "ratedCapacity";
+    bamm:preferredName "rated capacity"@en;
+    bamm:description "The total number of ampere-hours (Ah) that can be withdrawn from a fully charged battery under specific conditions is describing a regulatory requirement."@en;
+    bamm:characteristic :RatedCapacityCharacteristic;
+    bamm:exampleValue "210"^^xsd:decimal.
+:capacityFade a bamm:Property;
+    bamm:name "capacityFade";
+    bamm:preferredName "capacity fade"@en;
+    bamm:description "The decrease over time and upon usage in the amount of charge that a battery can deliver at the rated voltage, with respect to the original rated capacity declared by the manufacturer is describing a regulatory requirement."@en;
+    bamm:characteristic :CapacityFadeCharacteristic;
+    bamm:exampleValue "34"^^xsd:decimal.
+:internalResistance a bamm:Property;
+    bamm:name "internalResistance";
+    bamm:preferredName "internal resistance"@en;
+    bamm:description "Internal resistance in a battery cell or pack is describing a regulatory requirement."@en;
+    bamm:characteristic :InternalResistanceCharacteristic.
+:capacityThresholdExhaustion a bamm:Property;
+    bamm:name "capacityThresholdExhaustion";
+    bamm:preferredName "internal resistance"@en;
+    bamm:description "Capacity threshold for exhaustion as percentage value is describing a regulatory requirement."@en;
+    bamm:characteristic :CapacityThresholdExhaustionCharacterisitic;
+    bamm:exampleValue "23"^^xsd:decimal.
+:batteryEnergy a bamm:Property;
+    bamm:name "batteryEnergy";
+    bamm:preferredName "battery energy"@en;
+    bamm:description "Characterisitic to describe the energy (kWh) properties of the batterie."@en;
+    bamm:characteristic :BatteryEnergyCharacterisitc.
+:ratioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergy a bamm:Property;
+    bamm:name "ratioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergy";
+    bamm:preferredName "ratio maximum allowed battery power and maximum allowed battery energy"@en;
+    bamm:description "Ratio between maximum allowed battery power (W) and battery energy (Wh) is describing a regulatory requirement."@en;
+    bamm:characteristic :RatioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergyCharacterisitic;
+    bamm:exampleValue "0.611"^^xsd:float.
+:length a bamm:Property;
+    bamm:name "length";
+    bamm:preferredName "length"@en;
+    bamm:description "Length of the item is describing a business requirement."@en;
+    bamm:characteristic :MillimetreCharacteristic;
+    bamm:exampleValue "20000"^^xsd:integer.
+:width a bamm:Property;
+    bamm:name "width";
+    bamm:preferredName "width"@en;
+    bamm:description "Width of the item is describing a business requirement."@en;
+    bamm:characteristic :MillimetreCharacteristic;
+    bamm:exampleValue "1000"^^xsd:integer.
+:height a bamm:Property;
+    bamm:name "height";
+    bamm:preferredName "height"@en;
+    bamm:description "Height of the item is describing a business requirement."@en;
+    bamm:characteristic :MillimetreCharacteristic;
+    bamm:exampleValue "1"^^xsd:integer.
+:diameter a bamm:Property;
+    bamm:name "diameter";
+    bamm:preferredName "diameter"@en;
+    bamm:description "Diameter of the item."@en;
+    bamm:characteristic :MillimetreCharacteristic;
+    bamm:exampleValue "3"^^xsd:integer.
+:weight a bamm:Property;
+    bamm:name "weight";
+    bamm:preferredName "weight"@en;
+    bamm:description "Weight of the item is describing a regulatory requirement."@en;
+    bamm:characteristic :KilogramCharacteristic;
+    bamm:exampleValue "1007"^^xsd:integer.
+:stateOfHealth a bamm:Property;
+    bamm:name "stateOfHealth";
+    bamm:preferredName "state of health"@en;
+    bamm:description "Evidence/Certificate of the health evaluation of a battery for its use following repurposing or remanufacturing operations is describing a business requirement."@en;
+    bamm:characteristic :StateOfHealthCharacteristic;
+    bamm:exampleValue "12"^^xsd:integer.
+:stateOfCharge a bamm:Property;
+    bamm:name "stateOfCharge";
+    bamm:preferredName "state of charge"@en;
+    bamm:description "The value of the state of charge of the battery at the end of life i.e. when entering recycling scheme is describing a business requirement."@en;
+    bamm:characteristic :StateOfChargeCharacteristic;
+    bamm:exampleValue "23"^^xsd:integer.
+:statusBattery a bamm:Property;
+    bamm:name "statusBattery";
+    bamm:preferredName "status battery"@en;
+    bamm:description "Status of the battery is describing a regulatory requirement. Value list provided by the regulators."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "first life/ waste/ repaired/ repurposed/ recycled".
+:batteryType a bamm:Property;
+    bamm:name "batteryType";
+    bamm:preferredName "battery type"@en;
+    bamm:description "Battery type as described by the contents of the battery e.g. cell chemistry is describing a regulatory requirement."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "LFP, Natrium, Li-Ion, NMC, NCA, Solid-State".
+:batteryModel a bamm:Property;
+    bamm:name "batteryModel";
+    bamm:preferredName "battery model"@en;
+    bamm:description "Battery type as described by the contents of the battery e.g. cell chemistry is describing a regulatory requirement."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "LFP, Natrium, Li-Ion, NMC, NCA, Solid-State".
+:batteryIDDMCCode a bamm:Property;
+    bamm:name "batteryIDDMCCode";
+    bamm:preferredName "battery ID DMC code"@en;
+    bamm:description "Digital Matrix Code (DMC) of the battery i.e. serial number allowing for unequivocal identification of a battery is describing a regulatory requirement."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "X123456789012X12345678901234567".
+:dateOfManufacturing a bamm:Property;
+    bamm:name "dateOfManufacturing";
+    bamm:preferredName "date of manufacturing"@en;
+    bamm:description "Manufacturing date of the battery is describing a regulatory requirement."@en;
+    bamm:characteristic :Datestamp;
+    bamm:exampleValue "2022-03-07"^^xsd:date.
+:cathodeActiveMaterials a bamm:Property;
+    bamm:name "cathodeActiveMaterials";
+    bamm:preferredName "cathode active materials"@en;
+    bamm:description "The total amount of valuable materials contained in CAM material: Nickel, Cobalt, Lithium."@en;
+    bamm:characteristic :CathodeActiveMaterialsCharacterisitic.
+:recyclateContentActiveMaterials a bamm:Property;
+    bamm:name "recyclateContentActiveMaterials";
+    bamm:preferredName "recyclate content active materials"@en;
+    bamm:description "List of recovered Recyclate Content in Active Material Recycled is describing a regulatory requirement. The following materials have to be reported on as a minimium: Cobalt, Lithium, Nickel, Lead"@en;
+    bamm:characteristic :RecyclateContentActiveMaterialsCharacteristic.
+:anodeActiveMaterials a bamm:Property;
+    bamm:name "anodeActiveMaterials";
+    bamm:preferredName "anode active materials"@en;
+    bamm:description "The total amount of valuable materials contained in Anode: graphite"@en;
+    bamm:characteristic :AnodeActiveMaterialsCharacteristic.
+:cathodeCompositionOther a bamm:Property;
+    bamm:name "cathodeCompositionOther";
+    bamm:preferredName "cathode composition other"@en;
+    bamm:description "The composition or materials contained in the Cathode is describing a regulatory requirement."@en;
+    bamm:characteristic :CathodeCompositionOtherCharacteristic.
+:anodeCompositionOther a bamm:Property;
+    bamm:name "anodeCompositionOther";
+    bamm:preferredName "anode composition other"@en;
+    bamm:description "The composition or materials contained in the anode is describing a regulatory requirement."@en;
+    bamm:characteristic :AnodeCompositionOtherCharacteristic.
+:electrolyteComposition a bamm:Property;
+    bamm:name "electrolyteComposition";
+    bamm:preferredName "electrolyte composition"@en;
+    bamm:description "List of materials contained in the electrolyte is describing a regulatory requirement."@en;
+    bamm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52020DC0474>;
+    bamm:characteristic :ElectrolyteCompositionCharacteristic.
+:components a bamm:Property;
+    bamm:name "components";
+    bamm:preferredName "components"@en;
+    bamm:description "Properties of the batterie's comoponents."@en;
+    bamm:characteristic :ComponentsCharacteristic.
+:compositionOfBattery a bamm:Property;
+    bamm:name "compositionOfBattery";
+    bamm:preferredName "composition of battery"@en;
+    bamm:description "Full composition of battery is describing a business requirement."@en;
+    bamm:characteristic :CompositionOfBatteryCharacteristic.
+:criticalRawMaterials a bamm:Property;
+    bamm:name "criticalRawMaterials";
+    bamm:preferredName "critical raw materials"@en;
+    bamm:description "List of critical raw materials (CRM) as specified by EU in a battery is describing a regulatory requirement."@en;
+    bamm:characteristic :CriticalRawMaterialsCharacteristic.
+:temperatureRangeIdleStateLowerLimit a bamm:Property;
+    bamm:name "temperatureRangeIdleStateLowerLimit";
+    bamm:preferredName "temperature range idle state lower limit"@en;
+    bamm:description "The lower range of temperature the battery can withstand when not in use is describing a regulatory requirement."@en;
+    bamm:characteristic :TemperatureRangeCharacterisitic;
+    bamm:exampleValue "67"^^xsd:decimal.
+:temperatureRangeIdleStateUpperLimit a bamm:Property;
+    bamm:name "temperatureRangeIdleStateUpperLimit";
+    bamm:preferredName "temperature rangeIdle state upper limit"@en;
+    bamm:description "The upper range of temperature the battery can withstand when not in use is describing a regulatory requirement."@en;
+    bamm:characteristic :TemperatureRangeCharacterisitic;
+    bamm:exampleValue "67"^^xsd:decimal.
+:cycleLifeTestCRate a bamm:Property;
+    bamm:name "cycleLifeTestCRate";
+    bamm:preferredName "cycle life test c-rate"@en;
+    bamm:description "C-rate of Relevant Cycle-life Test is describing a regulatory requirement."@en;
+    bamm:characteristic :CycleLifeTestCRateCharacterisitc;
+    bamm:exampleValue "45"^^xsd:decimal.
+:cycleLifeTestDepthOfDischarge a bamm:Property;
+    bamm:name "cycleLifeTestDepthOfDischarge";
+    bamm:preferredName "cycle-life test depth of discharge"@en;
+    bamm:description "Depth of discharge in the cycle-life test is describing a regulatory requirement."@en;
+    bamm:characteristic :CycleLifeTestDepthOfDischargeCharacteristic;
+    bamm:exampleValue "23"^^xsd:decimal.
+:expectedLifetime a bamm:Property;
+    bamm:name "expectedLifetime";
+    bamm:preferredName "expected lifetime"@en;
+    bamm:description "Expected battery lifetime expressed in cycles, and reference test used is describing a regulatory requirement."@en;
+    bamm:characteristic :ExpectedLifetime;
+    bamm:exampleValue "456"^^xsd:decimal.
+:AttachmentLinkCharacteristic a bamm-c:Set;
+    bamm:name "AttachmentLinkCharacteristic";
+    bamm:preferredName "attachment"@en;
+    bamm:description "Links the referenced attachments"@en;
+    bamm:dataType :AttachmentEntity.
+:BatteryPowerCharacteristic a bamm:Characteristic;
+    bamm:name "BatteryPowerCharacteristic";
+    bamm:preferredName "battery power characteristic"@en;
+    bamm:description "Characterisitic to describe the power (W) properties of the batterie."@en;
+    bamm:dataType :BatteryPowerEntity.
+:BatteryVoltageCharacteristiC a bamm:Characteristic;
+    bamm:name "BatteryVoltageCharacteristiC";
+    bamm:preferredName "BatteryVoltageCharacteristic"@en;
+    bamm:description "Characterisitic to describe the voltage (V) properties of the batterie."@en;
+    bamm:dataType :BatteryVoltageEntity.
+:RatedCapacityCharacteristic a bamm-c:Measurement;
+    bamm:name "RatedCapacityCharacteristic";
+    bamm:preferredName "rated capacity characteristic"@en;
+    bamm:description "The total number of ampere-hours (Ah) that can be withdrawn from a fully charged battery under specific conditions is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:ampere.
+:CapacityFadeCharacteristic a bamm-c:Measurement;
+    bamm:name "CapacityFadeCharacteristic";
+    bamm:preferredName "capacity fade characteristic"@en;
+    bamm:description "The decrease over time and upon usage in the amount of charge that a battery can deliver at the rated voltage, with respect to the original rated capacity declared by the manufacturer is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:InternalResistanceCharacteristic a bamm:Characteristic;
+    bamm:name "InternalResistanceCharacteristic";
+    bamm:preferredName "internal resistance"@en;
+    bamm:description "Internal resistance in a battery cell or pack is describing a regulatory requirement."@en;
+    bamm:dataType :InternalResistanceEntity.
+:CapacityThresholdExhaustionCharacterisitic a bamm-c:Measurement;
+    bamm:name "CapacityThresholdExhaustionCharacterisitic";
+    bamm:preferredName "capacity threshold exhaustion characterisitic"@en;
+    bamm:description "Capacity threshold for exhaustion as percentage value is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:BatteryEnergyCharacterisitc a bamm:Characteristic;
+    bamm:name "BatteryEnergyCharacterisitc";
+    bamm:preferredName "battery energy characterisitc"@en;
+    bamm:description "Characterisitic to describe the energy (kWh) properties of the batterie."@en;
+    bamm:dataType :BatteryEnergyEntity.
+:RatioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergyCharacterisitic a bamm:Characteristic;
+    bamm:name "RatioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergyCharacterisitic";
+    bamm:preferredName "ratio maximum allowed battery power and maximum allowed battery energy characterisitic"@en;
+    bamm:description "Ratio between maximum allowed battery power (W) and battery energy (Wh) is describing a regulatory requirement."@en;
+    bamm:dataType xsd:float.
+:MillimetreCharacteristic a bamm-c:Measurement;
+    bamm:name "MillimetreCharacteristic";
+    bamm:preferredName "millimetre characteristic"@en;
+    bamm:description "A measurment for the length/width/height of an item."@en;
+    bamm:dataType xsd:integer;
+    bamm-c:unit unit:millimetre.
+:KilogramCharacteristic a bamm-c:Measurement;
+    bamm:name "KilogramCharacteristic";
+    bamm:preferredName "kilogram characteristic"@en;
+    bamm:description "A measurement for the weight of an item."@en;
+    bamm:dataType xsd:integer;
+    bamm-c:unit unit:kilogram.
+:StateOfHealthCharacteristic a bamm-c:Measurement;
+    bamm:name "StateOfHealthCharacteristic";
+    bamm:preferredName "state of health characteristic"@en;
+    bamm:description "Evidence/Certificate of the health evaluation of a battery for its use following repurposing or remanufacturing operations is describing a business requirement."@en;
+    bamm:dataType xsd:integer;
+    bamm-c:unit unit:percent.
+:StateOfChargeCharacteristic a bamm-c:Measurement;
+    bamm:name "StateOfChargeCharacteristic";
+    bamm:preferredName "state of charge characteristic"@en;
+    bamm:description "The value of the state of charge of the battery at the end of life i.e. when entering recycling scheme is describing a business requirement."@en;
+    bamm:dataType xsd:integer;
+    bamm-c:unit unit:percent.
+:CathodeActiveMaterialsCharacterisitic a bamm-c:Set;
+    bamm:name "CathodeActiveMaterialsCharacterisitic";
+    bamm:preferredName "cathode active materials"@en;
+    bamm:description "The total amount of valuable materials contained in CAM material: Nickel, Cobalt, Lithium."@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:RecyclateContentActiveMaterialsCharacteristic a bamm-c:Set;
+    bamm:name "RecyclateContentActiveMaterialsCharacteristic";
+    bamm:preferredName "recyclate content active materials"@en;
+    bamm:description "List of recovered Recyclate Content in Active Material Recycled is describing a regulatory requirement. The following materials have to be reported on as a minimium: Cobalt, Lithium, Nickel, Lead"@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:AnodeActiveMaterialsCharacteristic a bamm-c:Set;
+    bamm:name "AnodeActiveMaterialsCharacteristic";
+    bamm:preferredName "anode active materials"@en;
+    bamm:description "The total amount of valuable materials contained in Anode: graphite"@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:CathodeCompositionOtherCharacteristic a bamm-c:Set;
+    bamm:name "CathodeCompositionOtherCharacteristic";
+    bamm:preferredName "cathode composition other"@en;
+    bamm:description "The composition or materials contained in the Cathode is describing a regulatory requirement."@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:AnodeCompositionOtherCharacteristic a bamm-c:Set;
+    bamm:name "AnodeCompositionOtherCharacteristic";
+    bamm:preferredName "anode composition other"@en;
+    bamm:description "The composition or materials contained in the anode is describing a regulatory requirement."@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:ElectrolyteCompositionCharacteristic a bamm-c:Set;
+    bamm:name "ElectrolyteCompositionCharacteristic";
+    bamm:preferredName "electrolyte composition"@en;
+    bamm:description "List of materials contained in the electrolyte is describing a regulatory requirement."@en;
+    bamm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52020DC0474>;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:ComponentsCharacteristic a bamm:Characteristic;
+    bamm:name "ComponentsCharacteristic";
+    bamm:preferredName "components"@en;
+    bamm:description "Characteristics of the batterie's comoponents."@en;
+    bamm:dataType :CompomenentsEntity.
+:CompositionOfBatteryCharacteristic a bamm-c:Set;
+    bamm:name "CompositionOfBatteryCharacteristic";
+    bamm:preferredName "composition of battery"@en;
+    bamm:description "Full composition of battery is describing a business requirement."@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:CriticalRawMaterialsCharacteristic a bamm:Characteristic;
+    bamm:name "CriticalRawMaterialsCharacteristic";
+    bamm:preferredName "critical raw materials"@en;
+    bamm:description "List of critical raw materials (CRM) as specified by EU in a battery is describing a regulatory requirement."@en;
+    bamm:dataType xsd:string.
+:TemperatureRangeCharacterisitic a bamm-c:Measurement;
+    bamm:name "TemperatureRangeCharacterisitic";
+    bamm:preferredName "temperature range"@en;
+    bamm:description "The lower range of temperature the battery can withstand when not in use is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:degreeCelsius.
+:CycleLifeTestCRateCharacterisitc a bamm:Characteristic;
+    bamm:name "CycleLifeTestCRateCharacterisitc";
+    bamm:preferredName "cycle life test c-rate"@en;
+    bamm:description "C-rate of Relevant Cycle-life Test is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal.
+:CycleLifeTestDepthOfDischargeCharacteristic a bamm-c:Measurement;
+    bamm:name "CycleLifeTestDepthOfDischargeCharacteristic";
+    bamm:preferredName "cycle life test depth of discharge"@en;
+    bamm:description "Depth of discharge in the cycle-life test is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:ExpectedLifetime a bamm-c:Measurement;
+    bamm:name "ExpectedLifetime";
+    bamm:preferredName "expected lifetime"@en;
+    bamm:description "Expected battery lifetime expressed in cycles, and reference test used is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:piece.
+:AttachmentEntity a bamm:Entity;
+    bamm:name "AttachmentEntity";
+    bamm:properties (:fileLocation :title);
+    bamm:preferredName "AttachmentEntity"@en;
+    bamm:description "Entity encapsulating the details of a attachment for the battery"@en.
+:BatteryPowerEntity a bamm:Entity;
+    bamm:name "BatteryPowerEntity";
+    bamm:properties (:maximumAllowedBatteryPower :originalPower :powerFade :powerCapabilityAt20Charge :powerCapabilityAt80Charge :originalPowerCapability :originalPowerCapabilityLimits);
+    bamm:preferredName "battery power entity"@en;
+    bamm:description "Entity to bundle the power properties of a battery."@en.
+:BatteryVoltageEntity a bamm:Entity;
+    bamm:name "BatteryVoltageEntity";
+    bamm:properties (:minVoltage :nominalVoltage :maxVoltage);
+    bamm:preferredName "battery voltage entity"@en;
+    bamm:description "Entity to bundle the voltage properties of a battery."@en.
+:InternalResistanceEntity a bamm:Entity;
+    bamm:name "InternalResistanceEntity";
+    bamm:properties (:cellInternalResistance :packInternalResistance :packInternalResistanceIncrease);
+    bamm:preferredName "internal resistance"@en;
+    bamm:description "Entity to bundle the internal resistance properties of a battery."@en.
+:BatteryEnergyEntity a bamm:Entity;
+    bamm:name "BatteryEnergyEntity";
+    bamm:properties (:maximumAllowedBatteryEnergy :energyRoundtripEfficiency :energyRoundtripEfficiencyChange);
+    bamm:preferredName "battery energy entity"@en;
+    bamm:description "Entity to bundle the energy properties of a battery."@en.
+:MaterialNameAndWeightAndPercentageMassFractionEntity a bamm:Entity;
+    bamm:name "MaterialNameAndWeightAndPercentageMassFractionEntity";
+    bamm:properties ([
+  bamm:property :matierialPercentageMassFraction;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :matierialWeight;
+  bamm:optional "true"^^xsd:boolean
+] :materialName);
+    bamm:preferredName "material name and weight and percent"@en;
+    bamm:description "Entity to bundle a material's name, weight and percentage of mass."@en.
+:CompomenentsEntity a bamm:Entity;
+    bamm:name "CompomenentsEntity";
+    bamm:properties (:componentsSupplier :componentsPartNumber);
+    bamm:preferredName "components"@en;
+    bamm:description "Entity to bundle the components properties of a battery."@en.
+:fileLocation a bamm:Property;
+    bamm:name "fileLocation";
+    bamm:preferredName "file location"@en;
+    bamm:description "Location of the file"@en;
+    bamm:characteristic :FileLocationCharacteristic.
+:title a bamm:Property;
+    bamm:name "title";
+    bamm:preferredName "title"@en;
+    bamm:description "Title of the attached file"@en;
+    bamm:characteristic bamm-c:Text.
+:maximumAllowedBatteryPower a bamm:Property;
+    bamm:name "maximumAllowedBatteryPower";
+    bamm:preferredName "maximum allowed battery power"@en;
+    bamm:description "Maximum allowed battery power (W) of the battery is describing a business requirement."@en;
+    bamm:see <https%3A%2F%2Feur-lex.europa.eu%2Flegal-content%2FEN%2FTXT%2F%3Furi%3DCELEX%3A52020PC0798>;
+    bamm:characteristic :PowerCharacteristic;
+    bamm:exampleValue "55000.0"^^xsd:float.
+:originalPower a bamm:Property;
+    bamm:name "originalPower";
+    bamm:preferredName "battery original power"@en;
+    bamm:description "Original power capability in Watts is describing a regulatory requirement."@en;
+    bamm:characteristic :PowerCharacteristic;
+    bamm:exampleValue "7.56"^^xsd:float.
+:powerFade a bamm:Property;
+    bamm:name "powerFade";
+    bamm:preferredName "maximum allowed battery power"@en;
+    bamm:description "Maximum allowed battery power (W) of the battery is describing a business requirement."@en;
+    bamm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52020PC0798>;
+    bamm:characteristic :PowerFadeCharacteristic;
+    bamm:exampleValue "23.0"^^xsd:float.
+:powerCapabilityAt20Charge a bamm:Property;
+    bamm:name "powerCapabilityAt20Charge";
+    bamm:preferredName "power capability at 20 charge"@en;
+    bamm:description "Power (capability) at 20% state of charge. Description from the Regulation is describing a regulatory requirement."@en;
+    bamm:characteristic :PowerCharacteristic;
+    bamm:exampleValue "643"^^xsd:float.
+:powerCapabilityAt80Charge a bamm:Property;
+    bamm:name "powerCapabilityAt80Charge";
+    bamm:preferredName "power capability at 80 charge"@en;
+    bamm:description "Power (capability) at 80% state of charge. Description from the Regulation is describing a regulatory requirement."@en;
+    bamm:characteristic :PowerCharacteristic;
+    bamm:exampleValue "47"^^xsd:float.
+:originalPowerCapability a bamm:Property;
+    bamm:name "originalPowerCapability";
+    bamm:preferredName "original power capability"@en;
+    bamm:description "Performance ability of the high voltage battery i.e. the amount of energy that a battery is capable to provide over a given period of time is describing a regulatory requirement."@en;
+    bamm:characteristic :KilowattCharacteristic;
+    bamm:exampleValue "123"^^xsd:decimal.
+:originalPowerCapabilityLimits a bamm:Property;
+    bamm:name "originalPowerCapabilityLimits";
+    bamm:preferredName "original power capability limits"@en;
+    bamm:description "Performance ability of the high voltage battery according to limits i.e. how much power it can provide within given limits is describing a regulatory requirement."@en;
+    bamm:characteristic :KilowattCharacteristic;
+    bamm:exampleValue "123"^^xsd:decimal.
+:minVoltage a bamm:Property;
+    bamm:name "minVoltage";
+    bamm:preferredName "min voltage"@en;
+    bamm:description "Value of the minimal voltage the battery is rated for is describing a regulatory requirement."@en;
+    bamm:characteristic :VoltCharacteristic;
+    bamm:exampleValue "2"^^xsd:float.
+:nominalVoltage a bamm:Property;
+    bamm:name "nominalVoltage";
+    bamm:preferredName "nominal voltage"@en;
+    bamm:description "Value of the nominal voltage the battery is rated for is describing a regulatory requirement."@en;
+    bamm:characteristic :VoltCharacteristic;
+    bamm:exampleValue "4.3"^^xsd:float.
+:maxVoltage a bamm:Property;
+    bamm:name "maxVoltage";
+    bamm:preferredName "max voltage"@en;
+    bamm:description "Value of the maximum voltage the battery is rated for is describing a regulatory requirement."@en;
+    bamm:characteristic :VoltCharacteristic;
+    bamm:exampleValue "6"^^xsd:float.
+:cellInternalResistance a bamm:Property;
+    bamm:name "cellInternalResistance";
+    bamm:preferredName "cell internal resistance"@en;
+    bamm:description "The resistance offered by the cell in the flow of the current"@en;
+    bamm:characteristic :MilliohmCharacteristic;
+    bamm:exampleValue "45"^^xsd:decimal.
+:packInternalResistance a bamm:Property;
+    bamm:name "packInternalResistance";
+    bamm:preferredName "pack internal resistance"@en;
+    bamm:description "Total internal resistance in a battery pack is describing a regulatory requirement."@en;
+    bamm:characteristic :OhmCharacterisitic;
+    bamm:exampleValue "67"^^xsd:decimal.
+:packInternalResistanceIncrease a bamm:Property;
+    bamm:name "packInternalResistanceIncrease";
+    bamm:preferredName "pack internal resistanceIncrease"@en;
+    bamm:description "Increase in internal resistance of a battery pack over a period of time is describing a regulatory requirement."@en;
+    bamm:characteristic :PercentCharacteristic;
+    bamm:exampleValue "23"^^xsd:decimal.
+:maximumAllowedBatteryEnergy a bamm:Property;
+    bamm:name "maximumAllowedBatteryEnergy";
+    bamm:preferredName "maximum allowed battery energy"@en;
+    bamm:description "Maximum allowed battery energy (Wh) of the battery is describing a regulatory requirement."@en;
+    bamm:see <https%3A%2F%2Feur-lex.europa.eu%2Flegal-content%2FEN%2FTXT%2F%3Furi%3DCELEX%3A52020PC0798>;
+    bamm:characteristic :MaximumAllowedBatteryEnergyCharacteristic;
+    bamm:exampleValue "90000"^^xsd:float.
+:energyRoundtripEfficiency a bamm:Property;
+    bamm:name "energyRoundtripEfficiency";
+    bamm:preferredName "energy roundtrip efficiency"@en;
+    bamm:description "Round-trip efficiency is the percentage of electricity put into storage is describing a regulatory requirement."@en;
+    bamm:characteristic :EnergyRoundtripEfficiency;
+    bamm:exampleValue "56"^^xsd:decimal.
+:energyRoundtripEfficiencyChange a bamm:Property;
+    bamm:name "energyRoundtripEfficiencyChange";
+    bamm:preferredName "energy roundtrip efficiency"@en;
+    bamm:description "Round-trip efficiency is the percentage of electricity put into storage is describing a regulatory requirement."@en;
+    bamm:characteristic :EnergyRoundtripEfficiencyChangeCharacterisitic;
+    bamm:exampleValue "67"^^xsd:decimal.
+:matierialPercentageMassFraction a bamm:Property;
+    bamm:name "matierialPercentageMassFraction";
+    bamm:preferredName "matierial percentage mass fraction"@en;
+    bamm:description "Percentage mass fraction of a material."@en;
+    bamm:characteristic :MatierialPercentageMassFractionCharacteristic;
+    bamm:exampleValue "19"^^xsd:decimal.
+:matierialWeight a bamm:Property;
+    bamm:name "matierialWeight";
+    bamm:preferredName "material weight"@en;
+    bamm:description "Weight of the material (in gram)"@en;
+    bamm:characteristic :GramCharacteristic;
+    bamm:exampleValue "2.5"^^xsd:decimal.
+:materialName a bamm:Property;
+    bamm:name "materialName";
+    bamm:preferredName "material name"@en;
+    bamm:description "Name of the material"@en;
+    bamm:characteristic :Text.
+:componentsSupplier a bamm:Property;
+    bamm:name "componentsSupplier";
+    bamm:preferredName "components supplier"@en;
+    bamm:description "Contact details of the suppliers of replacement parts / spare parts is describing a regulatory requirement. Available fields should be like:\nName - Street - Number - ZIP Code - City - State - Country - Phone - Fax - Email - Website"@en;
+    bamm:characteristic :ComponentsSupplierCharacteristic.
+:componentsPartNumber a bamm:Property;
+    bamm:name "componentsPartNumber";
+    bamm:preferredName "components part number"@en;
+    bamm:description "The unique serial numbers of the different parts of a battery is describing a regulatory requirement."@en;
+    bamm:characteristic :ComponentsPartNumberList;
+    bamm:exampleValue "Case xxxxxxx/xx; Controller xxxxxxx/xx".
+:FileLocationCharacteristic a bamm:Characteristic;
+    bamm:name "FileLocationCharacteristic";
+    bamm:preferredName "file location"@en;
+    bamm:description "The path to the file"@en;
+    bamm:dataType xsd:anyURI.
+:PowerCharacteristic a bamm-c:Measurement;
+    bamm:name "PowerCharacteristic";
+    bamm:preferredName "power characteristic"@en;
+    bamm:description "Power capability in Watts"@en;
+    bamm:dataType xsd:float;
+    bamm-c:unit unit:watt.
+:PowerFadeCharacteristic a bamm-c:Measurement;
+    bamm:name "PowerFadeCharacteristic";
+    bamm:preferredName "power fade characteristic"@en;
+    bamm:description "The decrease over time and upon usage in the amount of power that a battery can deliver at the rated voltage is describing a regulatory requirement."@en;
+    bamm:dataType xsd:float;
+    bamm-c:unit unit:percent.
+:KilowattCharacteristic a bamm-c:Measurement;
+    bamm:name "KilowattCharacteristic";
+    bamm:preferredName "kilowatt characteristic"@en;
+    bamm:description "A measurement for the power of the battery."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:kilowatt.
+:VoltCharacteristic a bamm-c:Measurement;
+    bamm:name "VoltCharacteristic";
+    bamm:preferredName "volt characteristic"@en;
+    bamm:description "Value of the voltage the battery is rated for"@en;
+    bamm:dataType xsd:float;
+    bamm-c:unit unit:volt.
+:MilliohmCharacteristic a bamm-c:Measurement;
+    bamm:name "MilliohmCharacteristic";
+    bamm:preferredName "milliohm characteristic"@en;
+    bamm:description "The resistance offered by the cell in the flow of the current"@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:milliohm.
+:OhmCharacterisitic a bamm-c:Measurement;
+    bamm:name "OhmCharacterisitic";
+    bamm:preferredName "ohm characterisitic"@en;
+    bamm:description "Total internal resistance in a battery pack"@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:ohm.
+:PercentCharacteristic a bamm-c:Measurement;
+    bamm:name "PercentCharacteristic";
+    bamm:preferredName "percent characteristic"@en;
+    bamm:description "Increase in internal resistance of a battery pack over a period of time"@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:MaximumAllowedBatteryEnergyCharacteristic a bamm-c:Measurement;
+    bamm:name "MaximumAllowedBatteryEnergyCharacteristic";
+    bamm:preferredName "maximum allowed battery energy"@en;
+    bamm:description "Characterisitic to describe the energy (Wh) properties of the battery is describing a regulatory requirement."@en;
+    bamm:dataType xsd:float;
+    bamm-c:unit unit:wattHour.
+:EnergyRoundtripEfficiency a bamm-c:Measurement;
+    bamm:name "EnergyRoundtripEfficiency";
+    bamm:preferredName "energy roundtrip efficiency"@en;
+    bamm:description "Round-trip efficiency is the percentage of electricity put into storage is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:EnergyRoundtripEfficiencyChangeCharacterisitic a bamm-c:Measurement;
+    bamm:name "EnergyRoundtripEfficiencyChangeCharacterisitic";
+    bamm:preferredName "energy roundtrip efficiency change"@en;
+    bamm:description "Round-trip efficiency is the percentage of electricity put into storage after 50% of life of the battery is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:MatierialPercentageMassFractionCharacteristic a bamm-c:Measurement;
+    bamm:name "MatierialPercentageMassFractionCharacteristic";
+    bamm:preferredName "matierial percentage mass fraction"@en;
+    bamm:description "Percentage mass fraction of a material"@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:GramCharacteristic a bamm-c:Measurement;
+    bamm:name "GramCharacteristic";
+    bamm:preferredName "gram characteristic"@en;
+    bamm:description "Weight of the material (in gram)"@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:gram.
+:Text a bamm:Characteristic;
+    bamm:name "Text";
+    bamm:description "Describes a Property which contains plain text. This is intended exclusively for human readable strings, not for identifiers, measurement values, etc."@en;
+    bamm:dataType xsd:string.
+:ComponentsSupplierCharacteristic a bamm-c:Set;
+    bamm:name "ComponentsSupplierCharacteristic";
+    bamm:preferredName "components supplier"@en;
+    bamm:description "Contact details of the suppliers of replacement parts / spare parts is describing a regulatory requirement."@en;
+    bamm:dataType :ComponentsSupplierEntity.
+:ComponentsSupplierEntity a bamm:Entity;
+    bamm:name "ComponentsSupplierEntity";
+    bamm:properties (:address :contact :componentsSupplierName);
+    bamm:preferredName "components supplier"@en;
+    bamm:description "Entity encapsulating the details of a components supplier"@en.
+:componentsSupplierName a bamm:Property;
+    bamm:name "componentsSupplierName";
+    bamm:preferredName "components supplier name"@en;
+    bamm:description "Name of the components supplier"@en;
+    bamm:characteristic :Text;
+    bamm:exampleValue "XY Corporation".
+:ComponentsPartNumberList a bamm-c:Collection;
+    bamm:name "ComponentsPartNumberList";
+    bamm:preferredName "components part number list"@en;
+    bamm:description "A list of the unique serial numbers of the different parts of a battery is describing a regulatory requirement."@en;
+    bamm:dataType xsd:string.

--- a/io.catenax.battery.battery_pass/3.0.1/BatteryPass.ttl
+++ b/io.catenax.battery.battery_pass/3.0.1/BatteryPass.ttl
@@ -1,0 +1,920 @@
+#######################################################################
+# Copyright (c) 2023 BASF SE
+# Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft
+# Copyright (c) 2023 Robert Bosch GmbH
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2023 Henkel AG & Co. KGaA
+# Copyright (c) 2023 SAP SE
+# Copyright (c) 2023 T-Systems International GmbH
+# Copyright (c) 2023 ZF Friedrichshafen AG
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the 
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license, 
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:1.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:1.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:1.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:1.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.battery.battery_pass:3.0.1#>.
+@prefix address-c: <urn:bamm:io.catenax.shared.address_characteristic:1.0.1#>.
+@prefix contact-c: <urn:bamm:io.catenax.shared.contact_information:1.0.0#>.
+
+:BatteryPass a bamm:Aspect;
+    bamm:name "BatteryPass";
+    bamm:properties ([
+  bamm:property :document;
+  bamm:optional "true"^^xsd:boolean
+] :manufacturer :electrochemicalProperties :physicalDimensions :stateOfBattery :batteryIdentification :manufacturing :datePlacedOnMarket :cellChemistry :composition :cO2FootprintTotal :temperatureRangeIdleState :warrantyPeriod :batteryCycleLife);
+    bamm:operations ();
+    bamm:preferredName "battery pass"@en;
+    bamm:description "The battery pass describes information collected during the lifecycle of a battery"@en;
+    bamm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52020PC0798>;
+    bamm:events ().
+:document a bamm:Property;
+    bamm:name "document";
+    bamm:preferredName "document"@en;
+    bamm:description "Set of documents containing the description of battery components"@en;
+    bamm:characteristic :DocumentCharacteristic.
+:manufacturer a bamm:Property;
+    bamm:name "manufacturer";
+    bamm:preferredName "manufacturer"@en;
+    bamm:description "Legal entity which sells and invoices the battery"@en;
+    bamm:characteristic :ManufacturerCharacteristic.
+:electrochemicalProperties a bamm:Property;
+    bamm:name "electrochemicalProperties";
+    bamm:preferredName "electrochemical properties"@en;
+    bamm:description "Electrochemical properties of an electrochemical energy storage"@en;
+    bamm:characteristic :ElectrochemicalPropertiesCharacteristic.
+:physicalDimensions a bamm:Property;
+    bamm:name "physicalDimensions";
+    bamm:preferredName "physical dimensions"@en;
+    bamm:description "Geometrical properties of the battery"@en;
+    bamm:characteristic :PhysicalDimensionsCharacteristic.
+:stateOfBattery a bamm:Property;
+    bamm:name "stateOfBattery";
+    bamm:preferredName "state of battery"@en;
+    bamm:description "The condition of the battery at the end of life i.e. when entering recycling scheme"@en;
+    bamm:characteristic :StateOfBatteryCharacteristic.
+:batteryIdentification a bamm:Property;
+    bamm:name "batteryIdentification";
+    bamm:preferredName "battery identification"@en;
+    bamm:description "Information to identify a specific battery."@en;
+    bamm:characteristic :BatteryIdentificationCharacteristic.
+:manufacturing a bamm:Property;
+    bamm:name "manufacturing";
+    bamm:preferredName "manufacturing"@en;
+    bamm:description "Information about the manufacturing process of a battery"@en;
+    bamm:characteristic :ManufacturingCharacteristic.
+:datePlacedOnMarket a bamm:Property;
+    bamm:name "datePlacedOnMarket";
+    bamm:preferredName "date placed on market"@en;
+    bamm:description "Date on which vehicle is produced i.e. when battery is put in the market or production date of the vehicle is describing a regulatory requirement."@en;
+    bamm:characteristic :Datestamp.
+:cellChemistry a bamm:Property;
+    bamm:name "cellChemistry";
+    bamm:preferredName "cell chemistry"@en;
+    bamm:description "Information about the cell chemistry of a battery cell"@en;
+    bamm:characteristic :CellChemistryCharacteristic.
+:composition a bamm:Property;
+    bamm:name "composition";
+    bamm:preferredName "composition"@en;
+    bamm:description "Information about the composition of a battery and the combination of materials is describing a business requirement."@en;
+    bamm:characteristic :CompositionCharacteristic.
+:cO2FootprintTotal a bamm:Property;
+    bamm:name "cO2FootprintTotal";
+    bamm:preferredName "CO2 footprint total"@en;
+    bamm:description "The total carbon footprint of the battery, calculated as kg of carbon dioxide equivalent is describing a regulatory requirement."@en;
+    bamm:characteristic :CO2FootprintTotalCharacteristic;
+    bamm:exampleValue "124.00"^^xsd:double.
+:temperatureRangeIdleState a bamm:Property;
+    bamm:name "temperatureRangeIdleState";
+    bamm:preferredName "temperature range idle state"@en;
+    bamm:description "The range of temperature the battery can withstand when not in use is describing a regulatory requirement."@en;
+    bamm:characteristic :TemperatureRangeIdleStateCharacterisitic.
+:warrantyPeriod a bamm:Property;
+    bamm:name "warrantyPeriod";
+    bamm:preferredName "warranty period"@en;
+    bamm:description "Commercial warranty period of the battery is describing a regulatory requirement."@en;
+    bamm:characteristic :WarrantyPeriodCharacterisitic;
+    bamm:exampleValue "60"^^xsd:positiveInteger.
+:batteryCycleLife a bamm:Property;
+    bamm:name "batteryCycleLife";
+    bamm:preferredName "battery cycle life"@en;
+    bamm:description "Property describing the cycle life of a battery"@en;
+    bamm:characteristic :BatteryCycleLifeCharacteristic.
+:DocumentCharacteristic a bamm:Characteristic;
+    bamm:name "DocumentCharacteristic";
+    bamm:preferredName "document characteristic"@en;
+    bamm:description "Set of documents containing the description of battery components"@en;
+    bamm:dataType :DocumentEntity.
+:ManufacturerCharacteristic a bamm:Characteristic;
+    bamm:name "ManufacturerCharacteristic";
+    bamm:preferredName "manufacturer characteristic"@en;
+    bamm:description "A manufacturer of goods"@en;
+    bamm:dataType :ManufacturerEntity.
+:ElectrochemicalPropertiesCharacteristic a bamm:Characteristic;
+    bamm:name "ElectrochemicalPropertiesCharacteristic";
+    bamm:preferredName "electrochemical properties characteristic"@en;
+    bamm:description "Electrochemical characteristics to describe a battery"@en;
+    bamm:dataType :ElectrochemicalPropertiesEntity.
+:PhysicalDimensionsCharacteristic a bamm:Characteristic;
+    bamm:name "PhysicalDimensionsCharacteristic";
+    bamm:preferredName "physical dimensions characteristic"@en;
+    bamm:description "Geometrical properties of the battery"@en;
+    bamm:dataType :PhysicalDimensionsEntity.
+:StateOfBatteryCharacteristic a bamm:Characteristic;
+    bamm:name "StateOfBatteryCharacteristic";
+    bamm:preferredName "state of battery characteristic"@en;
+    bamm:description "The condition of the battery at the end of life i.e. when entering recycling scheme"@en;
+    bamm:dataType :StateOfBatteryEntity.
+:BatteryIdentificationCharacteristic a bamm:Characteristic;
+    bamm:name "BatteryIdentificationCharacteristic";
+    bamm:preferredName "battery identification characteristic"@en;
+    bamm:description "Information to identify a specific battery."@en;
+    bamm:dataType :BatteryIdentificationEntity.
+:ManufacturingCharacteristic a bamm:Characteristic;
+    bamm:name "ManufacturingCharacteristic";
+    bamm:preferredName "manufacturing characteristic"@en;
+    bamm:description "Information about the manufacturing process of a battery"@en;
+    bamm:dataType :ManufacturingEntity.
+:Datestamp a bamm:Characteristic;
+    bamm:name "Datestamp";
+    bamm:preferredName "datestamp"@en;
+    bamm:description "Describes a Property which contains the date and time with an optional timezone."@en;
+    bamm:dataType xsd:date.
+:CellChemistryCharacteristic a bamm:Characteristic;
+    bamm:name "CellChemistryCharacteristic";
+    bamm:preferredName "cell chemistry"@en;
+    bamm:description "Information about the the cell chemistry of a battery cell"@en;
+    bamm:dataType :CellChemistryEntity.
+:CompositionCharacteristic a bamm:Characteristic;
+    bamm:name "CompositionCharacteristic";
+    bamm:preferredName "composition"@en;
+    bamm:description "Information about the composition of a battery and the combination of materials is describing a business requirement."@en;
+    bamm:dataType :CompositionEntity.
+:CO2FootprintTotalCharacteristic a bamm-c:Measurement;
+    bamm:name "CO2FootprintTotalCharacteristic";
+    bamm:preferredName "co2 footprint total"@en;
+    bamm:description "The total carbon footprint of the battery, calculated as kg of carbon dioxide equivalent is describing a regulatory requirement."@en;
+    bamm:dataType xsd:double;
+    bamm-c:unit unit:kilogram.
+:TemperatureRangeIdleStateCharacterisitic a bamm:Characteristic;
+    bamm:name "TemperatureRangeIdleStateCharacterisitic";
+    bamm:preferredName "temperature range idle state"@en;
+    bamm:description "The range of temperature the battery can withstand when not in use is describing a regulatory requirement."@en;
+    bamm:dataType :TemperatureRangeIdleStateEntity.
+:WarrantyPeriodCharacterisitic a bamm-c:Measurement;
+    bamm:name "WarrantyPeriodCharacterisitic";
+    bamm:preferredName "warranty period"@en;
+    bamm:description "Commercial warranty period of the battery is describing a regulatory requirement."@en;
+    bamm:dataType xsd:positiveInteger;
+    bamm-c:unit unit:month.
+:BatteryCycleLifeCharacteristic a bamm:Characteristic;
+    bamm:name "BatteryCycleLifeCharacteristic";
+    bamm:preferredName "battery cycle life"@en;
+    bamm:description "Characteristic describing the cycle life of a battery"@en;
+    bamm:dataType :BatteryCycleLifeEntity.
+:DocumentEntity a bamm:Entity;
+    bamm:name "DocumentEntity";
+    bamm:properties ([
+  bamm:property :packagingInstructions;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :transportationInstructions;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :vehicleDismantlingProcedure;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :batteryDismantlingProcedure;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :safetyMeasures;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :testReportsResults;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :declarationOfConformity;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :responsibleSourcing;
+  bamm:optional "true"^^xsd:boolean
+]);
+    bamm:preferredName "document entity"@en;
+    bamm:description "Entity encapsulating the details of a attachment for the battery"@en.
+:ManufacturerEntity a bamm:Entity;
+    bamm:name "ManufacturerEntity";
+    bamm:properties (:name :contact :address);
+    bamm:preferredName "manufacturer"@en;
+    bamm:description "Entity encapsulating the details of a manufacturer of goods"@en.
+:ElectrochemicalPropertiesEntity a bamm:Entity;
+    bamm:name "ElectrochemicalPropertiesEntity";
+    bamm:properties (:batteryPower :batteryVoltage :ratedCapacity :capacityFade :internalResistance :capacityThresholdExhaustion :batteryEnergy :ratioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergy);
+    bamm:preferredName "electrochemical properties entity"@en;
+    bamm:description "Entity encapsulating the electrochemical details of a battery"@en.
+:PhysicalDimensionsEntity a bamm:Entity;
+    bamm:name "PhysicalDimensionsEntity";
+    bamm:properties (:length :width :height :diameter :weight);
+    bamm:preferredName "physical dimensions entity"@en;
+    bamm:description "Entity to bundle the characterisitics describing the physical dimensions"@en.
+:StateOfBatteryEntity a bamm:Entity;
+    bamm:name "StateOfBatteryEntity";
+    bamm:properties (:stateOfHealth :stateOfCharge :statusBattery);
+    bamm:preferredName "state of battery entity"@en;
+    bamm:description "Entity to bundle the characterisitics describing the state of a battery"@en.
+:BatteryIdentificationEntity a bamm:Entity;
+    bamm:name "BatteryIdentificationEntity";
+    bamm:properties (:batteryType :batteryModel :batteryIDDMCCode);
+    bamm:preferredName "battery identification entity"@en;
+    bamm:description "Entity to bundle the characterisitics describing the identification of a battery"@en.
+:ManufacturingEntity a bamm:Entity;
+    bamm:name "ManufacturingEntity";
+    bamm:properties (:dateOfManufacturing :address);
+    bamm:preferredName "manufacturing entity"@en;
+    bamm:description "Entity to bundle the characterisitics describing the manufacturing (place and date of manufacture)"@en.
+:CellChemistryEntity a bamm:Entity;
+    bamm:name "CellChemistryEntity";
+    bamm:properties (:cathodeActiveMaterials :recyclateContentActiveMaterials :anodeActiveMaterials :cathodeCompositionOther :anodeCompositionOther :electrolyteComposition);
+    bamm:preferredName "cell chemistry"@en;
+    bamm:description "Entity to bundle the characterisitics describing a battery's cell chemistry"@en.
+:CompositionEntity a bamm:Entity;
+    bamm:name "CompositionEntity";
+    bamm:properties (:components :compositionOfBattery :criticalRawMaterials);
+    bamm:preferredName "composition"@en;
+    bamm:description "Entity to bundle the characterisitics describing a battery's composition"@en.
+:TemperatureRangeIdleStateEntity a bamm:Entity;
+    bamm:name "TemperatureRangeIdleStateEntity";
+    bamm:properties (:temperatureRangeIdleStateLowerLimit :temperatureRangeIdleStateUpperLimit);
+    bamm:preferredName "temperature range idle state"@en;
+    bamm:description "Entity to bundle the characterisitics describing the battery's temperature range"@en.
+:BatteryCycleLifeEntity a bamm:Entity;
+    bamm:name "BatteryCycleLifeEntity";
+    bamm:properties (:cycleLifeTestCRate :cycleLifeTestDepthOfDischarge :expectedLifetime);
+    bamm:preferredName "battery cycle life entity"@en;
+    bamm:description "Entity to bundle the characterisitics describing the cycle life of a battery"@en.
+:packagingInstructions a bamm:Property;
+    bamm:name "packagingInstructions";
+    bamm:preferredName "packaging instructions"@en;
+    bamm:description "Instructions for safely packaging\nbatteries is describing a business requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:transportationInstructions a bamm:Property;
+    bamm:name "transportationInstructions";
+    bamm:preferredName "transportation instructions"@en;
+    bamm:description "Instructions for safely transporting\nbatteries is describing a business requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:vehicleDismantlingProcedure a bamm:Property;
+    bamm:name "vehicleDismantlingProcedure";
+    bamm:preferredName "vehicle dismantling procedure"@en;
+    bamm:description "Document containing the vehicle dismantling procedure is describing a regulatory requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:batteryDismantlingProcedure a bamm:Property;
+    bamm:name "batteryDismantlingProcedure";
+    bamm:preferredName "battery dismantling procedure"@en;
+    bamm:description "Document containing the battery dismantling procedure is describing a regulatory requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:safetyMeasures a bamm:Property;
+    bamm:name "safetyMeasures";
+    bamm:preferredName "safety measures"@en;
+    bamm:description "Safety measures document(s) is describing a regulatory requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:testReportsResults a bamm:Property;
+    bamm:name "testReportsResults";
+    bamm:preferredName "test reports results"@en;
+    bamm:description "Results of test reports which prove that the battery fulfills this regulation and its delegated regulations is describing a regulatory requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:declarationOfConformity a bamm:Property;
+    bamm:name "declarationOfConformity";
+    bamm:preferredName "declaration of conformity"@en;
+    bamm:description "Declaration of conformity (CE) is describing a regulatory requirement."@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:responsibleSourcing a bamm:Property;
+    bamm:name "responsibleSourcing";
+    bamm:preferredName "responsible sourcing"@en;
+    bamm:description "Document/Certificates on organizations compliance to ethical business practices"@en;
+    bamm:characteristic :AttachmentLinkCharacteristic.
+:name a bamm:Property;
+    bamm:name "name";
+    bamm:preferredName "name"@en;
+    bamm:description "Name of the manufacturer is describing a regulatory requirement."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Samsung".
+:contact a bamm:Property;
+    bamm:name "contact";
+    bamm:preferredName "contact"@en;
+    bamm:description "Contact details of the manufacturer"@en;
+    bamm:characteristic contact-c:ContactCharacteristic.
+:address a bamm:Property;
+    bamm:name "address";
+    bamm:preferredName "address"@en;
+    bamm:description "An postal address"@en;
+    bamm:characteristic address-c:PostalAddress.
+:batteryPower a bamm:Property;
+    bamm:name "batteryPower";
+    bamm:preferredName "attachment"@en;
+    bamm:description "Characteristic to describe the power (W) properties of the batterie."@en;
+    bamm:characteristic :BatteryPowerCharacteristic.
+:batteryVoltage a bamm:Property;
+    bamm:name "batteryVoltage";
+    bamm:preferredName "battery voltage"@en;
+    bamm:description "Voltage (V) of the battery."@en;
+    bamm:characteristic :BatteryVoltageCharacteristic.
+:ratedCapacity a bamm:Property;
+    bamm:name "ratedCapacity";
+    bamm:preferredName "rated capacity"@en;
+    bamm:description "The total number of ampere-hours (Ah) that can be withdrawn from a fully charged battery under specific conditions is describing a regulatory requirement."@en;
+    bamm:characteristic :RatedCapacityCharacteristic;
+    bamm:exampleValue "210"^^xsd:decimal.
+:capacityFade a bamm:Property;
+    bamm:name "capacityFade";
+    bamm:preferredName "capacity fade"@en;
+    bamm:description "The decrease over time and upon usage in the amount of charge that a battery can deliver at the rated voltage, with respect to the original rated capacity declared by the manufacturer is describing a regulatory requirement."@en;
+    bamm:characteristic :CapacityFadeCharacteristic;
+    bamm:exampleValue "34"^^xsd:decimal.
+:internalResistance a bamm:Property;
+    bamm:name "internalResistance";
+    bamm:preferredName "internal resistance"@en;
+    bamm:description "Internal resistance in a battery cell or pack is describing a regulatory requirement."@en;
+    bamm:characteristic :InternalResistanceCharacteristic.
+:capacityThresholdExhaustion a bamm:Property;
+    bamm:name "capacityThresholdExhaustion";
+    bamm:preferredName "capacity threshold exhaustion"@en;
+    bamm:description "Capacity threshold for exhaustion as percentage value is describing a regulatory requirement."@en;
+    bamm:characteristic :CapacityThresholdExhaustionCharacterisitic;
+    bamm:exampleValue "23"^^xsd:decimal.
+:batteryEnergy a bamm:Property;
+    bamm:name "batteryEnergy";
+    bamm:preferredName "battery energy"@en;
+    bamm:description "Characteristic to describe the energy (kWh) properties of the batterie."@en;
+    bamm:characteristic :BatteryEnergyCharacterisitc.
+:ratioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergy a bamm:Property;
+    bamm:name "ratioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergy";
+    bamm:preferredName "ratio maximum allowed battery power and maximum allowed battery energy"@en;
+    bamm:description "Ratio between maximum allowed battery power (W) and battery energy (Wh) is describing a regulatory requirement."@en;
+    bamm:characteristic :RatioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergyCharacterisitic;
+    bamm:exampleValue "0.611"^^xsd:float.
+:length a bamm:Property;
+    bamm:name "length";
+    bamm:preferredName "length"@en;
+    bamm:description "Length of the item is describing a business requirement."@en;
+    bamm:characteristic :MillimetreCharacteristic;
+    bamm:exampleValue "20000"^^xsd:integer.
+:width a bamm:Property;
+    bamm:name "width";
+    bamm:preferredName "width"@en;
+    bamm:description "Width of the item is describing a business requirement."@en;
+    bamm:characteristic :MillimetreCharacteristic;
+    bamm:exampleValue "1000"^^xsd:integer.
+:height a bamm:Property;
+    bamm:name "height";
+    bamm:preferredName "height"@en;
+    bamm:description "Height of the item is describing a business requirement."@en;
+    bamm:characteristic :MillimetreCharacteristic;
+    bamm:exampleValue "1"^^xsd:integer.
+:diameter a bamm:Property;
+    bamm:name "diameter";
+    bamm:preferredName "diameter"@en;
+    bamm:description "Diameter of the item."@en;
+    bamm:characteristic :MillimetreCharacteristic;
+    bamm:exampleValue "3"^^xsd:integer.
+:weight a bamm:Property;
+    bamm:name "weight";
+    bamm:preferredName "weight"@en;
+    bamm:description "Weight of the item is describing a regulatory requirement."@en;
+    bamm:characteristic :KilogramCharacteristic;
+    bamm:exampleValue "1007"^^xsd:integer.
+:stateOfHealth a bamm:Property;
+    bamm:name "stateOfHealth";
+    bamm:preferredName "state of health"@en;
+    bamm:description "Evidence/Certificate of the health evaluation of a battery for its use following repurposing or remanufacturing operations is describing a business requirement."@en;
+    bamm:characteristic :StateOfHealthCharacteristic;
+    bamm:exampleValue "12"^^xsd:integer.
+:stateOfCharge a bamm:Property;
+    bamm:name "stateOfCharge";
+    bamm:preferredName "state of charge"@en;
+    bamm:description "The value of the state of charge of the battery at the end of life i.e. when entering recycling scheme is describing a business requirement."@en;
+    bamm:characteristic :StateOfChargeCharacteristic;
+    bamm:exampleValue "23"^^xsd:integer.
+:statusBattery a bamm:Property;
+    bamm:name "statusBattery";
+    bamm:preferredName "status battery"@en;
+    bamm:description "Status of the battery is describing a regulatory requirement. Value list provided by the regulators."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "first life/ waste/ repaired/ repurposed/ recycled".
+:batteryType a bamm:Property;
+    bamm:name "batteryType";
+    bamm:preferredName "battery type"@en;
+    bamm:description "Battery type as described by the contents of the battery e.g. cell chemistry is describing a regulatory requirement."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "LFP, Natrium, Li-Ion, NMC, NCA, Solid-State".
+:batteryModel a bamm:Property;
+    bamm:name "batteryModel";
+    bamm:preferredName "battery model"@en;
+    bamm:description "Battery type as described by the contents of the battery e.g. cell chemistry is describing a regulatory requirement."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "LFP, Natrium, Li-Ion, NMC, NCA, Solid-State".
+:batteryIDDMCCode a bamm:Property;
+    bamm:name "batteryIDDMCCode";
+    bamm:preferredName "battery ID DMC code"@en;
+    bamm:description "Digital Matrix Code (DMC) of the battery i.e. serial number allowing for unequivocal identification of a battery is describing a regulatory requirement."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "X123456789012X12345678901234567".
+:dateOfManufacturing a bamm:Property;
+    bamm:name "dateOfManufacturing";
+    bamm:preferredName "date of manufacturing"@en;
+    bamm:description "Manufacturing date of the battery is describing a regulatory requirement."@en;
+    bamm:characteristic :Datestamp;
+    bamm:exampleValue "2023-03-07"^^xsd:date.
+:cathodeActiveMaterials a bamm:Property;
+    bamm:name "cathodeActiveMaterials";
+    bamm:preferredName "cathode active materials"@en;
+    bamm:description "The total amount of valuable materials contained in CAM material: Nickel, Cobalt, Lithium."@en;
+    bamm:characteristic :CathodeActiveMaterialsCharacterisitic.
+:recyclateContentActiveMaterials a bamm:Property;
+    bamm:name "recyclateContentActiveMaterials";
+    bamm:preferredName "recyclate content active materials"@en;
+    bamm:description "List of recovered Recyclate Content in Active Material Recycled is describing a regulatory requirement. The following materials have to be reported on as a minimium: Cobalt, Lithium, Nickel, Lead"@en;
+    bamm:characteristic :RecyclateContentActiveMaterialsCharacteristic.
+:anodeActiveMaterials a bamm:Property;
+    bamm:name "anodeActiveMaterials";
+    bamm:preferredName "anode active materials"@en;
+    bamm:description "The total amount of valuable materials contained in Anode: graphite"@en;
+    bamm:characteristic :AnodeActiveMaterialsCharacteristic.
+:cathodeCompositionOther a bamm:Property;
+    bamm:name "cathodeCompositionOther";
+    bamm:preferredName "cathode composition other"@en;
+    bamm:description "The composition or materials contained in the Cathode is describing a regulatory requirement."@en;
+    bamm:characteristic :CathodeCompositionOtherCharacteristic.
+:anodeCompositionOther a bamm:Property;
+    bamm:name "anodeCompositionOther";
+    bamm:preferredName "anode composition other"@en;
+    bamm:description "The composition or materials contained in the anode is describing a regulatory requirement."@en;
+    bamm:characteristic :AnodeCompositionOtherCharacteristic.
+:electrolyteComposition a bamm:Property;
+    bamm:name "electrolyteComposition";
+    bamm:preferredName "electrolyte composition"@en;
+    bamm:description "List of materials contained in the electrolyte is describing a regulatory requirement."@en;
+    bamm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52020DC0474>;
+    bamm:characteristic :ElectrolyteCompositionCharacteristic.
+:components a bamm:Property;
+    bamm:name "components";
+    bamm:preferredName "components"@en;
+    bamm:description "Properties of the batterie's comoponents."@en;
+    bamm:characteristic :ComponentsCharacteristic.
+:compositionOfBattery a bamm:Property;
+    bamm:name "compositionOfBattery";
+    bamm:preferredName "composition of battery"@en;
+    bamm:description "Full composition of battery is describing a business requirement."@en;
+    bamm:characteristic :CompositionOfBatteryCharacteristic.
+:criticalRawMaterials a bamm:Property;
+    bamm:name "criticalRawMaterials";
+    bamm:preferredName "critical raw materials"@en;
+    bamm:description "List of critical raw materials (CRM) as specified by EU in a battery is describing a regulatory requirement."@en;
+    bamm:characteristic :CriticalRawMaterialsCharacteristic.
+:temperatureRangeIdleStateLowerLimit a bamm:Property;
+    bamm:name "temperatureRangeIdleStateLowerLimit";
+    bamm:preferredName "temperature range idle state lower limit"@en;
+    bamm:description "The lower range of temperature the battery can withstand when not in use is describing a regulatory requirement."@en;
+    bamm:characteristic :TemperatureRangeCharacterisitic;
+    bamm:exampleValue "67"^^xsd:decimal.
+:temperatureRangeIdleStateUpperLimit a bamm:Property;
+    bamm:name "temperatureRangeIdleStateUpperLimit";
+    bamm:preferredName "temperature rangeIdle state upper limit"@en;
+    bamm:description "The upper range of temperature the battery can withstand when not in use is describing a regulatory requirement."@en;
+    bamm:characteristic :TemperatureRangeCharacterisitic;
+    bamm:exampleValue "67"^^xsd:decimal.
+:cycleLifeTestCRate a bamm:Property;
+    bamm:name "cycleLifeTestCRate";
+    bamm:preferredName "cycle life test c-rate"@en;
+    bamm:description "C-rate of Relevant Cycle-life Test is describing a regulatory requirement."@en;
+    bamm:characteristic :CycleLifeTestCRateCharacterisitc;
+    bamm:exampleValue "45"^^xsd:decimal.
+:cycleLifeTestDepthOfDischarge a bamm:Property;
+    bamm:name "cycleLifeTestDepthOfDischarge";
+    bamm:preferredName "cycle-life test depth of discharge"@en;
+    bamm:description "Depth of discharge in the cycle-life test is describing a regulatory requirement."@en;
+    bamm:characteristic :CycleLifeTestDepthOfDischargeCharacteristic;
+    bamm:exampleValue "23"^^xsd:decimal.
+:expectedLifetime a bamm:Property;
+    bamm:name "expectedLifetime";
+    bamm:preferredName "expected lifetime"@en;
+    bamm:description "Expected battery lifetime expressed in cycles, and reference test used is describing a regulatory requirement."@en;
+    bamm:characteristic :ExpectedLifetime;
+    bamm:exampleValue "456"^^xsd:decimal.
+:AttachmentLinkCharacteristic a bamm-c:Set;
+    bamm:name "AttachmentLinkCharacteristic";
+    bamm:preferredName "attachment"@en;
+    bamm:description "Links the referenced attachments"@en;
+    bamm:dataType :AttachmentEntity.
+:BatteryPowerCharacteristic a bamm:Characteristic;
+    bamm:name "BatteryPowerCharacteristic";
+    bamm:preferredName "battery power characteristic"@en;
+    bamm:description "Characteristic to describe the power (W) properties of the batterie."@en;
+    bamm:dataType :BatteryPowerEntity.
+:BatteryVoltageCharacteristic a bamm:Characteristic;
+    bamm:name "BatteryVoltageCharacteristic";
+    bamm:preferredName "BatteryVoltageCharacteristic"@en;
+    bamm:description "Characteristic to describe the voltage (V) properties of the batterie."@en;
+    bamm:dataType :BatteryVoltageEntity.
+:RatedCapacityCharacteristic a bamm-c:Measurement;
+    bamm:name "RatedCapacityCharacteristic";
+    bamm:preferredName "rated capacity characteristic"@en;
+    bamm:description "The total number of ampere-hours (Ah) that can be withdrawn from a fully charged battery under specific conditions is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:ampere.
+:CapacityFadeCharacteristic a bamm-c:Measurement;
+    bamm:name "CapacityFadeCharacteristic";
+    bamm:preferredName "capacity fade characteristic"@en;
+    bamm:description "The decrease over time and upon usage in the amount of charge that a battery can deliver at the rated voltage, with respect to the original rated capacity declared by the manufacturer is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:InternalResistanceCharacteristic a bamm:Characteristic;
+    bamm:name "InternalResistanceCharacteristic";
+    bamm:preferredName "internal resistance"@en;
+    bamm:description "Internal resistance in a battery cell or pack is describing a regulatory requirement."@en;
+    bamm:dataType :InternalResistanceEntity.
+:CapacityThresholdExhaustionCharacterisitic a bamm-c:Measurement;
+    bamm:name "CapacityThresholdExhaustionCharacterisitic";
+    bamm:preferredName "capacity threshold exhaustion characterisitic"@en;
+    bamm:description "Capacity threshold for exhaustion as percentage value is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:BatteryEnergyCharacterisitc a bamm:Characteristic;
+    bamm:name "BatteryEnergyCharacterisitc";
+    bamm:preferredName "battery energy characterisitc"@en;
+    bamm:description "Characteristic to describe the energy (kWh) properties of the batterie."@en;
+    bamm:dataType :BatteryEnergyEntity.
+:RatioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergyCharacterisitic a bamm:Characteristic;
+    bamm:name "RatioMaximumAllowedBatteryPowerAndMaximumAllowedBatteryEnergyCharacterisitic";
+    bamm:preferredName "ratio maximum allowed battery power and maximum allowed battery energy characterisitic"@en;
+    bamm:description "Ratio between maximum allowed battery power (W) and battery energy (Wh) is describing a regulatory requirement."@en;
+    bamm:dataType xsd:float.
+:MillimetreCharacteristic a bamm-c:Measurement;
+    bamm:name "MillimetreCharacteristic";
+    bamm:preferredName "millimetre characteristic"@en;
+    bamm:description "A measurment for the length/width/height of an item."@en;
+    bamm:dataType xsd:integer;
+    bamm-c:unit unit:millimetre.
+:KilogramCharacteristic a bamm-c:Measurement;
+    bamm:name "KilogramCharacteristic";
+    bamm:preferredName "kilogram characteristic"@en;
+    bamm:description "A measurement for the weight of an item."@en;
+    bamm:dataType xsd:integer;
+    bamm-c:unit unit:kilogram.
+:StateOfHealthCharacteristic a bamm-c:Measurement;
+    bamm:name "StateOfHealthCharacteristic";
+    bamm:preferredName "state of health characteristic"@en;
+    bamm:description "Evidence/Certificate of the health evaluation of a battery for its use following repurposing or remanufacturing operations is describing a business requirement."@en;
+    bamm:dataType xsd:integer;
+    bamm-c:unit unit:percent.
+:StateOfChargeCharacteristic a bamm-c:Measurement;
+    bamm:name "StateOfChargeCharacteristic";
+    bamm:preferredName "state of charge characteristic"@en;
+    bamm:description "The value of the state of charge of the battery at the end of life i.e. when entering recycling scheme is describing a business requirement."@en;
+    bamm:dataType xsd:integer;
+    bamm-c:unit unit:percent.
+:CathodeActiveMaterialsCharacterisitic a bamm-c:Set;
+    bamm:name "CathodeActiveMaterialsCharacterisitic";
+    bamm:preferredName "cathode active materials"@en;
+    bamm:description "The total amount of valuable materials contained in CAM material: Nickel, Cobalt, Lithium."@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:RecyclateContentActiveMaterialsCharacteristic a bamm-c:Set;
+    bamm:name "RecyclateContentActiveMaterialsCharacteristic";
+    bamm:preferredName "recyclate content active materials"@en;
+    bamm:description "List of recovered Recyclate Content in Active Material Recycled is describing a regulatory requirement. The following materials have to be reported on as a minimium: Cobalt, Lithium, Nickel, Lead"@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:AnodeActiveMaterialsCharacteristic a bamm-c:Set;
+    bamm:name "AnodeActiveMaterialsCharacteristic";
+    bamm:preferredName "anode active materials"@en;
+    bamm:description "The total amount of valuable materials contained in Anode: graphite"@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:CathodeCompositionOtherCharacteristic a bamm-c:Set;
+    bamm:name "CathodeCompositionOtherCharacteristic";
+    bamm:preferredName "cathode composition other"@en;
+    bamm:description "The composition or materials contained in the Cathode is describing a regulatory requirement."@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:AnodeCompositionOtherCharacteristic a bamm-c:Set;
+    bamm:name "AnodeCompositionOtherCharacteristic";
+    bamm:preferredName "anode composition other"@en;
+    bamm:description "The composition or materials contained in the anode is describing a regulatory requirement."@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:ElectrolyteCompositionCharacteristic a bamm-c:Set;
+    bamm:name "ElectrolyteCompositionCharacteristic";
+    bamm:preferredName "electrolyte composition"@en;
+    bamm:description "List of materials contained in the electrolyte is describing a regulatory requirement."@en;
+    bamm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52020DC0474>;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:ComponentsCharacteristic a bamm:Characteristic;
+    bamm:name "ComponentsCharacteristic";
+    bamm:preferredName "components"@en;
+    bamm:description "Characteristics of the batterie's comoponents."@en;
+    bamm:dataType :CompomenentsEntity.
+:CompositionOfBatteryCharacteristic a bamm-c:Set;
+    bamm:name "CompositionOfBatteryCharacteristic";
+    bamm:preferredName "composition of battery"@en;
+    bamm:description "Full composition of battery is describing a business requirement."@en;
+    bamm:dataType :MaterialNameAndWeightAndPercentageMassFractionEntity.
+:CriticalRawMaterialsCharacteristic a bamm:Characteristic;
+    bamm:name "CriticalRawMaterialsCharacteristic";
+    bamm:preferredName "critical raw materials"@en;
+    bamm:description "List of critical raw materials (CRM) as specified by EU in a battery is describing a regulatory requirement."@en;
+    bamm:dataType xsd:string.
+:TemperatureRangeCharacterisitic a bamm-c:Measurement;
+    bamm:name "TemperatureRangeCharacterisitic";
+    bamm:preferredName "temperature range"@en;
+    bamm:description "The lower range of temperature the battery can withstand when not in use is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:degreeCelsius.
+:CycleLifeTestCRateCharacterisitc a bamm:Characteristic;
+    bamm:name "CycleLifeTestCRateCharacterisitc";
+    bamm:preferredName "cycle life test c-rate"@en;
+    bamm:description "C-rate of Relevant Cycle-life Test is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal.
+:CycleLifeTestDepthOfDischargeCharacteristic a bamm-c:Measurement;
+    bamm:name "CycleLifeTestDepthOfDischargeCharacteristic";
+    bamm:preferredName "cycle life test depth of discharge"@en;
+    bamm:description "Depth of discharge in the cycle-life test is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:ExpectedLifetime a bamm-c:Measurement;
+    bamm:name "ExpectedLifetime";
+    bamm:preferredName "expected lifetime"@en;
+    bamm:description "Expected battery lifetime expressed in cycles, and reference test used is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:piece.
+:AttachmentEntity a bamm:Entity;
+    bamm:name "AttachmentEntity";
+    bamm:properties (:fileLocation :title);
+    bamm:preferredName "AttachmentEntity"@en;
+    bamm:description "Entity encapsulating the details of a attachment for the battery"@en.
+:BatteryPowerEntity a bamm:Entity;
+    bamm:name "BatteryPowerEntity";
+    bamm:properties (:maximumAllowedBatteryPower :powerFade :powerCapabilityAt20Charge :powerCapabilityAt80Charge :originalPowerCapability :originalPowerCapabilityLimits);
+    bamm:preferredName "battery power entity"@en;
+    bamm:description "Entity to bundle the power properties of a battery."@en.
+:BatteryVoltageEntity a bamm:Entity;
+    bamm:name "BatteryVoltageEntity";
+    bamm:properties (:minVoltage :nominalVoltage :maxVoltage);
+    bamm:preferredName "battery voltage entity"@en;
+    bamm:description "Entity to bundle the voltage properties of a battery."@en.
+:InternalResistanceEntity a bamm:Entity;
+    bamm:name "InternalResistanceEntity";
+    bamm:properties (:cellInternalResistance :packInternalResistance :packInternalResistanceIncrease);
+    bamm:preferredName "internal resistance"@en;
+    bamm:description "Entity to bundle the internal resistance properties of a battery."@en.
+:BatteryEnergyEntity a bamm:Entity;
+    bamm:name "BatteryEnergyEntity";
+    bamm:properties (:maximumAllowedBatteryEnergy :energyRoundtripEfficiency :energyRoundtripEfficiencyChange);
+    bamm:preferredName "battery energy entity"@en;
+    bamm:description "Entity to bundle the energy properties of a battery."@en.
+:MaterialNameAndWeightAndPercentageMassFractionEntity a bamm:Entity;
+    bamm:name "MaterialNameAndWeightAndPercentageMassFractionEntity";
+    bamm:properties ([
+  bamm:property :materialPercentageMassFraction;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :materialWeight;
+  bamm:optional "true"^^xsd:boolean
+] :materialName);
+    bamm:preferredName "material name and weight and percent"@en;
+    bamm:description "Entity to bundle a material's name, weight and percentage of mass."@en.
+:CompomenentsEntity a bamm:Entity;
+    bamm:name "CompomenentsEntity";
+    bamm:properties (:componentsSupplier :componentsPartNumber);
+    bamm:preferredName "components"@en;
+    bamm:description "Entity to bundle the components properties of a battery."@en.
+:fileLocation a bamm:Property;
+    bamm:name "fileLocation";
+    bamm:preferredName "file location"@en;
+    bamm:description "Location of the file"@en;
+    bamm:characteristic :FileLocationCharacteristic.
+:title a bamm:Property;
+    bamm:name "title";
+    bamm:preferredName "title"@en;
+    bamm:description "Title of the attached file"@en;
+    bamm:characteristic bamm-c:Text.
+:maximumAllowedBatteryPower a bamm:Property;
+    bamm:name "maximumAllowedBatteryPower";
+    bamm:preferredName "maximum allowed battery power"@en;
+    bamm:description "Maximum allowed battery power (W) of the battery is describing a business requirement."@en;
+    bamm:see <https%3A%2F%2Feur-lex.europa.eu%2Flegal-content%2FEN%2FTXT%2F%3Furi%3DCELEX%3A52020PC0798>;
+    bamm:characteristic :PowerCharacteristic.
+:powerFade a bamm:Property;
+    bamm:name "powerFade";
+    bamm:preferredName "maximum allowed battery power"@en;
+    bamm:description "Maximum allowed battery power (W) of the battery is describing a business requirement."@en;
+    bamm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52020PC0798>;
+    bamm:characteristic :PowerFadeCharacteristic;
+    bamm:exampleValue "23.0"^^xsd:float.
+:powerCapabilityAt20Charge a bamm:Property;
+    bamm:name "powerCapabilityAt20Charge";
+    bamm:preferredName "power capability at 20 charge"@en;
+    bamm:description "Power (capability) at 20% state of charge. Description from the Regulation is describing a regulatory requirement."@en;
+    bamm:characteristic :PowerCharacteristic.
+:powerCapabilityAt80Charge a bamm:Property;
+    bamm:name "powerCapabilityAt80Charge";
+    bamm:preferredName "power capability at 80 charge"@en;
+    bamm:description "Power (capability) at 80% state of charge. Description from the Regulation is describing a regulatory requirement."@en;
+    bamm:characteristic :PowerCharacteristic.
+:originalPowerCapability a bamm:Property;
+    bamm:name "originalPowerCapability";
+    bamm:preferredName "original power capability"@en;
+    bamm:description "Performance ability of the high voltage battery i.e. the amount of energy that a battery is capable to provide over a given period of time is describing a regulatory requirement."@en;
+    bamm:characteristic :PowerCharacteristic.
+:originalPowerCapabilityLimits a bamm:Property;
+    bamm:name "originalPowerCapabilityLimits";
+    bamm:preferredName "original power capability limits"@en;
+    bamm:description "Performance ability of the high voltage battery according to limits i.e. how much power it can provide within given limits is describing a regulatory requirement."@en;
+    bamm:characteristic :PowerCharacteristic.
+:minVoltage a bamm:Property;
+    bamm:name "minVoltage";
+    bamm:preferredName "min voltage"@en;
+    bamm:description "Value of the minimal voltage the battery is rated for is describing a regulatory requirement."@en;
+    bamm:characteristic :VoltCharacteristic;
+    bamm:exampleValue "2"^^xsd:float.
+:nominalVoltage a bamm:Property;
+    bamm:name "nominalVoltage";
+    bamm:preferredName "nominal voltage"@en;
+    bamm:description "Value of the nominal voltage the battery is rated for is describing a regulatory requirement."@en;
+    bamm:characteristic :VoltCharacteristic;
+    bamm:exampleValue "4.3"^^xsd:float.
+:maxVoltage a bamm:Property;
+    bamm:name "maxVoltage";
+    bamm:preferredName "max voltage"@en;
+    bamm:description "Value of the maximum voltage the battery is rated for is describing a regulatory requirement."@en;
+    bamm:characteristic :VoltCharacteristic;
+    bamm:exampleValue "6"^^xsd:float.
+:cellInternalResistance a bamm:Property;
+    bamm:name "cellInternalResistance";
+    bamm:preferredName "cell internal resistance"@en;
+    bamm:description "The resistance offered by the cell in the flow of the current"@en;
+    bamm:characteristic :MilliohmCharacteristic;
+    bamm:exampleValue "45"^^xsd:decimal.
+:packInternalResistance a bamm:Property;
+    bamm:name "packInternalResistance";
+    bamm:preferredName "pack internal resistance"@en;
+    bamm:description "Total internal resistance in a battery pack is describing a regulatory requirement."@en;
+    bamm:characteristic :OhmCharacterisitic;
+    bamm:exampleValue "67"^^xsd:decimal.
+:packInternalResistanceIncrease a bamm:Property;
+    bamm:name "packInternalResistanceIncrease";
+    bamm:preferredName "pack internal resistanceIncrease"@en;
+    bamm:description "Increase in internal resistance of a battery pack over a period of time is describing a regulatory requirement."@en;
+    bamm:characteristic :PercentCharacteristic;
+    bamm:exampleValue "23"^^xsd:decimal.
+:maximumAllowedBatteryEnergy a bamm:Property;
+    bamm:name "maximumAllowedBatteryEnergy";
+    bamm:preferredName "maximum allowed battery energy"@en;
+    bamm:description "Maximum allowed battery energy (Wh) of the battery is describing a regulatory requirement."@en;
+    bamm:see <https%3A%2F%2Feur-lex.europa.eu%2Flegal-content%2FEN%2FTXT%2F%3Furi%3DCELEX%3A52020PC0798>;
+    bamm:characteristic :MaximumAllowedBatteryEnergyCharacteristic;
+    bamm:exampleValue "90000"^^xsd:float.
+:energyRoundtripEfficiency a bamm:Property;
+    bamm:name "energyRoundtripEfficiency";
+    bamm:preferredName "energy roundtrip efficiency"@en;
+    bamm:description "Round-trip efficiency is the percentage of electricity put into storage is describing a regulatory requirement."@en;
+    bamm:characteristic :EnergyRoundtripEfficiency;
+    bamm:exampleValue "56"^^xsd:decimal.
+:energyRoundtripEfficiencyChange a bamm:Property;
+    bamm:name "energyRoundtripEfficiencyChange";
+    bamm:preferredName "energy roundtrip efficiency change"@en;
+    bamm:description "Round-trip efficiency is the percentage of electricity put into storage is describing a regulatory requirement."@en;
+    bamm:characteristic :EnergyRoundtripEfficiencyChangeCharacterisitic;
+    bamm:exampleValue "67"^^xsd:decimal.
+:materialPercentageMassFraction a bamm:Property;
+    bamm:name "materialPercentageMassFraction";
+    bamm:preferredName "material percentage mass fraction"@en;
+    bamm:description "Percentage mass fraction of a material."@en;
+    bamm:characteristic :materialPercentageMassFractionCharacteristic;
+    bamm:exampleValue "19"^^xsd:decimal.
+:materialWeight a bamm:Property;
+    bamm:name "materialWeight";
+    bamm:preferredName "material weight"@en;
+    bamm:description "Weight of the material (in gram)"@en;
+    bamm:characteristic :GramCharacteristic;
+    bamm:exampleValue "2.5"^^xsd:decimal.
+:materialName a bamm:Property;
+    bamm:name "materialName";
+    bamm:preferredName "material name"@en;
+    bamm:description "Name of the material"@en;
+    bamm:characteristic :Text;
+    bamm:exampleValue "Graphite".
+:componentsSupplier a bamm:Property;
+    bamm:name "componentsSupplier";
+    bamm:preferredName "components supplier"@en;
+    bamm:description "Contact details of the suppliers of replacement parts / spare parts is describing a regulatory requirement. Available fields should be like:\nName - Street - Number - ZIP Code - City - State - Country - Phone - Fax - Email - Website"@en;
+    bamm:characteristic :ComponentsSupplierCharacteristic.
+:componentsPartNumber a bamm:Property;
+    bamm:name "componentsPartNumber";
+    bamm:preferredName "components part number"@en;
+    bamm:description "The unique serial numbers of the different parts of a battery is describing a regulatory requirement."@en;
+    bamm:characteristic :ComponentsPartNumberList;
+    bamm:exampleValue "Case xxxxxxx/xx; Controller xxxxxxx/xx".
+:FileLocationCharacteristic a bamm:Characteristic;
+    bamm:name "FileLocationCharacteristic";
+    bamm:preferredName "file location"@en;
+    bamm:description "The path to the file"@en;
+    bamm:dataType xsd:anyURI.
+:PowerCharacteristic a bamm-c:Measurement;
+    bamm:name "PowerCharacteristic";
+    bamm:preferredName "power characteristic"@en;
+    bamm:description "Power capability in kilowatts"@en;
+    bamm-c:unit unit:kilowatt.
+:PowerFadeCharacteristic a bamm-c:Measurement;
+    bamm:name "PowerFadeCharacteristic";
+    bamm:preferredName "power fade characteristic"@en;
+    bamm:description "The decrease over time and upon usage in the amount of power that a battery can deliver at the rated voltage is describing a regulatory requirement."@en;
+    bamm:dataType xsd:float;
+    bamm-c:unit unit:percent.
+:VoltCharacteristic a bamm-c:Measurement;
+    bamm:name "VoltCharacteristic";
+    bamm:preferredName "volt characteristic"@en;
+    bamm:description "Value of the voltage the battery is rated for"@en;
+    bamm:dataType xsd:float;
+    bamm-c:unit unit:volt.
+:MilliohmCharacteristic a bamm-c:Measurement;
+    bamm:name "MilliohmCharacteristic";
+    bamm:preferredName "milliohm characteristic"@en;
+    bamm:description "The resistance offered by the cell in the flow of the current"@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:milliohm.
+:OhmCharacterisitic a bamm-c:Measurement;
+    bamm:name "OhmCharacterisitic";
+    bamm:preferredName "ohm characterisitic"@en;
+    bamm:description "Total internal resistance in a battery pack"@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:ohm.
+:PercentCharacteristic a bamm-c:Measurement;
+    bamm:name "PercentCharacteristic";
+    bamm:preferredName "percent characteristic"@en;
+    bamm:description "Increase in internal resistance of a battery pack over a period of time"@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:MaximumAllowedBatteryEnergyCharacteristic a bamm-c:Measurement;
+    bamm:name "MaximumAllowedBatteryEnergyCharacteristic";
+    bamm:preferredName "maximum allowed battery energy"@en;
+    bamm:description "Characteristic to describe the energy (Wh) properties of the battery is describing a regulatory requirement."@en;
+    bamm:dataType xsd:float;
+    bamm-c:unit unit:wattHour.
+:EnergyRoundtripEfficiency a bamm-c:Measurement;
+    bamm:name "EnergyRoundtripEfficiency";
+    bamm:preferredName "energy roundtrip efficiency"@en;
+    bamm:description "Round-trip efficiency is the percentage of electricity put into storage is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:EnergyRoundtripEfficiencyChangeCharacterisitic a bamm-c:Measurement;
+    bamm:name "EnergyRoundtripEfficiencyChangeCharacterisitic";
+    bamm:preferredName "energy roundtrip efficiency change"@en;
+    bamm:description "Round-trip efficiency is the percentage of electricity put into storage after 50% of life of the battery is describing a regulatory requirement."@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:materialPercentageMassFractionCharacteristic a bamm-c:Measurement;
+    bamm:name "materialPercentageMassFractionCharacteristic";
+    bamm:preferredName "material percentage mass fraction"@en;
+    bamm:description "Percentage mass fraction of a material"@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:percent.
+:GramCharacteristic a bamm-c:Measurement;
+    bamm:name "GramCharacteristic";
+    bamm:preferredName "gram characteristic"@en;
+    bamm:description "Weight of the material (in gram)"@en;
+    bamm:dataType xsd:decimal;
+    bamm-c:unit unit:gram.
+:Text a bamm:Characteristic;
+    bamm:name "Text";
+    bamm:description "Describes a Property which contains plain text. This is intended exclusively for human readable strings, not for identifiers, measurement values, etc."@en;
+    bamm:dataType xsd:string.
+:ComponentsSupplierCharacteristic a bamm-c:Set;
+    bamm:name "ComponentsSupplierCharacteristic";
+    bamm:preferredName "components supplier"@en;
+    bamm:description "Contact details of the suppliers of replacement parts / spare parts is describing a regulatory requirement."@en;
+    bamm:dataType :ComponentsSupplierEntity.
+:ComponentsPartNumberList a bamm-c:Collection;
+    bamm:name "ComponentsPartNumberList";
+    bamm:preferredName "components part number list"@en;
+    bamm:description "A list of the unique serial numbers of the different parts of a battery is describing a regulatory requirement."@en;
+    bamm:dataType xsd:string.
+:ComponentsSupplierEntity a bamm:Entity;
+    bamm:name "ComponentsSupplierEntity";
+    bamm:properties (:address :contact :componentsSupplierName);
+    bamm:preferredName "components supplier"@en;
+    bamm:description "Entity encapsulating the details of a components supplier"@en.
+:componentsSupplierName a bamm:Property;
+    bamm:name "componentsSupplierName";
+    bamm:preferredName "components supplier name"@en;
+    bamm:description "Name of the components supplier"@en;
+    bamm:characteristic :Text;
+    bamm:exampleValue "XY Corporation".

--- a/io.catenax.certificate_of_decommissioning/1.0.0/DecommissioningCertificate1.0.0.ttl
+++ b/io.catenax.certificate_of_decommissioning/1.0.0/DecommissioningCertificate1.0.0.ttl
@@ -1,0 +1,61 @@
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:1.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:1.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:1.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:1.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.openmanufacturing.digitaltwin:1.0.0#>.
+
+:DecommissioningCertificate a bamm:Aspect;
+    bamm:name "DecommissioningCertificate";
+    bamm:properties (:catenaXId :serialNumber :issuer :issueDate [
+  bamm:property :revocationDate;
+  bamm:optional "true"^^xsd:boolean
+]);
+    bamm:operations ();
+    bamm:events ();
+    bamm:preferredName "Decommissioning Certificate"@en.
+:catenaXId a bamm:Property;
+    bamm:name "catenaXId";
+    bamm:characteristic :Text;
+    bamm:preferredName "catenaXId"@en;
+    bamm:exampleValue "13172f88-b228-4501-a2c9-f0a038eb85ca";
+    bamm:description "Twin identification"@en;
+    bamm:see <https://en.wikipedia.org/wiki/Universally_unique_identifier>.
+:serialNumber a bamm:Property;
+    bamm:name "serialNumber";
+    bamm:characteristic :Text;
+    bamm:preferredName "serial number"@en;
+    bamm:exampleValue "qwertzuiop";
+    bamm:description "This is the \"real-world\" identification of an object which is bound to be destructed. In case of a complete vehicle, which was in circulation before, it has to be the VAN. "@en;
+    bamm:see <https://en.wikipedia.org/wiki/Serial_number>.
+:Text a bamm:Characteristic;
+    bamm:name "Text";
+    bamm:dataType xsd:string;
+    bamm:description "Describes a Property which contains plain text. This is intended exclusively for human readable strings, not for identifiers, measurement values, etc."@en.
+:issuer a bamm:Property;
+    bamm:name "issuer";
+    bamm:characteristic :Text;
+    bamm:preferredName "issuer"@en;
+    bamm:exampleValue "BPNLBMW000000001";
+    bamm:description "BPMN of the business partner who creates this certificate, usually a dismantler."@en;
+    bamm:see <https://en.wikipedia.org/wiki/Issuer>.
+:issueDate a bamm:Property;
+    bamm:name "issueDate";
+    bamm:characteristic :Timestamp;
+    bamm:preferredName "issue date"@en;
+    bamm:exampleValue "01.02.2023"^^xsd:dateTime;
+    bamm:description "This is the date when the item has been decommissioned by the issuer."@en;
+    bamm:see <https://en.wikipedia.org/wiki/Effective_date>.
+:Timestamp a bamm:Characteristic;
+    bamm:name "Timestamp";
+    bamm:dataType xsd:dateTime;
+    bamm:description "Describes a Property which contains the date and time with an optional timezone."@en.
+:revocationDate a bamm:Property;
+    bamm:name "revocationDate";
+    bamm:characteristic :Timestamp;
+    bamm:preferredName "revocation date"@en;
+    bamm:exampleValue "11.11.2023"^^xsd:dateTime;
+    bamm:description "This is the date when the  decommission certificate is revoked by the issuer. This only happens in expecitional cases when a vehicle has been marked as decommissioned by error or any other error is made in the issuance of the certificate"@en;
+    bamm:see <https://en.wikipedia.org/wiki/Effective_date>.


### PR DESCRIPTION
## Description

**Introduced adjustments:**
- Change the the copyright from "Badische Anilin und Sodafabrik societates Europaea" to "BASF SE"
- :BatteryVoltageCharacteristiC - large "C" at the end
- :RatedCapacityCharacteristic - the description states "The total number of ampere-hours (Ah) ..." - the  bamm-c:unit unit:ampere. is ampere though, not ampere hours.
- :OhmCharacterisitic - Typo. Characterisitic to be changed to Characteristic. Also in the bamm:preferredName "ohm characterisitic"@en;
- Same type in :BatteryEnergyCharacterisitc, (and please again check the bamm:preferredName - same!)
- Same typo in :CycleLifeTestCRateCharacterisitc
- :capacityThresholdExhaustion - the [bamm:preferredName here](https://github.com/eclipse-tractusx/sldt-semantic-models/blob/main/io.catenax.battery.battery_pass/3.0.0/BatteryPass.ttl#L354) is wrong (looks like a copy-paste issue from the lines above). It's not "internal resistance".
- :energyRoundtripEfficiencyChange - same as above, the preferredName should be "energy roundtrip efficiency change"@en;
- :originalPower }}and {{originalPowerCapability look like they do the same job? Both have the same preferredName, too.
- The picture attached still refers to KilowattCharacteristic and WattCharacteristic - has this changed in v.3.? (TD: I cannot find it any more)
- :batteryType and :batteryModel have the same description - copy-paste issue (see [CMP-431](https://jira.catena-x.net/browse/CMP-431) for a suggestion on the description)
- Misspelled "material" in model with "matierial": :matierialPercentageMassFraction, :matierialWeight, :MatierialPercentageMassFractionCharacteristic 
- Inconsistency in using a small letter for a property and a capital letter as first letter. Any reason for this?
- EnergyRoundtripEfficiencyChangeCharacterisitic   (looks like "PascalCase") but originalPower ("camelCase")
- Add examples for Battery Identification: X123456789012X12345678901234567
- Add examples for cellChemistry: LFP, Natrium, Li-Ion, NMC, NCA

Closes #

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "name" and "description"** in English language. 
- [ ] **no duplicate names or preferredNames** within an Aspect (e.g. a Property and the referenced Characteristic should not have the same name)
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the BAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
