### PR TITLE
Fix erroneous copyright attribution

### DIFF
--- a/io.catenax.week_based_capacity_group/1.0.0/WeekBasedCapacityGroup.ttl
+++ b/io.catenax.week_based_capacity_group/1.0.0/WeekBasedCapacityGroup.ttl
@@ -6,7 +6,6 @@
 # Copyright (c) 2023 Mercedes Benz AG
 # Copyright (c) 2023 SAP SE
 # Copyright (c) 2023 SupplyOn AG
-# Copyright (c) 2023 Volkswagen AG
 # Copyright (c) 2023 ZF Friedrichshafen AG
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 #

--- a/io.catenax.week_based_material_demand/1.0.0/WeekBasedMaterialDemand.ttl
+++ b/io.catenax.week_based_material_demand/1.0.0/WeekBasedMaterialDemand.ttl
@@ -6,7 +6,6 @@
 # Copyright (c) 2023 Mercedes Benz AG
 # Copyright (c) 2023 SAP SE
 # Copyright (c) 2023 SupplyOn AG
-# Copyright (c) 2023 Volkswagen AG
 # Copyright (c) 2023 ZF Friedrichshafen AG
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 #


### PR DESCRIPTION
## Description
Update the copyright attribution contained in the header of the `WeekBasedMaterialDemand` and `WeekBasedCapacityGroup` aspect models.