### PR TITLE
[New Model] Material Demand and Capacity Group (Demand and Capacity Management)

### DIFF
--- a/io.catenax.capacity_group/1.0.0/CapacityGroup.ttl
+++ b/io.catenax.capacity_group/1.0.0/CapacityGroup.ttl
@@ -1,0 +1,265 @@
+#######################################################################
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.capacity_group:1.0.0#>.
+
+:CapacityGroup a bamm:Aspect;
+    bamm:preferredName "Capacity Group"@en;
+    bamm:description "An entity made up of the weekly actual and maximum capacities for a specific customer in a given time period. A capacity group is used to compare demand and capacity data for one or several similar bundled materials in a defined unit of measure."@en;
+    bamm:properties (:capacityGroupId :name [
+  bamm:property :supplierLocations;
+  bamm:optional "true"^^xsd:boolean
+] :customer :supplier :unitOfMeasure :linkedDemandSeries :capacities :changedAt);
+    bamm:operations ();
+    bamm:events ().
+:capacityGroupId a bamm:Property;
+    bamm:preferredName "Capacity Group ID"@en;
+    bamm:description "The Capacity Group ID identifies the capacity group on a global level."@en;
+    bamm:characteristic :UUIDv4;
+    bamm:exampleValue "0157ba42-d2a8-4e28-8565-7b07830c1110".
+:name a bamm:Property;
+    bamm:preferredName "Capacity Group Name"@en;
+    bamm:description "Name of the capacity group."@en;
+    bamm:characteristic :CapacityGroupName;
+    bamm:exampleValue "Spark Plugs on drilling machine for car model XYZ".
+:supplierLocations a bamm:Property;
+    bamm:preferredName "Supplier Locations"@en;
+    bamm:description "The set of locations of the capacity group at the supplier."@en;
+    bamm:characteristic :BPNSSet;
+    bamm:exampleValue "Plant Hamburg".
+:customer a bamm:Property;
+    bamm:preferredName "Customer"@en;
+    bamm:description "A party that requests goods from a supplier."@en;
+    bamm:characteristic :BPNL;
+    bamm:exampleValue "BPNL8888888888XX".
+:supplier a bamm:Property;
+    bamm:preferredName "Supplier"@en;
+    bamm:description "A party that provides goods to a customer."@en;
+    bamm:characteristic :BPNL;
+    bamm:exampleValue "BPNL6666666666YY".
+:unitOfMeasure a bamm:Property;
+    bamm:preferredName "Unit of Measure"@en;
+    bamm:description "Unit of measurement for capacity quantities."@en;
+    bamm:characteristic :UnitOfMeasure;
+    bamm:exampleValue "KGM".
+:linkedDemandSeries a bamm:Property;
+    bamm:preferredName "Linked Demand Series"@en;
+    bamm:description "Set of demand series assigned to this capacity group."@en;
+    bamm:characteristic :LinkedDemandSeriesSet.
+:capacities a bamm:Property;
+    bamm:preferredName "Capacities"@en;
+    bamm:description "A time series with week-based granularity along a given time period containing the capacity values."@en;
+    bamm:characteristic :CapacityTimeSeries.
+:changedAt a bamm:Property;
+    bamm:preferredName "Changed At"@en;
+    bamm:description "Point in time when the capacity group was last updated at the supplier, either by a human user or an automated process."@en;
+    bamm:characteristic :Timestamp.
+:UUIDv4 a bamm:Characteristic;
+    bamm:preferredName "UUIDv4"@en;
+    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    bamm:see <http://handle.itu.int/11.1002/1000/11746>;
+    bamm:dataType xsd:string.
+:CapacityGroupName a bamm:Characteristic;
+    bamm:preferredName "Capacity Group Name"@en;
+    bamm:description "The name of a capacity group, used to distinguish it from other capacity groups."@en;
+    bamm:dataType xsd:string.
+:BPNSSet a bamm-c:Set;
+    bamm:preferredName "Business Partner Number Site Set"@en;
+    bamm:description "Contains a set of BPNS. Each BPNS represents a site which can be a production plant inside one location."@en;
+    bamm:dataType xsd:string.
+:BPNL a bamm:Characteristic;
+    bamm:preferredName "Business Partner Number Legal Entity"@en;
+    bamm:description "BPNL represents the legal entity of an organization participating in Catena-X."@en;
+    bamm:dataType xsd:string.
+:UnitOfMeasure a bamm-c:Enumeration;
+    bamm:preferredName "Unit of Measure"@en;
+    bamm:description "The Enumeration lists a selection of allowed units of measure referenced by their official code according to Codes for Units of Measure Used in International Trade"@en;
+    bamm:see <https://tfig.unece.org/contents/recommendation-20.htm>;
+    bamm:dataType xsd:string;
+    bamm-c:values ("GRM" "KGM" "TNE" "STN" "ONZ" "LBR" "CMT" "MTR" "KTM" "INH" "FOT" "YRD" "CMK" "MTK" "INK" "FTK" "YDK" "CMQ" "MTQ" "INQ" "FTQ" "YDQ" "MLT" "LTR" "HLT" "H87" "SET" "PR" "ZP" "KWH").
+:LinkedDemandSeriesSet a bamm-c:Set;
+    bamm:preferredName "Linked Demand Series Set"@en;
+    bamm:description "A set of demand series assigned to a certain capacity group."@en;
+    bamm:dataType :LinkedDemandSeries.
+:CapacityTimeSeries a bamm-c:SortedSet;
+    bamm:preferredName "Capacity Time Series"@en;
+    bamm:description "The weekly actual and maximum capacities in a given time period."@en;
+    bamm:dataType :Capacity.
+:LinkedDemandSeries a bamm:Entity;
+    bamm:preferredName "Linked Demand Series"@en;
+    bamm:description "Encapsulates information used to reference a specific demand series."@en;
+    bamm:properties (:materialNumberCustomer [
+  bamm:property :materialNumberSupplier;
+  bamm:optional "true"^^xsd:boolean
+] :customerLocation :demandCategory).
+:Capacity a bamm:Entity;
+    bamm:preferredName "Capacity"@en;
+    bamm:description "A supplier's realistically planned output per calendar week and material for a specific customer in a specific unit of measure, considering all positive or negative impacts on this capacity."@en;
+    bamm:properties (:calendarWeek :actualCapacity :maximumCapacity).
+:materialNumberCustomer a bamm:Property;
+    bamm:preferredName "Customer Material Number"@en;
+    bamm:description "Material identifier as assigned by customer. This material number identifies the material (as planned) in the customer's database."@en;
+    bamm:characteristic :MaterialNumber;
+    bamm:exampleValue "MNR-7307-AU340474.002".
+:materialNumberSupplier a bamm:Property;
+    bamm:preferredName "Supplier Material Number"@en;
+    bamm:description "Material identifier as assigned by supplier. This material number identifies the material (as planned) in the supplier's database."@en;
+    bamm:characteristic :MaterialNumber;
+    bamm:exampleValue "MNR-8101-ID146955.001".
+:customerLocation a bamm:Property;
+    bamm:preferredName "Customer Location"@en;
+    bamm:description "Location of the referenced demand series."@en;
+    bamm:characteristic :BPNS;
+    bamm:exampleValue "Plant Bremen".
+:demandCategory a bamm:Property;
+    bamm:preferredName "Demand Category"@en;
+    bamm:description "Type of demand of the referenced demand series."@en;
+    bamm:characteristic :DemandCategory.
+:calendarWeek a bamm:Property;
+    bamm:preferredName "Calendar Week"@en;
+    bamm:description "ISO Calendar Week of the given time series entry. Must be given as date of the Monday in the week."@en;
+    bamm:characteristic :CalendarWeek;
+    bamm:exampleValue "2022-08-01"^^xsd:date.
+:actualCapacity a bamm:Property;
+    bamm:preferredName "Actual Capacity"@en;
+    bamm:description "The actual capacity is the realistically planned output per calendar week and material for a specific customer in a specific unit of measure, considering all positive or negative impacts on this capacity."@en;
+    bamm:characteristic :Quantity;
+    bamm:exampleValue "1"^^xsd:decimal.
+:maximumCapacity a bamm:Property;
+    bamm:preferredName "Maximum Capacity"@en;
+    bamm:description "The supplier maximum capacity is the maximal available output per calendar week and material for a specific customer in a specific unit of measure. The maximum capacity thereby restricts the flexible capacity, as the flexible capacity is obtained from the difference of a suppliers maximum capacity minus actual capacity."@en;
+    bamm:characteristic :Quantity;
+    bamm:exampleValue "2"^^xsd:decimal.
+:MaterialNumber a bamm:Characteristic;
+    bamm:preferredName "Material Number"@en;
+    bamm:description "The material number is a multi-character string, usually assigned by an ERP system."@en;
+    bamm:dataType xsd:string.
+:BPNS a bamm:Characteristic;
+    bamm:preferredName "Business Partner Number Site"@en;
+    bamm:description "BPNS represents a site which can be a production plant inside one location."@en;
+    bamm:dataType xsd:string.
+:DemandCategory a bamm-c:Enumeration;
+    bamm:preferredName "Demand Category"@en;
+    bamm:description "The classification of demands used to prioritize or allocate capacities."@en;
+    bamm:dataType :DemandCategoryType;
+    bamm-c:values (:DemandCategoryDefault :DemandCategoryAfterSales :DemandCategorySeries :DemandCategoryPhaseInPeriod :DemandCategorySingleOrder :DemandCategorySmallSeries :DemandCategoryIncrementalDemand :DemandCategoryPhaseOutPeriod).
+:CalendarWeek a bamm:Characteristic;
+    bamm:preferredName "Calendar Week"@en;
+    bamm:description "An ISO calendar week in which a given capacity will be provided. Must be given as date of the Monday in the week."@en;
+    bamm:see <https://www.iso.org/standard/70907.html>;
+    bamm:dataType xsd:date.
+:Quantity a bamm:Characteristic;
+    bamm:preferredName "Quantity"@en;
+    bamm:description "Quantity of weekly actual or maximum capacity."@en;
+    bamm:dataType xsd:decimal.
+:DemandCategoryType a bamm:Entity;
+    bamm:preferredName "Demand Category Type"@en;
+    bamm:description "Describes the type of a demand category."@en;
+    bamm:properties (:demandCategoryCode [
+  bamm:property :demandCategoryName;
+  bamm:notInPayload "true"^^xsd:boolean
+]).
+:DemandCategoryDefault a :DemandCategoryType;
+    :demandCategoryCode "0001";
+    :demandCategoryName "Default"^^rdf:langString.
+:DemandCategoryAfterSales a :DemandCategoryType;
+    :demandCategoryCode "A1S1";
+    :demandCategoryName "After-Sales"^^rdf:langString.
+:DemandCategorySeries a :DemandCategoryType;
+    :demandCategoryCode "SR99";
+    :demandCategoryName "Series"^^rdf:langString.
+:DemandCategoryPhaseInPeriod a :DemandCategoryType;
+    :demandCategoryCode "PI01";
+    :demandCategoryName "Phase-In Period"^^rdf:langString.
+:DemandCategorySingleOrder a :DemandCategoryType;
+    :demandCategoryCode "OS01";
+    :demandCategoryName "Single-Order"^^rdf:langString.
+:DemandCategorySmallSeries a :DemandCategoryType;
+    :demandCategoryCode "OI01";
+    :demandCategoryName "Small-Series"^^rdf:langString.
+:DemandCategoryIncrementalDemand a :DemandCategoryType;
+    :demandCategoryCode "ID01";
+    :demandCategoryName "Incremental Demand"^^rdf:langString.
+:DemandCategoryPhaseOutPeriod a :DemandCategoryType;
+    :demandCategoryCode "PO01";
+    :demandCategoryName "Phase-Out Period"^^rdf:langString.
+:demandCategoryCode a bamm:Property;
+    bamm:description "The code identifiying a demand category."@en;
+    bamm:characteristic :DemandCategoryCode.
+:demandCategoryName a bamm:Property;
+    bamm:description "The name describing a demand category."@en;
+    bamm:characteristic bamm-c:MultiLanguageText.
+:DemandCategoryCode a bamm-c:Code;
+    bamm:preferredName "Demand Category Code"@en;
+    bamm:description "The code identifiying a demand category."@en;
+    bamm:dataType xsd:string.
+:QuantityRange a bamm-c:RangeConstraint;
+    bamm:preferredName "Quantity Range"@en;
+    bamm:description "Constraint to ensure a non-negative value for quantities."@en;
+    bamm-c:minValue "0"^^xsd:decimal;
+    bamm-c:maxValue "999999999999999999.999"^^xsd:decimal;
+    bamm-c:lowerBoundDefinition bamm-c:AT_LEAST;
+    bamm-c:upperBoundDefinition bamm-c:AT_MOST.
+:BPNSTrait a bamm-c:Trait;
+    bamm:preferredName "BPNS Trait"@en;
+    bamm:description "Trait to ensure data format for BPNS."@en;
+    bamm-c:baseCharacteristic :BPNS;
+    bamm-c:constraint :BPNSRegularExpression.
+:BPNSRegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "BPNS Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the BPNS is composed of prefix 'BPNS', 10 digits and two uppercase letters."@en;
+    bamm:value "^BPNS[0-9]{8}[a-zA-Z0-9]{4}$".
+:UUIDv4RegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "UUIDv4 Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens)."@en;
+    bamm:value "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$".
+:UUIDv4IdTrait a bamm-c:Trait;
+    bamm:preferredName "UUIDv4 Trait"@en;
+    bamm:description "Trait to ensure data format for UUIDv4."@en;
+    bamm-c:baseCharacteristic :UUIDv4;
+    bamm-c:constraint :UUIDv4RegularExpression.
+:BPNLTrait a bamm-c:Trait;
+    bamm:preferredName "BPNL Trait"@en;
+    bamm:description "Trait to ensure data format for BPNL."@en;
+    bamm-c:baseCharacteristic :BPNL;
+    bamm-c:constraint :BPNLRegularExpression.
+:BPNLRegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "BPNL Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the BPNL is composed of prefix 'BPNL', 10 digits and two uppercase letters."@en;
+    bamm:value "^BPNL[0-9]{8}[a-zA-Z0-9]{4}$".
+:QuantityFixedPoint a bamm-c:FixedPointConstraint;
+    bamm:preferredName "Quantity Fixed Point"@en;
+    bamm:description "Constraint to ensure size of quantities: 12 digits plus 3 decimal places."@en;
+    bamm-c:integer "15"^^xsd:positiveInteger;
+    bamm-c:scale "1000"^^xsd:positiveInteger.
+:BPNSSetTrait a bamm-c:Trait;
+    bamm:preferredName "BPNS Set Trait"@en;
+    bamm:description "Trait to ensure data format for BPNS set."@en;
+    bamm-c:baseCharacteristic :BPNSSet;
+    bamm-c:constraint :BPNSRegularExpression.
+:QuantityTrait a bamm-c:Trait;
+    bamm-c:baseCharacteristic :Quantity;
+    bamm-c:constraint :QuantityRange, :QuantityFixedPoint.
+:Timestamp a bamm:Characteristic;
+    bamm:preferredName "Timestamp"@en;
+    bamm:description "Point in time."@en;
+    bamm:dataType xsd:dateTimeStamp.

--- a/io.catenax.capacity_group/1.0.0/metadata.json
+++ b/io.catenax.capacity_group/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release" }

--- a/io.catenax.capacity_group/RELEASE_NOTES.md
+++ b/io.catenax.capacity_group/RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [1.0.0]
+- initial version of capacity group model

--- a/io.catenax.material_demand/1.0.0/MaterialDemand.ttl
+++ b/io.catenax.material_demand/1.0.0/MaterialDemand.ttl
@@ -1,0 +1,251 @@
+#######################################################################
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:bamm:io.catenax.material_demand:1.0.0#>.
+
+:MaterialDemand a bamm:Aspect;
+    bamm:preferredName "Material Demand"@en;
+    bamm:description "The requirements of a customer towards a specific supplier for a specific material. Each material demand is unique by its Customer, Supplier and Material Number."@en;
+    bamm:properties (:materialDemandId :demandSeries :customer :supplier :unitOfMeasure :materialNumberCustomer [
+  bamm:property :materialNumberSupplier;
+  bamm:optional "true"^^xsd:boolean
+] :materialDescriptionCustomer :changedAt);
+    bamm:operations ();
+    bamm:events ().
+:materialDemandId a bamm:Property;
+    bamm:preferredName "Material Demand ID"@en;
+    bamm:description "The Material Demand ID identifies the material demand on a global level."@en;
+    bamm:characteristic :UUIDv4;
+    bamm:exampleValue "0157ba42-d2a8-4e28-8565-7b07830c1110".
+:demandSeries a bamm:Property;
+    bamm:preferredName "Demand Series"@en;
+    bamm:description "The weekly demands for a dedicated material in a given time period, distinguished by their demand location and demand category."@en;
+    bamm:characteristic :DemandSeriesSet.
+:customer a bamm:Property;
+    bamm:preferredName "Customer"@en;
+    bamm:description "A party that requests goods from a supplier."@en;
+    bamm:characteristic :BPNL;
+    bamm:exampleValue "BPNL8888888888XX".
+:supplier a bamm:Property;
+    bamm:preferredName "Supplier"@en;
+    bamm:description "A party that provides goods to a customer."@en;
+    bamm:characteristic :BPNL;
+    bamm:exampleValue "BPNL6666666666YY".
+:unitOfMeasure a bamm:Property;
+    bamm:preferredName "Unit of Measure"@en;
+    bamm:description "Unit of measurement for demand quantities."@en;
+    bamm:characteristic :UnitOfMeasure;
+    bamm:exampleValue "KGM".
+:materialNumberCustomer a bamm:Property;
+    bamm:preferredName "Customer Material Number"@en;
+    bamm:description "Material identifier as assigned by customer. This material number identifies the material (as planned) in customer's database. Must be unique for each Material Demand in the customer-supplier relationship."@en;
+    bamm:characteristic :MaterialNumber;
+    bamm:exampleValue "MNR-7307-AU340474.002".
+:materialNumberSupplier a bamm:Property;
+    bamm:preferredName "Supplier Material Number"@en;
+    bamm:description "Material identifier as assigned by supplier. This material number identifies the material (as planned) in supplier's database."@en;
+    bamm:characteristic :MaterialNumber;
+    bamm:exampleValue "MNR-8101-ID146955.001".
+:materialDescriptionCustomer a bamm:Property;
+    bamm:preferredName "Customer Material Description"@en;
+    bamm:description "Description of the material."@en;
+    bamm:characteristic :MaterialDescription;
+    bamm:exampleValue "Spark Plug".
+:changedAt a bamm:Property;
+    bamm:preferredName "Changed At"@en;
+    bamm:description "Point in time when the material demand was last updated at the customer, either by a human user or an automated process."@en;
+    bamm:characteristic :Timestamp.
+:UUIDv4 a bamm:Characteristic;
+    bamm:preferredName "UUIDv4"@en;
+    bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    bamm:dataType xsd:string;
+    bamm:see <http://handle.itu.int/11.1002/1000/11746>.
+:DemandSeriesSet a bamm-c:Set;
+    bamm:preferredName "Demand Series Set"@en;
+    bamm:description "A set of demand series belonging to a certain material demand. Each demand series in the set must have a unique combination of customer location and demand category."@en;
+    bamm:dataType :DemandSeries.
+:BPNL a bamm:Characteristic;
+    bamm:preferredName "Business Partner Number Legal Entity"@en;
+    bamm:description "BPNL represents the legal entity of an organization participating in Catena-X."@en;
+    bamm:dataType xsd:string.
+:expectedSupplierLocation a bamm:Property;
+    bamm:preferredName "Expected Supplier Location"@en;
+    bamm:description "The location from where the customer expects the supplier to fulfill the demands of the demand series. Used as informational field only, not for assigning demand series to capacity groups."@en;
+    bamm:characteristic :BPNS;
+    bamm:exampleValue "Plant Hamburg".
+:BPNS a bamm:Characteristic;
+    bamm:preferredName "Business Partner Number Site"@en;
+    bamm:description "BPNS represents a site which can be a production plant inside one location."@en;
+    bamm:dataType xsd:string.
+:UnitOfMeasure a bamm-c:Enumeration;
+    bamm:preferredName "Unit of Measure"@en;
+    bamm:description "The Enumeration lists a selection of allowed units of measure referenced by their official code according to Codes for Units of Measure Used in International Trade"@en;
+    bamm:dataType xsd:string;
+    bamm:see <https://tfig.unece.org/contents/recommendation-20.htm>;
+    bamm-c:values ("GRM" "KGM" "TNE" "STN" "ONZ" "LBR" "CMT" "MTR" "KTM" "INH" "FOT" "YRD" "CMK" "MTK" "INK" "FTK" "YDK" "CMQ" "MTQ" "INQ" "FTQ" "YDQ" "MLT" "LTR" "HLT" "H87" "SET" "PR" "ZP" "KWH" "").
+:MaterialNumber a bamm:Characteristic;
+    bamm:preferredName "Material Number"@en;
+    bamm:description "The material number is a multi-character string, usually assigned by an ERP system."@en;
+    bamm:dataType xsd:string.
+:MaterialDescription a bamm:Characteristic;
+    bamm:preferredName "Material Description"@en;
+    bamm:description "Description of a material demand."@en;
+    bamm:dataType xsd:string.
+:Timestamp a bamm:Characteristic;
+    bamm:preferredName "Timestamp"@en;
+    bamm:description "Point in time."@en;
+    bamm:dataType xsd:dateTimeStamp.
+:DemandSeries a bamm:Entity;
+    bamm:preferredName "Demand Series"@en;
+    bamm:description "Encapsulates the demand series related information."@en;
+    bamm:properties (:customerLocation :demandCategory :demands [
+  bamm:property :expectedSupplierLocation;
+  bamm:optional "true"^^xsd:boolean
+]).
+:UUIDv4RegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "UUIDv4 Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens)."@en;
+    bamm:value "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$".
+:UUIDv4IdTrait a bamm-c:Trait;
+    bamm:preferredName "UUIDv4 Trait"@en;
+    bamm:description "Trait to ensure data format for UUIDv4."@en;
+    bamm-c:baseCharacteristic :UUIDv4;
+    bamm-c:constraint :UUIDv4RegularExpression.
+:customerLocation a bamm:Property;
+    bamm:preferredName "Customer Location"@en;
+    bamm:description "Location at which the customer needs the specified material for this demand series."@en;
+    bamm:characteristic :BPNS;
+    bamm:exampleValue "Plant Bremen".
+:demandCategory a bamm:Property;
+    bamm:preferredName "Demand Category"@en;
+    bamm:description "Type of demand for this demand series."@en;
+    bamm:characteristic :DemandCategory.
+:demands a bamm:Property;
+    bamm:preferredName "Demands"@en;
+    bamm:description "A time series with week-based granularity along a given time period to describe the demand values for this demand series."@en;
+    bamm:characteristic :DemandTimeSeries.
+:DemandCategory a bamm-c:Enumeration;
+    bamm:preferredName "Demand Category"@en;
+    bamm:description "The classification of demands used to prioritize or allocate capacities."@en;
+    bamm:dataType :DemandCategoryType;
+    bamm-c:values (:DemandCategoryDefault :DemandCategoryAfterSales :DemandCategorySeries :DemandCategoryPhaseInPeriod :DemandCategorySingleOrder :DemandCategorySmallSeries :DemandCategoryIncrementalDemand :DemandCategoryPhaseOutPeriod).
+:DemandTimeSeries a bamm-c:SortedSet;
+    bamm:preferredName "Demand Time Series"@en;
+    bamm:description "The weekly demands in a given time period."@en;
+    bamm:dataType :Demand.
+:DemandCategoryType a bamm:Entity;
+    bamm:preferredName "Demand Category Type"@en;
+    bamm:description "Describes the type of a demand category."@en;
+    bamm:properties (:demandCategoryCode [
+  bamm:property :demandCategoryName;
+  bamm:notInPayload "true"^^xsd:boolean
+]).
+:DemandCategoryDefault a :DemandCategoryType;
+    :demandCategoryCode "0001";
+    :demandCategoryName "Default"^^rdf:langString.
+:DemandCategoryAfterSales a :DemandCategoryType;
+    :demandCategoryCode "A1S1";
+    :demandCategoryName "After-Sales"^^rdf:langString.
+:DemandCategorySeries a :DemandCategoryType;
+    :demandCategoryCode "SR99";
+    :demandCategoryName "Series"^^rdf:langString.
+:DemandCategoryPhaseInPeriod a :DemandCategoryType;
+    :demandCategoryCode "PI01";
+    :demandCategoryName "Phase-In Period"^^rdf:langString.
+:DemandCategorySingleOrder a :DemandCategoryType;
+    :demandCategoryCode "OS01";
+    :demandCategoryName "Single-Order"^^rdf:langString.
+:DemandCategorySmallSeries a :DemandCategoryType;
+    :demandCategoryCode "OI01";
+    :demandCategoryName "Small-Series"^^rdf:langString.
+:DemandCategoryIncrementalDemand a :DemandCategoryType;
+    :demandCategoryCode "ID01";
+    :demandCategoryName "Incremental Demand"^^rdf:langString.
+:DemandCategoryPhaseOutPeriod a :DemandCategoryType;
+    :demandCategoryCode "PO01";
+    :demandCategoryName "Phase-Out Period"^^rdf:langString.
+:Demand a bamm:Entity;
+    bamm:preferredName "Demand"@en;
+    bamm:description "A single demand for a given calendar week."@en;
+    bamm:properties (:calendarWeek :demand).
+:demandCategoryCode a bamm:Property;
+    bamm:description "The code identifiying a demand category."@en;
+    bamm:characteristic :DemandCategoryCode.
+:demandCategoryName a bamm:Property;
+    bamm:description "The name describing a demand category."@en;
+    bamm:characteristic bamm-c:MultiLanguageText.
+:calendarWeek a bamm:Property;
+    bamm:preferredName "Calendar Week"@en;
+    bamm:description "ISO Calendar Week of the given time series entry. Must be given as date of the Monday in the week."@en;
+    bamm:characteristic :CalendarWeek;
+    bamm:exampleValue "2022-08-01"^^xsd:date.
+:demand a bamm:Property;
+    bamm:preferredName "Demand"@en;
+    bamm:description "Quantity of goods required in the specified calendar week."@en;
+    bamm:characteristic :Quantity;
+    bamm:exampleValue "1"^^xsd:decimal.
+:DemandCategoryCode a bamm-c:Code;
+    bamm:preferredName "Demand Category Code"@en;
+    bamm:description "The code identifiying a demand category."@en;
+    bamm:dataType xsd:string.
+:CalendarWeek a bamm:Characteristic;
+    bamm:preferredName "Calendar Week"@en;
+    bamm:description "An ISO calendar week in which a given demand is needed. Must be given as date of the Monday in the week."@en;
+    bamm:dataType xsd:date;
+    bamm:see <https://www.iso.org/standard/70907.html>.
+:Quantity a bamm:Characteristic;
+    bamm:preferredName "Quantity"@en;
+    bamm:description "Quantities of weekly demands."@en;
+    bamm:dataType xsd:decimal.
+:BPNSTrait a bamm-c:Trait;
+    bamm:preferredName "BPNS Trait"@en;
+    bamm:description "Trait to ensure data format for BPNS."@en;
+    bamm-c:baseCharacteristic :BPNS;
+    bamm-c:constraint :BPNSRegularExpression.
+:BPNSRegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "BPNS Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the BPNS is composed of prefix 'BPNS', 10 digits and two uppercase letters."@en;
+    bamm:value "^BPNS[0-9]{8}[a-zA-Z0-9]{4}$".
+:BPNLTrait a bamm-c:Trait;
+    bamm:preferredName "BPNL Trait"@en;
+    bamm:description "Trait to ensure data format for BPNL."@en;
+    bamm-c:baseCharacteristic :BPNL;
+    bamm-c:constraint :BPNLRegularExpression.
+:BPNLRegularExpression a bamm-c:RegularExpressionConstraint;
+    bamm:preferredName "BPNL Regular Expression"@en;
+    bamm:description "The provided regular expression ensures that the BPNL is composed of prefix 'BPNL', 10 digits and two uppercase letters."@en;
+    bamm:value "^BPNL[0-9]{8}[a-zA-Z0-9]{4}$".
+:QuantityRange a bamm-c:RangeConstraint;
+    bamm:preferredName "Quantity Range"@en;
+    bamm:description "Constraint to ensure a non-negative value for quantities."@en;
+    bamm-c:minValue "0"^^xsd:decimal;
+    bamm-c:maxValue "999999999999999999.999"^^xsd:decimal;
+    bamm-c:lowerBoundDefinition bamm-c:AT_LEAST;
+    bamm-c:upperBoundDefinition bamm-c:AT_MOST.
+:QuantityTrait a bamm-c:Trait;
+    bamm-c:baseCharacteristic :Quantity;
+    bamm-c:constraint :QuantityRange, :QuantityFixedPoint.
+:QuantityFixedPoint a bamm-c:FixedPointConstraint;
+    bamm:preferredName "Quantity Fixed Point"@en;
+    bamm:description "Constraint to ensure size of quantities: 12 digits plus 3 decimal places."@en;
+    bamm-c:integer "15"^^xsd:positiveInteger;
+    bamm-c:scale "1000"^^xsd:positiveInteger.

--- a/io.catenax.material_demand/1.0.0/metadata.json
+++ b/io.catenax.material_demand/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release" }

--- a/io.catenax.material_demand/RELEASE_NOTES.md
+++ b/io.catenax.material_demand/RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [1.0.0]
+- initial version of material demand model


### PR DESCRIPTION
## Description
In DCM, customers along a supply chain want to make the demands for their materials at certain locations with certain demand categories available for their suppliers. Demand data is provided on a weekly basis for the next two years. Suppliers, in return make their capacities for certain demand series (based on material, location and demand category) transparent to the respective customers.

This PR contains the two interdependent aspect models of Material Demand and Capacity Group. It is based on the previous issues and PRs in the old BAMMAspects repository.

See also:
- https://github.com/catenax/BAMMmodels/issues/182
- https://github.com/catenax/BAMMmodels/issues/183
- https://github.com/catenax/BAMMmodels/pull/207
- https://github.com/catenax/BAMMmodels/pull/208

## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "name" and "description"** in English language. 
- [ ] **no duplicate names or preferredNames** within an Aspect (e.g. a Property and the referenced Characteristic should not have the same name)
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the BAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
