### PR TITLE
New submodel AssetTrackerLinks

### DIFF
--- a/io.catenax.asset_tracker_links/1.0.0/AssetTrackerLinks.ttl
+++ b/io.catenax.asset_tracker_links/1.0.0/AssetTrackerLinks.ttl
@@ -22,7 +22,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix : <urn:bamm:io.openmanufacturing.digitaltwin:1.0.0#>.
+@prefix : <urn:bamm:io.catenax.asset_tracker_links:1.0.0#>.
 
 :AssetTrackerLinks a bamm:Aspect;
     bamm:preferredName "Asset Tracker Links"@en;
@@ -37,7 +37,7 @@
     bamm:exampleValue "urn:uuid:ed85f17e-29dd-473c-9cb8-d7ad1dc44d2f".
 :childParts a bamm:Property;
     bamm:preferredName "Child Parts"@en;
-    bamm:description "Set of child parts, of which the given parent object is assembled by (one structural level down)."@en;
+    bamm:description "Set of child parts, of which the given parent object consist of."@en;
     bamm:characteristic :SetOfChildPartsCharacteristic.
 :CatenaXIdTraitCharacteristic a bamm-c:Trait;
     bamm:description "Trait to ensure UUID v4 data format"@en;
@@ -45,7 +45,7 @@
     bamm-c:constraint :UUIDv4RegularExpression.
 :SetOfChildPartsCharacteristic a bamm-c:Set;
     bamm:preferredName "Set of Child Parts"@en;
-    bamm:description "Set of child parts the parent object is assembled by (one structural level down)."@en;
+    bamm:description "Set of child parts the parent object consist of."@en;
     bamm:dataType :ChildData.
 :UUIDv4Characteristic a bamm:Characteristic;
     bamm:preferredName "UUID v4"@en;
@@ -59,28 +59,28 @@
     bamm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)".
 :ChildData a bamm:Entity;
     bamm:preferredName "Child Data"@en;
-    bamm:description "Catena-X ID and meta data of the assembled child part."@en;
+    bamm:description "Catena-X ID and meta data of the child part."@en;
     bamm:properties (:childCatenaXId :paired :pairedOn :unpairedOn).
 :childCatenaXId a bamm:Property;
     bamm:preferredName "Catena-X Child Identifier"@en;
-    bamm:description "The Catena-X ID of the child object which is assembled into the given parent part."@en;
+    bamm:description "The Catena-X ID of the child object which is linked to the given parent part."@en;
     bamm:characteristic :CatenaXIdTraitCharacteristic.
 :paired a bamm:Property;
     bamm:preferredName "paired"@en;
-    bamm:description "Is currently paired "@en;
+    bamm:description "Currently paired when set to true."@en;
     bamm:characteristic :PairedCharacteristic;
     bamm:exampleValue "true"^^xsd:boolean.
 :pairedOn a bamm:Property;
     bamm:preferredName "Paired On"@en;
-    bamm:description "Timestamp of pairing of IoT Device to an Asset"@en;
+    bamm:description "Timestamp of pairing of IoT Device to an Asset."@en;
     bamm:characteristic bamm-c:Timestamp;
     bamm:exampleValue "2023-02-03T14:48:54.709Z"^^xsd:dateTime.
 :unpairedOn a bamm:Property;
     bamm:preferredName "Unpaired On"@en;
-    bamm:description "Timestamp of the unpairing of IoT Device from an Asset"@en;
+    bamm:description "Timestamp of the unpairing of IoT Device from an Asset."@en;
     bamm:characteristic bamm-c:Timestamp;
     bamm:exampleValue "2023-02-04T14:48:54.709Z"^^xsd:dateTime.
 :PairedCharacteristic a bamm:Characteristic;
     bamm:preferredName "Paired Characteristic"@en;
-    bamm:description "Characteristic describing the property paired"@en;
+    bamm:description "Characteristic describing the property paired."@en;
     bamm:dataType xsd:boolean.

--- a/io.catenax.asset_tracker_links/1.0.0/AssetTrackerLinks.ttl
+++ b/io.catenax.asset_tracker_links/1.0.0/AssetTrackerLinks.ttl
@@ -72,12 +72,12 @@
     bamm:exampleValue "true"^^xsd:boolean.
 :pairedOn a bamm:Property;
     bamm:preferredName "Paired On"@en;
-    bamm:description "Timestamp of pairing of IoT Device to an Asset."@en;
+    bamm:description "Timestamp of pairing of an IoT Device to an Asset."@en;
     bamm:characteristic bamm-c:Timestamp;
     bamm:exampleValue "2023-02-03T14:48:54.709Z"^^xsd:dateTime.
 :unpairedOn a bamm:Property;
     bamm:preferredName "Unpaired On"@en;
-    bamm:description "Timestamp of the unpairing of IoT Device from an Asset."@en;
+    bamm:description "Timestamp of the unpairing of an IoT Device from an Asset."@en;
     bamm:characteristic bamm-c:Timestamp;
     bamm:exampleValue "2023-02-04T14:48:54.709Z"^^xsd:dateTime.
 :PairedCharacteristic a bamm:Characteristic;

--- a/io.catenax.asset_tracker_links/1.0.0/AssetTrackerLinks.ttl
+++ b/io.catenax.asset_tracker_links/1.0.0/AssetTrackerLinks.ttl
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 BASF SE
 # Copyright (c) 2023 Henkel AG & Co. KGaA
 # Copyright (c) 2023 ZF Friedrichshafen AG
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.asset_tracker_links/1.0.0/AssetTrackerLinks.ttl
+++ b/io.catenax.asset_tracker_links/1.0.0/AssetTrackerLinks.ttl
@@ -1,0 +1,86 @@
+#######################################################################
+# Copyright (c) 2022 BASF SE
+# Copyright (c) 2022 Henkel AG & Co. KGaA
+# Copyright (c) 2022 ZF Friedrichshafen AG
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.openmanufacturing.digitaltwin:1.0.0#>.
+
+:AssetTrackerLinks a bamm:Aspect;
+    bamm:preferredName "Asset Tracker Links"@en;
+    bamm:description "Represent the link between Asset and IoT Device (tracker) with timestamps of pairing and unpairing."@en;
+    bamm:properties (:catenaXId :childParts);
+    bamm:operations ();
+    bamm:events ().
+:catenaXId a bamm:Property;
+    bamm:preferredName "Catena-X Identifier"@en;
+    bamm:description "The Catena-X ID of the givenasset, valid for the Catena-X dataspace."@en;
+    bamm:characteristic :CatenaXIdTraitCharacteristic;
+    bamm:exampleValue "urn:uuid:ed85f17e-29dd-473c-9cb8-d7ad1dc44d2f".
+:childParts a bamm:Property;
+    bamm:preferredName "Child Parts"@en;
+    bamm:description "Set of child parts, of which the given parent object is assembled by (one structural level down)."@en;
+    bamm:characteristic :SetOfChildPartsCharacteristic.
+:CatenaXIdTraitCharacteristic a bamm-c:Trait;
+    bamm:description "Trait to ensure UUID v4 data format"@en;
+    bamm-c:baseCharacteristic :UUIDv4Characteristic;
+    bamm-c:constraint :UUIDv4RegularExpression.
+:SetOfChildPartsCharacteristic a bamm-c:Set;
+    bamm:preferredName "Set of Child Parts"@en;
+    bamm:description "Set of child parts the parent object is assembled by (one structural level down)."@en;
+    bamm:dataType :ChildData.
+:UUIDv4Characteristic a bamm:Characteristic;
+    bamm:preferredName "UUID v4"@en;
+    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    bamm:dataType xsd:string;
+    bamm:see <https://tools.ietf.org/html/rfc4122>.
+:UUIDv4RegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "Catena-X Id Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en;
+    bamm:see <https://datatracker.ietf.org/doc/html/rfc4122>;
+    bamm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)".
+:ChildData a bamm:Entity;
+    bamm:preferredName "Child Data"@en;
+    bamm:description "Catena-X ID and meta data of the assembled child part."@en;
+    bamm:properties (:childCatenaXId :paired :pairedOn :unpairedOn).
+:childCatenaXId a bamm:Property;
+    bamm:preferredName "Catena-X Child Identifier"@en;
+    bamm:description "The Catena-X ID of the child object which is assembled into the given parent part."@en;
+    bamm:characteristic :CatenaXIdTraitCharacteristic.
+:paired a bamm:Property;
+    bamm:preferredName "paired"@en;
+    bamm:description "Is currently paired "@en;
+    bamm:characteristic :PairedCharacteristic;
+    bamm:exampleValue "true"^^xsd:boolean.
+:pairedOn a bamm:Property;
+    bamm:preferredName "Paired On"@en;
+    bamm:description "Timestamp of pairing of IoT Device to an Asset"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:exampleValue "2023-02-03T14:48:54.709Z"^^xsd:dateTime.
+:unpairedOn a bamm:Property;
+    bamm:preferredName "Unpaired On"@en;
+    bamm:description "Timestamp of the unpairing of IoT Device from an Asset"@en;
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:exampleValue "2023-02-04T14:48:54.709Z"^^xsd:dateTime.
+:PairedCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Paired Characteristic"@en;
+    bamm:description "Characteristic describing the property paired"@en;
+    bamm:dataType xsd:boolean.

--- a/io.catenax.asset_tracker_links/1.0.0/AssetTrackerLinks.ttl
+++ b/io.catenax.asset_tracker_links/1.0.0/AssetTrackerLinks.ttl
@@ -1,7 +1,7 @@
 #######################################################################
-# Copyright (c) 2022 BASF SE
-# Copyright (c) 2022 Henkel AG & Co. KGaA
-# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2023 BASF SE
+# Copyright (c) 2023 Henkel AG & Co. KGaA
+# Copyright (c) 2023 ZF Friedrichshafen AG
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -60,7 +60,7 @@
 :ChildData a bamm:Entity;
     bamm:preferredName "Child Data"@en;
     bamm:description "Catena-X ID and meta data of the child part."@en;
-    bamm:properties (:childCatenaXId :paired :pairedOn :unpairedOn).
+    bamm:properties (:childCatenaXId :paired :pairedOn :unpairedOn :historicalData).
 :childCatenaXId a bamm:Property;
     bamm:preferredName "Catena-X Child Identifier"@en;
     bamm:description "The Catena-X ID of the child object which is linked to the given parent part."@en;
@@ -84,3 +84,12 @@
     bamm:preferredName "Paired Characteristic"@en;
     bamm:description "Characteristic describing the property paired."@en;
     bamm:dataType xsd:boolean.
+:historicalData a bamm:Property;
+    bamm:preferredName "Historical Data"@en;
+    bamm:description "Describes the location where the historical sensor data can be found. "@en;
+    bamm:characteristic :ResourcePath;
+    bamm:exampleValue "https://mycompany.s3.amazonaws.com/historicalsensordata"^^xsd:anyURI.
+:ResourcePath a bamm:Characteristic;
+    bamm:preferredName "Resource Path"@en;
+    bamm:description "The path of a resource."@en;
+    bamm:dataType xsd:anyURI.

--- a/io.catenax.asset_tracker_links/1.0.0/metadata.json
+++ b/io.catenax.asset_tracker_links/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.asset_tracker_links/RELEASE_NOTES.md
+++ b/io.catenax.asset_tracker_links/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [Unreleased]
+
+## [1.0.0] - 2023-02-22
+### Added
+- initial model
+
+### Changed
+n/a
+
+### Removed
+


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->
New model AssetTrackerLinks required by the product Asset Tracking (BD Sustainability)
 -->

Closes #56 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "name" and "description"** in English language. 
- [x] **no duplicate names or preferredNames** within an Aspect (e.g. a Property and the referenced Characteristic should not have the same name)
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
