### PR TITLE
PartAsSpecified reopen PR due to ECA failure

### DIFF
--- a/io.catenax.part_as_specified/1.0.1/PartAsSpecified.ttl
+++ b/io.catenax.part_as_specified/1.0.1/PartAsSpecified.ttl
@@ -1,0 +1,88 @@
+#######################################################################
+# Copyright (c) 2022 T-Systems International GmbH
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022 Volkswagen AG
+# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.part_as_specified:1.0.1#>.
+
+:PartAsSpecified a bamm:Aspect;
+    bamm:preferredName "part as specified"@en;
+    bamm:description "The aspect model PartAsSpecified belongs to the Part Catalogue. A PartAsSpecified represents a certain OEM catalog part on part number level. Providing a digital representation of the part as specified by the OEM. The link to the serialized part is done via the partId, this can only be done if the respective DT was provided by the supplier within the value chain."@en;
+    bamm:properties (:partTypeInformation [
+  bamm:property :validityPeriod;
+  bamm:optional "true"^^xsd:boolean
+]);
+    bamm:operations ();
+    bamm:events ().
+:partTypeInformation a bamm:Property;
+    bamm:preferredName "part type information"@en;
+    bamm:description "Encapsulation for data related to the part type."@en;
+    bamm:characteristic :PartTypeInformationCharacteristic.
+:validityPeriod a bamm:Property;
+    bamm:preferredName "validity period"@en;
+    bamm:characteristic :ValidityPeriodCharacteristic.
+:PartTypeInformationCharacteristic a bamm:Characteristic;
+    bamm:preferredName "part type information characteristic"@en;
+    bamm:description "The characteristic of the part type."@en;
+    bamm:dataType :PartTypeInformationEntity.
+:ValidityPeriodCharacteristic a bamm:Characteristic;
+    bamm:preferredName "validity period characteristic"@en;
+    bamm:description "The characteristic of the validity period."@en;
+    bamm:dataType :ValidityPeriodEntity.
+:PartTypeInformationEntity a bamm:Entity;
+    bamm:preferredName "part type information entity"@en;
+    bamm:description "Encapsulation for data related to the part type"@en;
+    bamm:properties (:classification :nameAtOwner :ownerPartId :partVersion).
+:ValidityPeriodEntity a bamm:Entity;
+    bamm:preferredName "validity period entity"@en;
+    bamm:description "Encapsulation for data related to the validity period."@en;
+    bamm:properties (:validFrom :validTo).
+:classification a bamm:Property;
+    bamm:preferredName "classification"@en;
+    bamm:description "The classification of the part type."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "product".
+:nameAtOwner a bamm:Property;
+    bamm:preferredName "name at owner"@en;
+    bamm:description "Name of the part as assigned by the part owner."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "Mirror left".
+:ownerPartId a bamm:Property;
+    bamm:preferredName "owner part id"@en;
+    bamm:description " \tpartID as assigned by the part owner. The partID identifies the part in the part owner's data space. The partId does not reference a specific instance of a part and thus should not be confused with the serial number."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "94A2032".
+:partVersion a bamm:Property;
+    bamm:preferredName "part version"@en;
+    bamm:description "This is the version of the part. The engineering will at times supercede an older part version by a newer one, which might have different material aspects, physical dimensions etc., still maintaining compatibility."@en;
+    bamm:characteristic bamm-c:Text;
+    bamm:exampleValue "0.3".
+:validFrom a bamm:Property;
+    bamm:preferredName "valid from"@en;
+    bamm:description "Start date of the validity period."@en;
+    bamm:characteristic bamm-c:Timestamp.
+:validTo a bamm:Property;
+    bamm:preferredName "valid to"@en;
+    bamm:description "End date of the validity period."@en;
+    bamm:characteristic bamm-c:Timestamp.

--- a/io.catenax.part_as_specified/1.0.1/metadata.json
+++ b/io.catenax.part_as_specified/1.0.1/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.part_as_specified/RELEASE_NOTES.md
+++ b/io.catenax.part_as_specified/RELEASE_NOTES.md
@@ -3,6 +3,15 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.1] - 2023-01-30
+### Added
+n/a
+
+### Changed
+bugfixes due to TC feedback
+
+### Removed
+
 ## [1.0.0] - 2022-09-09
 ### Added
 - initial model


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

Closes #

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "name" and "description"** in English language. 
- [ ] **no duplicate names or preferredNames** within an Aspect (e.g. a Property and the referenced Characteristic should not have the same name)
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the BAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
