### PR TITLE
Part as planned 1.0.1

### DIFF
--- a/io.catenax.part_as_planned/1.0.1/PartAsPlanned.ttl
+++ b/io.catenax.part_as_planned/1.0.1/PartAsPlanned.ttl
@@ -32,9 +32,18 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 @prefix : <urn:bamm:io.catenax.part_as_planned:1.0.1#>.
 
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.part_as_planned:1.0.1#>.
+
 :PartAsPlanned a bamm:Aspect;
-    bamm:preferredName "Part AsPlanned"@en;
-    bamm:description "A Part AsPlanned represents an item in the Catena-X Bill of Material (BOM) in As-Planned lifecycle status in a specific version. "@en;
+    bamm:preferredName "Part as Planned"@en;
+    bamm:description "A Part as Planned represents an item in the Catena-X Bill of Material (BOM) in As-Planned lifecycle status in a specific version. "@en;
     bamm:properties (:catenaXId :partTypeInformation [
   bamm:property :validityPeriod;
   bamm:optional "true"^^xsd:boolean
@@ -42,7 +51,7 @@
     bamm:operations ();
     bamm:events ().
 :catenaXId a bamm:Property;
-    bamm:preferredName "Catena-X Identifier"@en;
+    bamm:preferredName "Catena-X ID"@en;
     bamm:description "The fully anonymous Catena-X ID of the serialized part, valid for the Catena-X dataspace."@en;
     bamm:characteristic :CatenaXIdTrait;
     bamm:exampleValue "580d3adf-1981-44a0-a214-13d6ceed9379".
@@ -57,30 +66,23 @@
 :CatenaXIdTrait a bamm-c:Trait;
     bamm:preferredName "Catena-X ID Trait"@en;
     bamm:description "Trait to ensure data format for Catena-X ID"@en;
-    bamm-c:baseCharacteristic :UUIDv4;
-    bamm-c:constraint :UUIDv4RegularExpression.
+    bamm-c:baseCharacteristic :Uuidv4Characteristic;
+    bamm-c:constraint :Uuidv4RegularExpression.
 :PartTypeInformationCharacteristic a bamm:Characteristic;
     bamm:preferredName "Part Type Information Characteristic"@en;
     bamm:description "The characteristics of the part type"@en;
     bamm:dataType :PartTypeInformationEntity.
 :ValidityPeriodCharacteristic a bamm:Characteristic;
     bamm:preferredName "Validity Period Characteristic"@en;
-    bamm:description "ValidityPeriodCharacteristic"@en;
+    bamm:description "Characteristic to define a continuous validity period."@en;
     bamm:dataType :ValidityPeriodEntity.
-:UUIDv4 a bamm:Characteristic;
-    bamm:preferredName "UUIDv4"@en;
-    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
-    bamm:dataType xsd:string.
-:UUIDv4RegularExpression a bamm-c:RegularExpressionConstraint;
-    bamm:preferredName "Catena-X Id Regular Expression"@en;
-    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens)."@en;
-    bamm:value "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$".
 :PartTypeInformationEntity a bamm:Entity;
     bamm:preferredName "Part Type Information Entity"@en;
     bamm:description "Encapsulation for data related to the part type"@en;
     bamm:properties (:manufacturerPartId :nameAtManufacturer :classification).
 :ValidityPeriodEntity a bamm:Entity;
-    bamm:preferredName "ValidityPeriodEntity"@en;
+    bamm:preferredName "Validity Period Entity"@en;
+    bamm:description "Defines a continuous validity period."@en;
     bamm:properties ([
   bamm:property :validFrom;
   bamm:optional "true"^^xsd:boolean
@@ -94,23 +96,25 @@
     bamm:characteristic :PartIdCharacteristic;
     bamm:exampleValue "123-0.740-3434-A".
 :nameAtManufacturer a bamm:Property;
-    bamm:preferredName "Name at Manufacturer"@en;
+    bamm:preferredName "Name at manufacturer"@en;
     bamm:description "Name of the part as assigned by the manufacturer"@en;
     bamm:characteristic :PartNameCharacteristic;
     bamm:exampleValue "Mirror left".
 :classification a bamm:Property;
     bamm:preferredName "Classifcation"@en;
     bamm:description "The classification of the part type according to STEP standard definition"@en;
-    bamm:characteristic :ClassificationCharacteristic;
+    bamm:characteristic :ClassificationEnumerationCharacteristic;
     bamm:exampleValue "software".
 :validFrom a bamm:Property;
-    bamm:preferredName "Valid From"@en;
+    bamm:preferredName "Valid from"@en;
     bamm:description "Start date of validity period"@en;
-    bamm:characteristic :Timestamp.
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:exampleValue "2023-03-06T14:50:23.230+01:00"^^xsd:dateTime.
 :validTo a bamm:Property;
-    bamm:preferredName "Valid To"@en;
+    bamm:preferredName "Valid to"@en;
     bamm:description "End date of validity period"@en;
-    bamm:characteristic :Timestamp.
+    bamm:characteristic bamm-c:Timestamp;
+    bamm:exampleValue "2023-08-06T14:50:23.230+01:00"^^xsd:dateTime.
 :PartIdCharacteristic a bamm:Characteristic;
     bamm:preferredName "Part ID Characteristic"@en;
     bamm:description "The part ID is a multi-character string, ususally assigned by an ERP system"@en;
@@ -119,12 +123,17 @@
     bamm:preferredName "Part Name Characteristic"@en;
     bamm:description "Part Name in string format from the respective system in the value chain"@en;
     bamm:dataType xsd:string.
-:ClassificationCharacteristic a bamm-c:Enumeration;
-    bamm:preferredName "Classification Characteristic"@en;
+:Uuidv4Characteristic a bamm:Characteristic;
+    bamm:preferredName "UUIDv4"@en;
+    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    bamm:dataType xsd:string.
+:Uuidv4RegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "Catena-X ID Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens)."@en;
+    bamm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)".
+:ClassificationEnumerationCharacteristic a bamm-c:Enumeration;
+    bamm:preferredName "Classification Enumeration Characteristic"@en;
     bamm:description "A part type must be placed into one of the following classes: 'component', 'product', 'software', ‘assembly’, 'tool', or 'raw material'."@en;
     bamm:dataType xsd:string;
     bamm:see <http://private.pdm-if.org/web/pdm-if/recommended-practices1>;
     bamm-c:values ("product" "raw material" "software" "assembly" "tool" "component").
-:Timestamp a bamm:Characteristic;
-    bamm:description "Describes a Property which contains the date and time with an optional timezone."@en;
-    bamm:dataType xsd:dateTime.

--- a/io.catenax.part_as_planned/1.0.1/PartAsPlanned.ttl
+++ b/io.catenax.part_as_planned/1.0.1/PartAsPlanned.ttl
@@ -1,0 +1,130 @@
+#######################################################################
+# Copyright (c) 2022 BASF SE
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright (c) 2022 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2022 Henkel AG & Co. KGaA
+# Copyright (c) 2022 Mercedes Benz AG
+# Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022 T-Systems International GmbH
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.part_as_planned:1.0.1#>.
+
+:PartAsPlanned a bamm:Aspect;
+    bamm:preferredName "Part AsPlanned"@en;
+    bamm:description "A Part AsPlanned represents an item in the Catena-X Bill of Material (BOM) in As-Planned lifecycle status in a specific version. "@en;
+    bamm:properties (:catenaXId :partTypeInformation [
+  bamm:property :validityPeriod;
+  bamm:optional "true"^^xsd:boolean
+]);
+    bamm:operations ();
+    bamm:events ().
+:catenaXId a bamm:Property;
+    bamm:preferredName "Catena-X Identifier"@en;
+    bamm:description "The fully anonymous Catena-X ID of the serialized part, valid for the Catena-X dataspace."@en;
+    bamm:characteristic :CatenaXIdTrait;
+    bamm:exampleValue "580d3adf-1981-44a0-a214-13d6ceed9379".
+:partTypeInformation a bamm:Property;
+    bamm:preferredName "Part Type Information"@en;
+    bamm:description "The part type from which the serialized part has been instantiated"@en;
+    bamm:characteristic :PartTypeInformationCharacteristic.
+:validityPeriod a bamm:Property;
+    bamm:preferredName "Validity Period"@en;
+    bamm:description "The period of time during which the Part is offered by the manufacturer and can be purchased by customers."@en;
+    bamm:characteristic :ValidityPeriodCharacteristic.
+:CatenaXIdTrait a bamm-c:Trait;
+    bamm:preferredName "Catena-X ID Trait"@en;
+    bamm:description "Trait to ensure data format for Catena-X ID"@en;
+    bamm-c:baseCharacteristic :UUIDv4;
+    bamm-c:constraint :UUIDv4RegularExpression.
+:PartTypeInformationCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Part Type Information Characteristic"@en;
+    bamm:description "The characteristics of the part type"@en;
+    bamm:dataType :PartTypeInformationEntity.
+:ValidityPeriodCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Validity Period Characteristic"@en;
+    bamm:description "ValidityPeriodCharacteristic"@en;
+    bamm:dataType :ValidityPeriodEntity.
+:UUIDv4 a bamm:Characteristic;
+    bamm:preferredName "UUIDv4"@en;
+    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    bamm:dataType xsd:string.
+:UUIDv4RegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "Catena-X Id Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens)."@en;
+    bamm:value "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$".
+:PartTypeInformationEntity a bamm:Entity;
+    bamm:preferredName "Part Type Information Entity"@en;
+    bamm:description "Encapsulation for data related to the part type"@en;
+    bamm:properties (:manufacturerPartId :nameAtManufacturer :classification).
+:ValidityPeriodEntity a bamm:Entity;
+    bamm:preferredName "ValidityPeriodEntity"@en;
+    bamm:properties ([
+  bamm:property :validFrom;
+  bamm:optional "true"^^xsd:boolean
+] [
+  bamm:property :validTo;
+  bamm:optional "true"^^xsd:boolean
+]).
+:manufacturerPartId a bamm:Property;
+    bamm:preferredName "Manufacturer Part ID"@en;
+    bamm:description "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part in the manufacturer`s dataspace. The Part ID references a specific version of a part. The version number must be included in the Part ID if it is available.\n\nThe Part ID does not reference a specific instance of a part and must not be confused with the serial number."@en;
+    bamm:characteristic :PartIdCharacteristic;
+    bamm:exampleValue "123-0.740-3434-A".
+:nameAtManufacturer a bamm:Property;
+    bamm:preferredName "Name at Manufacturer"@en;
+    bamm:description "Name of the part as assigned by the manufacturer"@en;
+    bamm:characteristic :PartNameCharacteristic;
+    bamm:exampleValue "Mirror left".
+:classification a bamm:Property;
+    bamm:preferredName "Classifcation"@en;
+    bamm:description "The classification of the part type according to STEP standard definition"@en;
+    bamm:characteristic :ClassificationCharacteristic;
+    bamm:exampleValue "software".
+:validFrom a bamm:Property;
+    bamm:preferredName "Valid From"@en;
+    bamm:description "Start date of validity period"@en;
+    bamm:characteristic :Timestamp.
+:validTo a bamm:Property;
+    bamm:preferredName "Valid To"@en;
+    bamm:description "End date of validity period"@en;
+    bamm:characteristic :Timestamp.
+:PartIdCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Part ID Characteristic"@en;
+    bamm:description "The part ID is a multi-character string, ususally assigned by an ERP system"@en;
+    bamm:dataType xsd:string.
+:PartNameCharacteristic a bamm:Characteristic;
+    bamm:preferredName "Part Name Characteristic"@en;
+    bamm:description "Part Name in string format from the respective system in the value chain"@en;
+    bamm:dataType xsd:string.
+:ClassificationCharacteristic a bamm-c:Enumeration;
+    bamm:preferredName "Classification Characteristic"@en;
+    bamm:description "A part type must be placed into one of the following classes: 'component', 'product', 'software', ‘assembly’, 'tool', or 'raw material'."@en;
+    bamm:dataType xsd:string;
+    bamm:see <http://private.pdm-if.org/web/pdm-if/recommended-practices1>;
+    bamm-c:values ("product" "raw material" "software" "assembly" "tool" "component").
+:Timestamp a bamm:Characteristic;
+    bamm:description "Describes a Property which contains the date and time with an optional timezone."@en;
+    bamm:dataType xsd:dateTime.

--- a/io.catenax.part_as_planned/1.0.1/PartAsPlanned.ttl
+++ b/io.catenax.part_as_planned/1.0.1/PartAsPlanned.ttl
@@ -1,16 +1,16 @@
 #######################################################################
-# Copyright (c) 2022 BASF SE
-# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# Copyright (c) 2022 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
-# Copyright (c) 2022 German Edge Cloud GmbH & Co. KG
-# Copyright (c) 2022 Henkel AG & Co. KGaA
-# Copyright (c) 2022 Mercedes Benz AG
-# Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
-# Copyright (c) 2022 SAP SE
-# Copyright (c) 2022 Siemens AG
-# Copyright (c) 2022 T-Systems International GmbH
-# Copyright (c) 2022 ZF Friedrichshafen AG
-# Copyright (c) 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2023 BASF SE
+# Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright (c) 2023 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2023 Henkel AG & Co. KGaA
+# Copyright (c) 2023 Mercedes Benz AG
+# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 SAP SE
+# Copyright (c) 2023 Siemens AG
+# Copyright (c) 2023 T-Systems International GmbH
+# Copyright (c) 2023 ZF Friedrichshafen AG
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.part_as_planned/1.0.1/metadata.json
+++ b/io.catenax.part_as_planned/1.0.1/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.part_as_planned/RELEASE_NOTES.md
+++ b/io.catenax.part_as_planned/RELEASE_NOTES.md
@@ -8,7 +8,10 @@ All notable changes to this model will be documented in this file.
 n/a
 
 ### Changed
-- several element descriptions, more explicitly mentioning version information of a part as planned
+- PartAsPlanned aspect element and manufacturerPartID property elements have improved descriptions , more explicitly mentioning versioning information of a part as planned
+- all characteristics, entities, and constraints now have proper names, preferred names and descriptions
+- validFrom and validTo properties now have more meaningful example values.
+- fixed some typos in preferred names and descriptions.
 
 ### Removed
 n/a

--- a/io.catenax.part_as_planned/RELEASE_NOTES.md
+++ b/io.catenax.part_as_planned/RELEASE_NOTES.md
@@ -3,6 +3,16 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.1]
+### Added
+n/a
+
+### Changed
+- several element descriptions, more explicitly mentioning version information of a part as planned
+
+### Removed
+n/a
+
 ## [1.0.0] - 2022-08-06
 ### Added
 - initial model


### PR DESCRIPTION
## Description
Improved descriptions of some elements to make versions of part as planned more explicit

Closes #60 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "name" and "description"** in English language. 
- [x] **no duplicate names or preferredNames** within an Aspect (e.g. a Property and the referenced Characteristic should not have the same name)
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
