### PR TITLE
Updated data model io.catenax.vehicle.product_description to SAMM:2.0.0

### DIFF
--- a/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
+++ b/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
@@ -51,7 +51,7 @@
 :anonymizedVin a samm:Property ;
    samm:preferredName "Anonymized VIN"@en ;
    samm:description "OEM-specific hashed VIN; link to car data over pseydomized/hashed VIN or Catena-X unique digital twin identifier"@en ;
-   samm:characteristic samm-c:Text ;
+   samm:characteristic :UniqueID ;
    samm:exampleValue "3747429FGH382923974682" .
 
 :catenaXId a samm:Property ;
@@ -88,7 +88,7 @@
    samm:preferredName "Vehicle steering pos"@en ;
    samm:description "position of vehicle steering wheel, Left or right"@en ;
    samm:characteristic :VehicleSteeringPos ;
-   samm:exampleValue "Left-Hand Drive(LHD)" .
+   samm:exampleValue "Left-Hand Drive" .
 
 :emptyWeight a samm:Property ;
    samm:preferredName "vehicle empty weight"@en ;
@@ -100,7 +100,7 @@
    samm:preferredName "Drive type"@en ;
    samm:description "drive type of a vehicle according enumeration"@en ;
    samm:characteristic :DriveTypeNHTSA ;
-   samm:exampleValue "Front-Wheel Drive(FWD)" .
+   samm:exampleValue "Front-Wheel Drive" .
 
 :systemPower a samm:Property ;
    samm:preferredName "Complete system power"@en ;
@@ -161,6 +161,11 @@
    samm:description "the fuel type of the vehicle"@en ;
    samm:characteristic :FuelCharacteristic .
 
+:UniqueID a samm:Characteristic ;
+   samm:preferredName "unique ID"@en ;
+   samm:description "Characteristic for a unique id: every linked property to this characteristic is a unique ID"@en ;
+   samm:dataType xsd:string .
+
 :CatenaXIdTrait a samm-c:Trait ;
    samm:preferredName "Catena-X ID Trait"@en ;
    samm:description "Trait to ensure data format for Catena-X ID"@en ;
@@ -172,7 +177,7 @@
    samm:description "vehicle steering position enumeration from NHTSA, see table [vPICList_lite].[dbo].[Steering]"@en ;
    samm:see <https://vpic.nhtsa.dot.gov/api/> ;
    samm:dataType xsd:string ;
-   samm-c:values ( "Left-Hand Drive (LHD)" "Right-Hand Drive (RHD)" ) .
+   samm-c:values ( "Left-Hand Drive" "Right-Hand Drive" ) .
 
 :Weight a samm-c:Measurement ;
    samm:preferredName "Weight"@en ;
@@ -185,7 +190,7 @@
    samm:description "enumeration of drive type according NHTSA, table [vPICList_lite].[dbo].[DriveType]"@en ;
    samm:see <https://vpic.nhtsa.dot.gov/api/> ;
    samm:dataType xsd:string ;
-   samm-c:values ( "All-Wheel Drive(AWD)" "Front-Wheel Drive(FWD)" "Rear-Wheel Drive(RWD)" ) .
+   samm-c:values ( "All-Wheel Drive" "Front-Wheel Drive" "Rear-Wheel Drive" ) .
 
 :EnginePower a samm-c:Measurement ;
    samm:preferredName "Engine Power"@en ;

--- a/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
+++ b/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
@@ -1,27 +1,18 @@
 #######################################################################
-# Copyright (c) 2023 Robert Bosch GmbH
-# Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# Copyright (c) 2023 Volkswagen AG
-# Copyright (c) 2023 ZF Friedrichshafen AG
-# Copyright (c) 2023 SAP SE
-# Copyright (c) 2023 Siemens AG
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
-#
-# Copyrights of version 2.0.0 and 1.0.0:
 # Copyright (c) 2022 Allgemeine Deutsche Automobil-Club (ADAC) e.V
 # Copyright (c) 2022 Badische Anilin und Sodafabrik societates Europaea
-# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022, 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 # Copyright (c) 2022 Deutsches Zentrum für Luft- und Raumfahrt e. V. (DLR)
 # Copyright (c) 2022 Henkel AG & Co. KGaA
 # Copyright (c) 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. für ihre Institute IPK und IPK
 # Copyright (c) 2022 LRP Autorecycling Leipzig GmbH
 # Copyright (c) 2022 Mercedes Benz AG
-# Copyright (c) 2022 Robert Bosch GmbH
-# Copyright (c) 2022 SAP SE
-# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022, 2023 Robert Bosch GmbH
+# Copyright (c) 2022, 2023 SAP SE
+# Copyright (c) 2022, 2023 Siemens AG
 # Copyright (c) 2022 T-Systems International GmbH
-# Copyright (c) 2022 Volkswagen AG
-# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022, 2023 Volkswagen AG
+# Copyright (c) 2022, 2023 ZF Friedrichshafen AG
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
+++ b/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
@@ -1,6 +1,10 @@
 #######################################################################
 # Copyright (c) 2023 Robert Bosch GmbH
 # Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2023 Volkswagen AG
+# Copyright (c) 2023 ZF Friedrichshafen AG
+# Copyright (c) 2023 SAP SE
+# Copyright (c) 2023 Siemens AG
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional

--- a/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
+++ b/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
@@ -41,23 +41,23 @@
    samm:events ( ) .
 
 :vehicle a samm:Property ;
-   samm:preferredName "vehicle"@en ;
-   samm:description "vehicle: can be a car, bus, truck..."@en ;
+   samm:preferredName "Vehicle"@en ;
+   samm:description "A vehicle can be a car, bus, truck..."@en ;
    samm:characteristic :VehicleCharacteristic .
 
 :VehicleCharacteristic a samm:Characteristic ;
    samm:preferredName "Vehicle Characteristic"@en ;
-   samm:description "bundles all general vehicle data"@en ;
+   samm:description "This chracteristic bundles all general vehicle data."@en ;
    samm:dataType :Vehicle .
 
 :Vehicle a samm:Entity ;
    samm:preferredName "Vehicle"@en ;
-   samm:description "Vehicle data"@en ;
+   samm:description "Vehicle data that does not fit into one of the other entities."@en ;
    samm:properties ( :anonymizedVin [ samm:property :catenaXId; samm:optional true ] :vehicleSeries :modelDescription :modelIdentifier :class :steeringPos :emptyWeight :driveType :systemPower [ samm:property :hybridizationType; samm:optional true ] [ samm:property :softwareCategory; samm:optional true ] [ samm:property :softwareVersion; samm:optional true ] :oem :body :equipments :production :sale :engines :fuel ) .
 
 :anonymizedVin a samm:Property ;
    samm:preferredName "Anonymized VIN"@en ;
-   samm:description "OEM-specific hashed VIN; link to car data over pseydomized/hashed VIN or Catena-X unique digital twin identifier"@en ;
+   samm:description "OEM-specific hashed VIN; link to car data over pseydomized/hashed VIN or Catena-X unique digital twin identifier."@en ;
    samm:characteristic :UniqueID ;
    samm:exampleValue "3747429FGH382923974682" .
 
@@ -81,127 +81,127 @@
 
 :modelIdentifier a samm:Property ;
    samm:preferredName "Model identifier"@en ;
-   samm:description "OEM-specific model identifier or OEM-specific project name"@en ;
+   samm:description "OEM-specific model identifier or OEM-specific project name."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "689-G8" .
 
 :class a samm:Property ;
    samm:preferredName "Vehicle class"@en ;
-   samm:description "class of the vehicle"@en ;
+   samm:description "Class of the vehicle."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "A" .
 
 :steeringPos a samm:Property ;
    samm:preferredName "Vehicle steering pos"@en ;
-   samm:description "position of vehicle steering wheel, Left or right"@en ;
+   samm:description "Position of vehicle steering wheel, Left or right."@en ;
    samm:characteristic :VehicleSteeringPos ;
    samm:exampleValue "Left-Hand Drive" .
 
 :emptyWeight a samm:Property ;
-   samm:preferredName "vehicle empty weight"@en ;
-   samm:description "The empty weight of the vehicle in kg as specified"@en ;
+   samm:preferredName "Vehicle empty weight"@en ;
+   samm:description "The empty weight of the vehicle in kg as specified."@en ;
    samm:characteristic :Weight ;
    samm:exampleValue "2000"^^xsd:double .
 
 :driveType a samm:Property ;
    samm:preferredName "Drive type"@en ;
-   samm:description "drive type of a vehicle according enumeration"@en ;
+   samm:description "Drive type of a vehicle according enumeration."@en ;
    samm:characteristic :DriveTypeNHTSA ;
    samm:exampleValue "Front-Wheel Drive" .
 
 :systemPower a samm:Property ;
    samm:preferredName "Complete system power"@en ;
-   samm:description "Complete power of this vehicle in KW"@en ;
+   samm:description "Complete power of this vehicle in KW."@en ;
    samm:characteristic :EnginePower ;
    samm:exampleValue 110 .
 
 :hybridizationType a samm:Property ;
    samm:preferredName "Hybridization"@en ;
-   samm:description "Kind of the hybridization in this vehicle"@en ;
+   samm:description "Degree of hybridization in this vehicle."@en ;
    samm:characteristic :Hybridization ;
    samm:exampleValue "no hybrid" .
 
 :softwareCategory a samm:Property ;
    samm:preferredName "Software category"@en ;
-   samm:description "Some OEMs brings in the software as complete package for all systems:\nTo identify this software: software category and software version is needed.\nSoftware category when this car was built"@en ;
+   samm:description "Some OEMs bring in the software as complete package for all systems:\nTo identify this software: software category and software version is needed.\nSoftware category when this car was built."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "TZGH64738" .
 
 :softwareVersion a samm:Property ;
    samm:preferredName "Software version"@en ;
-   samm:description "Some OEMs brings in the software as complete package for all systems:\nTo identify this software: software category and software version is needed.\nSoftware version when this car was built\n"@en ;
+   samm:description "Some OEMs brings in the software as complete package for all systems:\nTo identify this software: software category and software version is needed.\nSoftware version when this car was built\n."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "3.4.9837.567" .
 
 :oem a samm:Property ;
    samm:preferredName "OEM"@en ;
-   samm:description "original equipment manufacturer"@en ;
+   samm:description "Original equipment manufacturer."@en ;
    samm:characteristic :OEMCharacteristic .
 
 :body a samm:Property ;
-   samm:preferredName "vehicle body"@en ;
-   samm:description "vehicle body"@en ;
+   samm:preferredName "Vehicle body"@en ;
+   samm:description "Vehicle body."@en ;
    samm:characteristic :BodyCharacteristic .
 
 :equipments a samm:Property ;
    samm:preferredName "Equipments"@en ;
-   samm:description "Equipments"@en ;
+   samm:description "Equipments."@en ;
    samm:characteristic :Equipments .
 
 :production a samm:Property ;
    samm:preferredName "Production"@en ;
-   samm:description "bundles production-related information"@en ;
+   samm:description "This property bundles production-related information."@en ;
    samm:characteristic :ProductionCharacteristic .
 
 :sale a samm:Property ;
    samm:preferredName "Sale"@en ;
-   samm:description "bundles all sales related information"@en ;
+   samm:description "This property bundles all sales related information."@en ;
    samm:characteristic :SaleCharacteristic .
 
 :engines a samm:Property ;
    samm:preferredName "Engines"@en ;
-   samm:description "List of installed engines in the vehicle"@en ;
+   samm:description "List of installed engines in the vehicle."@en ;
    samm:characteristic :Engines .
 
 :fuel a samm:Property ;
    samm:preferredName "Fuel"@en ;
-   samm:description "the fuel type of the vehicle"@en ;
+   samm:description "The fuel type of the vehicle."@en ;
    samm:characteristic :FuelCharacteristic .
 
 :UniqueID a samm:Characteristic ;
    samm:preferredName "unique ID"@en ;
-   samm:description "Characteristic for a unique id: every linked property to this characteristic is a unique ID"@en ;
+   samm:description "Characteristic for a unique id: every linked property to this characteristic is a unique ID."@en ;
    samm:dataType xsd:string .
 
 :CatenaXIdTrait a samm-c:Trait ;
    samm:preferredName "Catena-X ID Trait"@en ;
-   samm:description "Trait to ensure data format for Catena-X ID"@en ;
+   samm:description "Trait to ensure data format for Catena-X ID."@en ;
    samm-c:baseCharacteristic :UUIDv4 ;
    samm-c:constraint :UUIDv4RegularExpression .
 
 :VehicleSteeringPos a samm-c:Enumeration ;
    samm:preferredName "Vehicle steering position(NHTSA)"@en ;
-   samm:description "vehicle steering position enumeration from NHTSA, see table [vPICList_lite].[dbo].[Steering]"@en ;
+   samm:description "Vehicle steering position enumeration from NHTSA, see table [vPICList_lite].[dbo].[Steering]"@en ;
    samm:see <https://vpic.nhtsa.dot.gov/api/> ;
    samm:dataType xsd:string ;
    samm-c:values ( "Left-Hand Drive" "Right-Hand Drive" ) .
 
 :Weight a samm-c:Measurement ;
    samm:preferredName "Weight"@en ;
-   samm:description "weight of an object"@en ;
+   samm:description "Weight of an object."@en ;
    samm:dataType xsd:double ;
    samm-c:unit unit:kilogram .
 
 :DriveTypeNHTSA a samm-c:Enumeration ;
    samm:preferredName "Drive type(NHTSA)"@en ;
-   samm:description "enumeration of drive type according NHTSA, table [vPICList_lite].[dbo].[DriveType]"@en ;
+   samm:description "Enumeration of drive type according NHTSA, table [vPICList_lite].[dbo].[DriveType]"@en ;
    samm:see <https://vpic.nhtsa.dot.gov/api/> ;
    samm:dataType xsd:string ;
    samm-c:values ( "All-Wheel Drive" "Front-Wheel Drive" "Rear-Wheel Drive" ) .
 
 :EnginePower a samm-c:Measurement ;
    samm:preferredName "Engine Power"@en ;
-   samm:description "engine power expressed in kilowatt"@en ;
+   samm:description "Engine power expressed in kilowatt."@en ;
    samm:dataType xsd:integer ;
    samm-c:unit unit:kilowatt .
 
@@ -213,17 +213,17 @@
 
 :OEMCharacteristic a samm:Characteristic ;
    samm:preferredName "OEM Characteristic"@en ;
-   samm:description "OEMCharacteristic"@en ;
+   samm:description "OEM characteristic describes an original eequipment manufacturer(OEM)."@en ;
    samm:dataType :OriginalEquipmentManufacturer .
 
 :BodyCharacteristic a samm:Characteristic ;
    samm:preferredName "Body Characteristic"@en ;
-   samm:description "bundles all body-related information"@en ;
+   samm:description "Bundles all body-related information."@en ;
    samm:dataType :Body .
 
 :Equipments a samm-c:List ;
    samm:preferredName "Equipment List"@en ;
-   samm:description "list of equipments installed in the vehicle"@en ;
+   samm:description "List of equipments installed in the vehicle."@en ;
    samm:dataType :Equipment .
 
 :ProductionCharacteristic a samm:Characteristic ;
@@ -233,7 +233,7 @@
 
 :SaleCharacteristic a samm:Characteristic ;
    samm:preferredName "Sale Characteristic"@en ;
-   samm:description "Sale Characteristic"@en ;
+   samm:description "Characteristic for sale-oriented information."@en ;
    samm:dataType :Sale .
 
 :Engines a samm-c:List ;
@@ -243,7 +243,7 @@
 
 :FuelCharacteristic a samm:Characteristic ;
    samm:preferredName "Fuel Characteristic"@en ;
-   samm:description "FuelCharacteristic"@en ;
+   samm:description "Characteristic for the fuel used in the vehicle."@en ;
    samm:dataType :Fuel .
 
 :UUIDv4 a samm:Characteristic ;
@@ -259,27 +259,27 @@
 
 :OriginalEquipmentManufacturer a samm:Entity ;
    samm:preferredName "OEM"@en ;
-   samm:description "describes one OEM to which this vehicle belongs to"@en ;
+   samm:description "Describes one original eequipment manufacturer (OEM) to which this vehicle belongs to."@en ;
    samm:properties ( :wmiCode :wmiDescription :cxBPN ) .
 
 :Body a samm:Entity ;
    samm:preferredName "Body"@en ;
-   samm:description "body related data"@en ;
+   samm:description "All vhicel body-related data."@en ;
    samm:properties ( :numberOfDoors :colorId :colorDescription [ samm:property :kbaBody; samm:optional true ] [ samm:property :nhtsaBody; samm:optional true ] ) .
 
 :Equipment a samm:Entity ;
    samm:preferredName "Equipment"@en ;
-   samm:description "one optional equipment in car"@en ;
+   samm:description "One equipment of the vehicle."@en ;
    samm:properties ( :equipmentIdentifier :equipmentDescription :group ) .
 
 :Production a samm:Entity ;
    samm:preferredName "Production"@en ;
-   samm:description "production-related data"@en ;
+   samm:description "Entity to bundle all production-related data."@en ;
    samm:properties ( :productionDate :plantIdentifier :plantDescription ) .
 
 :Sale a samm:Entity ;
    samm:preferredName "Sale"@en ;
-   samm:description "all sale-related data"@en ;
+   samm:description "Bundels all sale-related data"@en ;
    samm:properties ( :soldDate :countryCode :countryGroup ) .
 
 :Engine a samm:Entity ;
@@ -289,38 +289,38 @@
 
 :Fuel a samm:Entity ;
    samm:preferredName "Fuel"@en ;
-   samm:description "fuel-related data"@en ;
+   samm:description "Bundels all fuel-related data."@en ;
    samm:properties ( [ samm:property :kbaFuelType; samm:optional true ] [ samm:property :nhtsaFuelType; samm:optional true ] ) .
 
 :wmiCode a samm:Property ;
    samm:preferredName "WMI Code"@en ;
-   samm:description "short name/code of vehicle manufacturer according  to world manufacturer information(wmi). The wmiCode are the first 3 chars of the vehicle identification number.\nA list of in NHTSA registered wmiCodes can be found in attribute Wmi in table [vPICList_lite].[dbo].[Wmi] "@en ;
+   samm:description "Short name/code of vehicle manufacturer according to world manufacturer information(wmi). The wmiCode are the first 3 chars of the vehicle identification number.\nA list of in NHTSA registered wmiCodes can be found in attribute Wmi in table [vPICList_lite].[dbo].[Wmi] "@en ;
    samm:see <https://vpic.nhtsa.dot.gov/> ;
    samm:characteristic :OemShortNameTrait ;
    samm:exampleValue "WBA" .
 
 :wmiDescription a samm:Property ;
    samm:preferredName "OEM name"@en ;
-   samm:description "name of OEM according NHTSA or other authorities. Has to be compliant with/linked wmiCode attribute.\nFor NHTSA: name of table [vPICList_lite].[dbo].[Manufacturer]"@en ;
+   samm:description "Name of OEM according NHTSA or other authorities. Has to be compliant with/linked wmiCode attribute.\nFor NHTSA: name of table [vPICList_lite].[dbo].[Manufacturer]"@en ;
    samm:see <https://vpic.nhtsa.dot.gov/> ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "BMW AG" .
 
 :cxBPN a samm:Property ;
    samm:preferredName "CX Business partner number"@en ;
-   samm:description "Catena-X business partner number of this company"@en ;
+   samm:description "Catena-X business partner number of this company."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "BPN-811" .
 
 :numberOfDoors a samm:Property ;
    samm:preferredName "Number of doors"@en ;
-   samm:description "describes the number of doors of a vehicle"@en ;
+   samm:description "Describes the number of doors of a vehicle."@en ;
    samm:characteristic :PositiveNumber ;
    samm:exampleValue "5"^^xsd:positiveInteger .
 
 :colorId a samm:Property ;
    samm:preferredName "Color identifier"@en ;
-   samm:description "Colour code describes the code of a specific colour of one vehicle."@en ;
+   samm:description "Colour code describes the code of a specific colour of a vehicle."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "LY7W " .
 
@@ -332,49 +332,49 @@
 
 :kbaBody a samm:Property ;
    samm:preferredName "Body variant(KBA)"@en ;
-   samm:description "vehicle variant - Body shapes according German KBA"@en ;
+   samm:description "Vehicle variant - Body shapes according German KBA"@en ;
    samm:characteristic :KbaVariant ;
    samm:exampleValue "SUV" .
 
 :nhtsaBody a samm:Property ;
    samm:preferredName "Body variant(NHTSA)"@en ;
-   samm:description "vehicle variant - Body shapes according US NHTSA"@en ;
+   samm:description "Vehicle variant - Body shapes according US NHTSA"@en ;
    samm:characteristic :NhtsaVariant ;
    samm:exampleValue "Sedan" .
 
 :equipmentIdentifier a samm:Property ;
    samm:preferredName "Equipment Id"@en ;
-   samm:description "The identifier of a specific equipment"@en ;
+   samm:description "The identifier of a specific equipment."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "S248A" .
 
 :equipmentDescription a samm:Property ;
    samm:preferredName "Equipment description"@en ;
-   samm:description "The equipment variants description"@en ;
+   samm:description "The equipment variants description."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Seat heating front" .
 
 :group a samm:Property ;
    samm:preferredName "Equipment group"@en ;
-   samm:description "grouping the special equipments into categories like Interior"@en ;
+   samm:description "Bundels all equipment-oriented information into categories like Interior"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Interior" .
 
 :productionDate a samm:Property ;
    samm:preferredName "Vehicle production Date"@en ;
-   samm:description "production date of the vehicle"@en ;
+   samm:description "Production date of the vehicle"@en ;
    samm:characteristic samm-c:Timestamp ;
    samm:exampleValue "2018-01-15T00:00:00"^^xsd:dateTime .
 
 :plantIdentifier a samm:Property ;
    samm:preferredName "Production plant id"@en ;
-   samm:description "plant id of the final assembly of the vehicle"@en ;
+   samm:description "Plant id of the final assembly of the vehicle"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "4711" .
 
 :plantDescription a samm:Property ;
    samm:preferredName "Vehicle production plant name"@en ;
-   samm:description "long name of the production plant of the vehicle"@en ;
+   samm:description "Long name of the production plant of the vehicle"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Wolfsburg" .
 
@@ -386,13 +386,13 @@
 
 :countryCode a samm:Property ;
    samm:preferredName "Vehicle sold country"@en ;
-   samm:description "vehicle sold country in ISO 8601 alpha 3"@en ;
+   samm:description "Vehicle sold country in ISO 8601 alpha 3"@en ;
    samm:characteristic :CountryCodeTrait ;
    samm:exampleValue "DEU" .
 
 :countryGroup a samm:Property ;
    samm:preferredName "Vehicle sold region"@en ;
-   samm:description "region where this car was sold"@en ;
+   samm:description "Region where this car was sold"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Europe" .
 
@@ -404,19 +404,19 @@
 
 :engineDescription a samm:Property ;
    samm:preferredName "Engine Description"@en ;
-   samm:description "description of the engine"@en ;
+   samm:description "Description of the engine"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "2.0 TDI" .
 
 :engineSeries a samm:Property ;
    samm:preferredName "Vehicle engine series"@en ;
-   samm:description "engine series"@en ;
+   samm:description "Engine series as defined by OEM"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "EA189" .
 
 :serialNumber a samm:Property ;
    samm:preferredName "Engine serial number"@en ;
-   samm:description "serial number of the installed engine"@en ;
+   samm:description "Serial number of the installed engine"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "3434937GJJG3738" .
 
@@ -428,31 +428,31 @@
 
 :power a samm:Property ;
    samm:preferredName "Engine power"@en ;
-   samm:description "engine power is the power that an engine can put out"@en ;
+   samm:description "Engine power is the power that an engine can put out"@en ;
    samm:characteristic :EnginePower ;
    samm:exampleValue 110 .
 
 :engineProductionDate a samm:Property ;
    samm:preferredName "Engine production date"@en ;
-   samm:description "date when the engine was produced"@en ;
+   samm:description "Date when the engine was produced"@en ;
    samm:characteristic samm-c:Timestamp ;
    samm:exampleValue "2017-10-20T00:00:00"^^xsd:dateTime .
 
 :installDate a samm:Property ;
    samm:preferredName "Engine install date"@en ;
-   samm:description "date when the engine was installed"@en ;
+   samm:description "Date when the engine was installed"@en ;
    samm:characteristic samm-c:Timestamp ;
    samm:exampleValue "2018-01-10T00:00:00"^^xsd:dateTime .
 
 :kbaFuelType a samm:Property ;
    samm:preferredName "Fuel type(KBA)"@en ;
-   samm:description "description of the fuel according german KBA"@en ;
+   samm:description "Description of the fuel according german KBA"@en ;
    samm:characteristic :FuelKBA ;
    samm:exampleValue "Diesel" .
 
 :nhtsaFuelType a samm:Property ;
    samm:preferredName "Fuel type(NHTSA)"@en ;
-   samm:description "description of the fuel according US NHTSA"@en ;
+   samm:description "Description of the fuel according US NHTSA"@en ;
    samm:characteristic :FuelNHTSA ;
    samm:exampleValue "Diesel" .
 
@@ -482,20 +482,20 @@
 
 :CubicCapacity a samm-c:Measurement ;
    samm:preferredName "Cubic Capacity"@en ;
-   samm:description "cubic capacity of the engine"@en ;
+   samm:description "Cubic capacity of the engine"@en ;
    samm:dataType xsd:integer ;
    samm-c:unit unit:cubicCentimetre .
 
 :FuelKBA a samm-c:Enumeration ;
    samm:preferredName "Fuel type (KBA)"@en ;
-   samm:description "enumeration of possible fuel types of a vehicle according german KBA"@en ;
+   samm:description "Enumeration of possible fuel types of a vehicle according german KBA"@en ;
    samm:see <https://www.kba.de/SharedDocs/Downloads/DE/SV/sv221_m1_schad_pdf.pdf> ;
    samm:dataType xsd:string ;
    samm-c:values ( "Unbekannt" "Diesel" "Benzin" "Vielstoff" "Elektro" "Benzin/Fl?ssiggas" "Benzin/komp.Erdgas" "Hybr.Benzin/E" "Erdgas NG" "Hybr.Diesel/E" "Wasserstoff" "Hybr.Wasserst./E" "Wasserstoff/Benzin" "Wasserst./Benzin/E" "BZ/Wasserstoff" "BZ/Benzin" "BZ/Methanol" "BZ/Ethanol" "Hybr.Vielstoff/E" "Methan" "Benzin/Methan" "Hybr.Erdgas/E" "Benzin/Ethanol" "Hybr.B/E ext.aufl." "Hybr.D/E ext.aufl." "Hybr.LPG/E ext.aufl." "Hybr.W/E ext.aufl." "Hybr.V/E ext.aufl." "Hybr.NG/E ext.aufl." "Hybr.Wod.B/Eext.aufl" "Wasserstoff/NG" "Hybr.W/NG/E ext.aufl" "Ethanol" "Hybr.BZ/W/E" "Hybr.BZ/W/E ext. aufl." "Zweistoff LNG/Diesel" "Andere" "Fluessiggas" "Hybr.Fluessiggas/E" "Verfluessigtes Erdgas(LNG)" ) .
 
 :FuelNHTSA a samm-c:Enumeration ;
    samm:preferredName "Fuel type (NHTSA)"@en ;
-   samm:description "enumeration from NHTSA vpic database, table [vPICList_lite].[dbo].[FuelType]"@en ;
+   samm:description "Enumeration from NHTSA vpic database, table [vPICList_lite].[dbo].[FuelType]"@en ;
    samm:see <https://vpic.nhtsa.dot.gov/api/> ;
    samm:dataType xsd:string ;
    samm-c:values ( "Compressed Hydrogen/Hydrogen" "Compressed Natural Gas(CNG)" "Diesel" "Electric" "Ethanol(E85)" "Flexible Fuel Vehicle(FFV)" "Fuel Cell" "Gasoline" "Liquefied Natural Gas(LNG)" "Liquefied Petroleum Gas(propane or LPG)" "Methanol(M85)" "Natural Gas" "Neat Ethanol(E100)" "Neat Methanol(M100)" "Unknown" ) .

--- a/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
+++ b/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
@@ -65,7 +65,7 @@
    samm:preferredName "Vehicle Catena-X Identifier"@en ;
    samm:description "A fully anonymous Catena-X identifier that is registered in C-X Digital twin registry. Can be used for vehicles, parts, workshops, ....."@en ;
    samm:characteristic :CatenaXIdTrait ;
-   samm:exampleValue "urn:uuid:580d3adf-1981-44a0-a214-13d6ceed9379" .
+   samm:exampleValue "580d3adf-1981-44a0-a214-13d6ceed9379" .
 
 :vehicleSeries a samm:Property ;
    samm:preferredName "Vehicle series"@en ;
@@ -255,7 +255,7 @@
    samm:preferredName "Catena-X Id Regular Expression"@en ;
    samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), prefixed by \"urn:uuid:\" to make it an IRI."@en ;
    samm:see <https://datatracker.ietf.org/doc/html/rfc4122> ;
-   samm:value "^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" .
+   samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)" .
 
 :OriginalEquipmentManufacturer a samm:Entity ;
    samm:preferredName "OEM"@en ;
@@ -285,7 +285,7 @@
 :Engine a samm:Entity ;
    samm:preferredName "Engine Entity"@en ;
    samm:description "Describing one installed engine"@en ;
-   samm:properties ( :engineId :engineDescription :engineSeries :serialNumber [ samm:property :size; samm:optional true ] :power :engineProductionDate :installDate ) .
+   samm:properties ( :engineId :engineDescription :engineSeries :serialNumber [ samm:property :size; samm:optional true ] :power [ samm:property :engineProductionDate; samm:optional true ] [ samm:property :installDate; samm:optional true ] ) .
 
 :Fuel a samm:Entity ;
    samm:preferredName "Fuel"@en ;

--- a/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
+++ b/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
@@ -1,0 +1,507 @@
+#######################################################################
+# Copyright (c) 2023 Robert Bosch GmbH
+# Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.vehicle.product_description:3.0.0#> .
+
+:ProductDescription a samm:Aspect ;
+   samm:preferredName "Vehicle master data"@en ;
+   samm:description "Master data of one vehicle - from an end customer view. So this model represents the vehicle as it was sold to the customer. All entities and properties are immutable over the lifetime of the vehicle."@en ;
+   samm:properties ( :vehicle ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:vehicle a samm:Property ;
+   samm:preferredName "vehicle"@en ;
+   samm:description "vehicle: can be a car, bus, truck..."@en ;
+   samm:characteristic :VehicleCharacteristic .
+
+:VehicleCharacteristic a samm:Characteristic ;
+   samm:preferredName "Vehicle Characteristic"@en ;
+   samm:description "bundles all general vehicle data"@en ;
+   samm:dataType :Vehicle .
+
+:Vehicle a samm:Entity ;
+   samm:preferredName "Vehicle"@en ;
+   samm:description "Vehicle data"@en ;
+   samm:properties ( :anonymizedVin [ samm:property :catenaXId; samm:optional true ] :vehicleSeries :modelDescription :modelIdentifier :class :steeringPos :emptyWeight :driveType :systemPower [ samm:property :hybridizationType; samm:optional true ] [ samm:property :softwareCategory; samm:optional true ] [ samm:property :softwareVersion; samm:optional true ] :oem :body :equipments :production :sale :engines :fuel ) .
+
+:anonymizedVin a samm:Property ;
+   samm:preferredName "Anonymized VIN"@en ;
+   samm:description "OEM-specific hashed VIN; link to car data over pseydomized/hashed VIN or Catena-X unique digital twin identifier"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "3747429FGH382923974682" .
+
+:catenaXId a samm:Property ;
+   samm:preferredName "Vehicle Catena-X Identifier"@en ;
+   samm:description "A fully anonymous Catena-X identifier that is registered in C-X Digital twin registry. Can be used for vehicles, parts, workshops, ....."@en ;
+   samm:characteristic :CatenaXIdTrait ;
+   samm:exampleValue "urn:uuid:580d3adf-1981-44a0-a214-13d6ceed9379" .
+
+:vehicleSeries a samm:Property ;
+   samm:preferredName "Vehicle series"@en ;
+   samm:description "vehicle series, normally one level above model. E.g. vehicle series =\"Golf\", vehicle model=\"Golf VIII\""@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Golf" .
+
+:modelDescription a samm:Property ;
+   samm:preferredName "Vehicle model"@en ;
+   samm:description "Detail vehicle model like \"Golf VIII\""@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Golf VIII" .
+
+:modelIdentifier a samm:Property ;
+   samm:preferredName "Model identifier"@en ;
+   samm:description "OEM-specific model identifier or OEM-specific project name"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "689-G8" .
+
+:class a samm:Property ;
+   samm:preferredName "Vehicle class"@en ;
+   samm:description "class of the vehicle"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A" .
+
+:steeringPos a samm:Property ;
+   samm:preferredName "Vehicle steering pos"@en ;
+   samm:description "position of vehicle steering wheel, Left or right"@en ;
+   samm:characteristic :VehicleSteeringPos ;
+   samm:exampleValue "Left-Hand Drive(LHD)" .
+
+:emptyWeight a samm:Property ;
+   samm:preferredName "vehicle empty weight"@en ;
+   samm:description "The empty weight of the vehicle in kg as specified"@en ;
+   samm:characteristic :Weight ;
+   samm:exampleValue "2000"^^xsd:double .
+
+:driveType a samm:Property ;
+   samm:preferredName "Drive type"@en ;
+   samm:description "drive type of a vehicle according enumeration"@en ;
+   samm:characteristic :DriveTypeNHTSA ;
+   samm:exampleValue "Front-Wheel Drive(FWD)" .
+
+:systemPower a samm:Property ;
+   samm:preferredName "Complete system power"@en ;
+   samm:description "Complete power of this vehicle in KW"@en ;
+   samm:characteristic :EnginePower ;
+   samm:exampleValue 110 .
+
+:hybridizationType a samm:Property ;
+   samm:preferredName "Hybridization"@en ;
+   samm:description "Kind of the hybridization in this vehicle"@en ;
+   samm:characteristic :Hybridization ;
+   samm:exampleValue "no hybrid" .
+
+:softwareCategory a samm:Property ;
+   samm:preferredName "Software category"@en ;
+   samm:description "Some OEMs brings in the software as complete package for all systems:\nTo identify this software: software category and software version is needed.\nSoftware category when this car was built"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "TZGH64738" .
+
+:softwareVersion a samm:Property ;
+   samm:preferredName "Software version"@en ;
+   samm:description "Some OEMs brings in the software as complete package for all systems:\nTo identify this software: software category and software version is needed.\nSoftware version when this car was built\n"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "3.4.9837.567" .
+
+:oem a samm:Property ;
+   samm:preferredName "OEM"@en ;
+   samm:description "original equipment manufacturer"@en ;
+   samm:characteristic :OEMCharacteristic .
+
+:body a samm:Property ;
+   samm:preferredName "vehicle body"@en ;
+   samm:description "vehicle body"@en ;
+   samm:characteristic :BodyCharacteristic .
+
+:equipments a samm:Property ;
+   samm:preferredName "Equipments"@en ;
+   samm:description "Equipments"@en ;
+   samm:characteristic :Equipments .
+
+:production a samm:Property ;
+   samm:preferredName "Production"@en ;
+   samm:description "bundles production-related information"@en ;
+   samm:characteristic :ProductionCharacteristic .
+
+:sale a samm:Property ;
+   samm:preferredName "Sale"@en ;
+   samm:description "bundles all sales related information"@en ;
+   samm:characteristic :SaleCharacteristic .
+
+:engines a samm:Property ;
+   samm:preferredName "Engines"@en ;
+   samm:description "List of installed engines in the vehicle"@en ;
+   samm:characteristic :Engines .
+
+:fuel a samm:Property ;
+   samm:preferredName "Fuel"@en ;
+   samm:description "the fuel type of the vehicle"@en ;
+   samm:characteristic :FuelCharacteristic .
+
+:CatenaXIdTrait a samm-c:Trait ;
+   samm:preferredName "Catena-X ID Trait"@en ;
+   samm:description "Trait to ensure data format for Catena-X ID"@en ;
+   samm-c:baseCharacteristic :UUIDv4 ;
+   samm-c:constraint :UUIDv4RegularExpression .
+
+:VehicleSteeringPos a samm-c:Enumeration ;
+   samm:preferredName "Vehicle steering position(NHTSA)"@en ;
+   samm:description "vehicle steering position enumeration from NHTSA, see table [vPICList_lite].[dbo].[Steering]"@en ;
+   samm:see <https://vpic.nhtsa.dot.gov/api/> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Left-Hand Drive (LHD)" "Right-Hand Drive (RHD)" ) .
+
+:Weight a samm-c:Measurement ;
+   samm:preferredName "Weight"@en ;
+   samm:description "weight of an object"@en ;
+   samm:dataType xsd:double ;
+   samm-c:unit unit:kilogram .
+
+:DriveTypeNHTSA a samm-c:Enumeration ;
+   samm:preferredName "Drive type(NHTSA)"@en ;
+   samm:description "enumeration of drive type according NHTSA, table [vPICList_lite].[dbo].[DriveType]"@en ;
+   samm:see <https://vpic.nhtsa.dot.gov/api/> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "All-Wheel Drive(AWD)" "Front-Wheel Drive(FWD)" "Rear-Wheel Drive(RWD)" ) .
+
+:EnginePower a samm-c:Measurement ;
+   samm:preferredName "Engine Power"@en ;
+   samm:description "engine power expressed in kilowatt"@en ;
+   samm:dataType xsd:integer ;
+   samm-c:unit unit:kilowatt .
+
+:Hybridization a samm-c:Enumeration ;
+   samm:preferredName "Hybridization"@en ;
+   samm:description "Enum of possible hybridization values"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "battery electric vehicle" "hybrid electric vehicle" "no hybrid" "plugin hybrid electric vehicle" "range extender" ) .
+
+:OEMCharacteristic a samm:Characteristic ;
+   samm:preferredName "OEM Characteristic"@en ;
+   samm:description "OEMCharacteristic"@en ;
+   samm:dataType :OriginalEquipmentManufacturer .
+
+:BodyCharacteristic a samm:Characteristic ;
+   samm:preferredName "Body Characteristic"@en ;
+   samm:description "bundles all body-related information"@en ;
+   samm:dataType :Body .
+
+:Equipments a samm-c:List ;
+   samm:preferredName "Equipment List"@en ;
+   samm:description "list of equipments installed in the vehicle"@en ;
+   samm:dataType :Equipment .
+
+:ProductionCharacteristic a samm:Characteristic ;
+   samm:preferredName "Production Characteristic"@en ;
+   samm:description "Production Characteristic"@en ;
+   samm:dataType :Production .
+
+:SaleCharacteristic a samm:Characteristic ;
+   samm:preferredName "Sale Characteristic"@en ;
+   samm:description "Sale Characteristic"@en ;
+   samm:dataType :Sale .
+
+:Engines a samm-c:List ;
+   samm:preferredName "Engines"@en ;
+   samm:description "A list of all installed engines in the vehicle"@en ;
+   samm:dataType :Engine .
+
+:FuelCharacteristic a samm:Characteristic ;
+   samm:preferredName "Fuel Characteristic"@en ;
+   samm:description "FuelCharacteristic"@en ;
+   samm:dataType :Fuel .
+
+:UUIDv4 a samm:Characteristic ;
+   samm:preferredName "UUIDv4"@en ;
+   samm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en ;
+   samm:dataType xsd:string .
+
+:UUIDv4RegularExpression a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Catena-X Id Regular Expression"@en ;
+   samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), prefixed by \"urn:uuid:\" to make it an IRI."@en ;
+   samm:see <https://datatracker.ietf.org/doc/html/rfc4122> ;
+   samm:value "^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" .
+
+:OriginalEquipmentManufacturer a samm:Entity ;
+   samm:preferredName "OEM"@en ;
+   samm:description "describes one OEM to which this vehicle belongs to"@en ;
+   samm:properties ( :wmiCode :wmiDescription :cxBPN ) .
+
+:Body a samm:Entity ;
+   samm:preferredName "Body"@en ;
+   samm:description "body related data"@en ;
+   samm:properties ( :numberOfDoors :colorId :colorDescription [ samm:property :kbaBody; samm:optional true ] [ samm:property :nhtsaBody; samm:optional true ] ) .
+
+:Equipment a samm:Entity ;
+   samm:preferredName "Equipment"@en ;
+   samm:description "one optional equipment in car"@en ;
+   samm:properties ( :equipmentIdentifier :equipmentDescription :group ) .
+
+:Production a samm:Entity ;
+   samm:preferredName "Production"@en ;
+   samm:description "production-related data"@en ;
+   samm:properties ( :productionDate :plantIdentifier :plantDescription ) .
+
+:Sale a samm:Entity ;
+   samm:preferredName "Sale"@en ;
+   samm:description "all sale-related data"@en ;
+   samm:properties ( :soldDate :countryCode :countryGroup ) .
+
+:Engine a samm:Entity ;
+   samm:preferredName "Engine Entity"@en ;
+   samm:description "Describing one installed engine"@en ;
+   samm:properties ( :engineId :engineDescription :engineSeries :serialNumber [ samm:property :size; samm:optional true ] :power :engineProductionDate :installDate ) .
+
+:Fuel a samm:Entity ;
+   samm:preferredName "Fuel"@en ;
+   samm:description "fuel-related data"@en ;
+   samm:properties ( [ samm:property :kbaFuelType; samm:optional true ] [ samm:property :nhtsaFuelType; samm:optional true ] ) .
+
+:wmiCode a samm:Property ;
+   samm:preferredName "WMI Code"@en ;
+   samm:description "short name/code of vehicle manufacturer according  to world manufacturer information(wmi). The wmiCode are the first 3 chars of the vehicle identification number.\nA list of in NHTSA registered wmiCodes can be found in attribute Wmi in table [vPICList_lite].[dbo].[Wmi] "@en ;
+   samm:see <https://vpic.nhtsa.dot.gov/> ;
+   samm:characteristic :OemShortNameTrait ;
+   samm:exampleValue "WBA" .
+
+:wmiDescription a samm:Property ;
+   samm:preferredName "OEM name"@en ;
+   samm:description "name of OEM according NHTSA or other authorities. Has to be compliant with/linked wmiCode attribute.\nFor NHTSA: name of table [vPICList_lite].[dbo].[Manufacturer]"@en ;
+   samm:see <https://vpic.nhtsa.dot.gov/> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BMW AG" .
+
+:cxBPN a samm:Property ;
+   samm:preferredName "CX Business partner number"@en ;
+   samm:description "Catena-X business partner number of this company"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BPN-811" .
+
+:numberOfDoors a samm:Property ;
+   samm:preferredName "Number of doors"@en ;
+   samm:description "describes the number of doors of a vehicle"@en ;
+   samm:characteristic :PositiveNumber ;
+   samm:exampleValue "5"^^xsd:positiveInteger .
+
+:colorId a samm:Property ;
+   samm:preferredName "Color identifier"@en ;
+   samm:description "Colour code describes the code of a specific colour of one vehicle."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "LY7W " .
+
+:colorDescription a samm:Property ;
+   samm:preferredName "Color description"@en ;
+   samm:description "Colour name describes the colour of the colour code as a written word."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Light grey" .
+
+:kbaBody a samm:Property ;
+   samm:preferredName "Body variant(KBA)"@en ;
+   samm:description "vehicle variant - Body shapes according German KBA"@en ;
+   samm:characteristic :KbaVariant ;
+   samm:exampleValue "SUV" .
+
+:nhtsaBody a samm:Property ;
+   samm:preferredName "Body variant(NHTSA)"@en ;
+   samm:description "vehicle variant - Body shapes according US NHTSA"@en ;
+   samm:characteristic :NhtsaVariant ;
+   samm:exampleValue "Sedan" .
+
+:equipmentIdentifier a samm:Property ;
+   samm:preferredName "Equipment Id"@en ;
+   samm:description "The identifier of a specific equipment"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "S248A" .
+
+:equipmentDescription a samm:Property ;
+   samm:preferredName "Equipment description"@en ;
+   samm:description "The equipment variants description"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Seat heating front" .
+
+:group a samm:Property ;
+   samm:preferredName "Equipment group"@en ;
+   samm:description "grouping the special equipments into categories like Interior"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Interior" .
+
+:productionDate a samm:Property ;
+   samm:preferredName "Vehicle production Date"@en ;
+   samm:description "production date of the vehicle"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2018-01-15T00:00:00"^^xsd:dateTime .
+
+:plantIdentifier a samm:Property ;
+   samm:preferredName "Production plant id"@en ;
+   samm:description "plant id of the final assembly of the vehicle"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "4711" .
+
+:plantDescription a samm:Property ;
+   samm:preferredName "Vehicle production plant name"@en ;
+   samm:description "long name of the production plant of the vehicle"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Wolfsburg" .
+
+:soldDate a samm:Property ;
+   samm:preferredName "Vehicle sold date:"@en ;
+   samm:description "Sold date of the vehicle = warranty start date for this vehicle"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2018-02-03T00:00:00"^^xsd:dateTime .
+
+:countryCode a samm:Property ;
+   samm:preferredName "Vehicle sold country"@en ;
+   samm:description "vehicle sold country in ISO 8601 alpha 3"@en ;
+   samm:characteristic :CountryCodeTrait ;
+   samm:exampleValue "DEU" .
+
+:countryGroup a samm:Property ;
+   samm:preferredName "Vehicle sold region"@en ;
+   samm:description "region where this car was sold"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Europe" .
+
+:engineId a samm:Property ;
+   samm:preferredName "Engine ID:"@en ;
+   samm:description "OEM-specific identifier/type of the installed engine"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "CKBY" .
+
+:engineDescription a samm:Property ;
+   samm:preferredName "Engine Description"@en ;
+   samm:description "description of the engine"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "2.0 TDI" .
+
+:engineSeries a samm:Property ;
+   samm:preferredName "Vehicle engine series"@en ;
+   samm:description "engine series"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "EA189" .
+
+:serialNumber a samm:Property ;
+   samm:preferredName "Engine serial number"@en ;
+   samm:description "serial number of the installed engine"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "3434937GJJG3738" .
+
+:size a samm:Property ;
+   samm:preferredName "Engine size"@en ;
+   samm:description "Cubic capacity in a combustion engine  - not available in battery-electric vehicles"@en ;
+   samm:characteristic :CubicCapacity ;
+   samm:exampleValue 1968 .
+
+:power a samm:Property ;
+   samm:preferredName "Engine power"@en ;
+   samm:description "engine power is the power that an engine can put out"@en ;
+   samm:characteristic :EnginePower ;
+   samm:exampleValue 110 .
+
+:engineProductionDate a samm:Property ;
+   samm:preferredName "Engine production date"@en ;
+   samm:description "date when the engine was produced"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2017-10-20T00:00:00"^^xsd:dateTime .
+
+:installDate a samm:Property ;
+   samm:preferredName "Engine install date"@en ;
+   samm:description "date when the engine was installed"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2018-01-10T00:00:00"^^xsd:dateTime .
+
+:kbaFuelType a samm:Property ;
+   samm:preferredName "Fuel type(KBA)"@en ;
+   samm:description "description of the fuel according german KBA"@en ;
+   samm:characteristic :FuelKBA ;
+   samm:exampleValue "Diesel" .
+
+:nhtsaFuelType a samm:Property ;
+   samm:preferredName "Fuel type(NHTSA)"@en ;
+   samm:description "description of the fuel according US NHTSA"@en ;
+   samm:characteristic :FuelNHTSA ;
+   samm:exampleValue "Diesel" .
+
+:OemShortNameTrait a samm-c:Trait ;
+   samm-c:baseCharacteristic :WorldManufacturerInformation ;
+   samm-c:constraint :WorldManufacturerInformationCodeLength .
+
+:PositiveNumber a samm:Characteristic ;
+   samm:dataType xsd:positiveInteger .
+
+:KbaVariant a samm-c:Enumeration ;
+   samm:preferredName "KBA Variant"@en ;
+   samm:description "Current version of the Enumeration is sub-set of list defined from the German Federal Office for motor vehicles. "@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Limousine" "Schr?ghecklimousine" "Kombilimousine" "Coup?" "Kabrio-Limousine" "Cabrio-Limousine" "Mehrzweckfahrzeug" "Pkw-Pick-up" "Van" "Pick-up" ) .
+
+:NhtsaVariant a samm-c:Enumeration ;
+   samm:preferredName "NHTSA Variant"@en ;
+   samm:description "Enumeration comming from NHTSA offline database vpic, table [vPICList_lite].[dbo].[BodyStyle]"@en ;
+   samm:see <https://vpic.nhtsa.dot.gov/api/> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Cargo Van" "Convertible" "Cabriolet" "Coupe" "Crossover Utility Vehicle(CUV)" "Hatchback" "Liftback" "Notchback" "Limousine" "Low Speed Vehicle(LSV)" "Neighborhood Electric Vehicle(NEV)" "Minivan" "Pickup" "Roadster" "Sedan" "Saloon" "Sport Utility Truck(SUT)" "Sport Utility Vehicle(SUV)" "Multi-Purpose Vehicle(MPV)" "Van" "Wagon" ) .
+
+:CountryCodeTrait a samm-c:Trait ;
+   samm-c:baseCharacteristic :CountryCodeCharacteristic ;
+   samm-c:constraint :CountryCodeRegularExpression .
+
+:CubicCapacity a samm-c:Measurement ;
+   samm:preferredName "Cubic Capacity"@en ;
+   samm:description "cubic capacity of the engine"@en ;
+   samm:dataType xsd:integer ;
+   samm-c:unit unit:cubicCentimetre .
+
+:FuelKBA a samm-c:Enumeration ;
+   samm:preferredName "Fuel type (KBA)"@en ;
+   samm:description "enumeration of possible fuel types of a vehicle according german KBA"@en ;
+   samm:see <https://www.kba.de/SharedDocs/Downloads/DE/SV/sv221_m1_schad_pdf.pdf> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Unbekannt" "Diesel" "Benzin" "Vielstoff" "Elektro" "Fl?ssiggas" "Benzin/Fl?ssiggas" "Benzin/komp.Erdgas" "Hybr.Benzin/E" "Erdgas NG" "Hybr.Diesel/E" "Wasserstoff" "Hybr.Wasserst./E" "Wasserstoff/Benzin" "Wasserst./Benzin/E" "BZ/Wasserstoff" "BZ/Benzin" "BZ/Methanol" "BZ/Ethanol" "Hybr.Vielstoff/E" "Methan" "Benzin/Methan" "Hybr.Erdgas/E" "Benzin/Ethanol" "Hybr.Fl?ssiggas/E" "Hybr.B/E ext.aufl." "Hybr.D/E ext.aufl." "Hybr.LPG/E ext.aufl." "Hybr.W/E ext.aufl." "Hybr.V/E ext.aufl." "Hybr.NG/E ext.aufl." "Hybr.Wod.B/Eext.aufl" "Wasserstoff/NG" "Hybr.W/NG/E ext.aufl" "Ethanol" "Hybr.BZ/W/E" "Hybr.BZ/W/E ext. aufl." "Zweistoff LNG/Diesel" "Verfl?ssigtes Erdgas (LNG)" "Andere" ) .
+
+:FuelNHTSA a samm-c:Enumeration ;
+   samm:preferredName "Fuel type (NHTSA)"@en ;
+   samm:description "enumeration from NHTSA vpic database, table [vPICList_lite].[dbo].[FuelType]"@en ;
+   samm:see <https://vpic.nhtsa.dot.gov/api/> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Compressed Hydrogen/Hydrogen" "Compressed Natural Gas(CNG)" "Diesel" "Electric" "Ethanol(E85)" "Flexible Fuel Vehicle(FFV)" "Fuel Cell" "Gasoline" "Liquefied Natural Gas(LNG)" "Liquefied Petroleum Gas(propane or LPG)" "Methanol(M85)" "Natural Gas" "Neat Ethanol(E100)" "Neat Methanol(M100)" "Unknown" ) .
+
+:WorldManufacturerInformation a samm:Characteristic ;
+   samm:description "The wmiCode are the first 2 or 3 chars of a vehicle identification number (VIN)"@en ;
+   samm:dataType xsd:string .
+
+:WorldManufacturerInformationCodeLength a samm-c:LengthConstraint ;
+   samm:description "Restricts the length of wmiCode to exactly 3 chars"@en ;
+   samm:see <https://vpic.nhtsa.dot.gov/> ;
+   samm-c:minValue "3"^^xsd:nonNegativeInteger ;
+   samm-c:maxValue "3"^^xsd:nonNegativeInteger .
+
+:CountryCodeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Country Code Characteristic"@en ;
+   samm:description "ISO 3166-1 alpha-3 ? three-letter country codes "@en ;
+   samm:dataType xsd:string .
+
+:CountryCodeRegularExpression a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Country Code Regular Expression"@en ;
+   samm:description "Regular Expression that ensures a three-letter code "@en ;
+   samm:see <https://www.iso.org/iso-3166-country-codes.html> ;
+   samm:value "^[A-Z][A-Z][A-Z]$" .
+

--- a/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
+++ b/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
@@ -169,7 +169,7 @@
    samm:characteristic :FuelCharacteristic .
 
 :UniqueID a samm:Characteristic ;
-   samm:preferredName "unique ID"@en ;
+   samm:preferredName "Unique ID"@en ;
    samm:description "Characteristic for a unique id: every linked property to this characteristic is a unique ID."@en ;
    samm:dataType xsd:string .
 
@@ -207,7 +207,7 @@
 
 :Hybridization a samm-c:Enumeration ;
    samm:preferredName "Hybridization"@en ;
-   samm:description "Enum of possible hybridization values"@en ;
+   samm:description "Enumeration of possible hybridization values"@en ;
    samm:dataType xsd:string ;
    samm-c:values ( "battery electric vehicle" "hybrid electric vehicle" "no hybrid" "plugin hybrid electric vehicle" "range extender" ) .
 

--- a/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
+++ b/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
@@ -455,7 +455,7 @@
    samm:preferredName "KBA Variant"@en ;
    samm:description "Current version of the Enumeration is sub-set of list defined from the German Federal Office for motor vehicles. "@en ;
    samm:dataType xsd:string ;
-   samm-c:values ( "Limousine" "Schr?ghecklimousine" "Kombilimousine" "Coup?" "Kabrio-Limousine" "Cabrio-Limousine" "Mehrzweckfahrzeug" "Pkw-Pick-up" "Van" "Pick-up" ) .
+   samm-c:values ( "Limousine" "Kombilimousine" "Kabrio-Limousine" "Cabrio-Limousine" "Mehrzweckfahrzeug" "Pkw-Pick-up" "Van" "Pick-up" "Coupe" "Schraeghecklimousine" ) .
 
 :NhtsaVariant a samm-c:Enumeration ;
    samm:preferredName "NHTSA Variant"@en ;
@@ -479,7 +479,7 @@
    samm:description "enumeration of possible fuel types of a vehicle according german KBA"@en ;
    samm:see <https://www.kba.de/SharedDocs/Downloads/DE/SV/sv221_m1_schad_pdf.pdf> ;
    samm:dataType xsd:string ;
-   samm-c:values ( "Unbekannt" "Diesel" "Benzin" "Vielstoff" "Elektro" "Fl?ssiggas" "Benzin/Fl?ssiggas" "Benzin/komp.Erdgas" "Hybr.Benzin/E" "Erdgas NG" "Hybr.Diesel/E" "Wasserstoff" "Hybr.Wasserst./E" "Wasserstoff/Benzin" "Wasserst./Benzin/E" "BZ/Wasserstoff" "BZ/Benzin" "BZ/Methanol" "BZ/Ethanol" "Hybr.Vielstoff/E" "Methan" "Benzin/Methan" "Hybr.Erdgas/E" "Benzin/Ethanol" "Hybr.Fl?ssiggas/E" "Hybr.B/E ext.aufl." "Hybr.D/E ext.aufl." "Hybr.LPG/E ext.aufl." "Hybr.W/E ext.aufl." "Hybr.V/E ext.aufl." "Hybr.NG/E ext.aufl." "Hybr.Wod.B/Eext.aufl" "Wasserstoff/NG" "Hybr.W/NG/E ext.aufl" "Ethanol" "Hybr.BZ/W/E" "Hybr.BZ/W/E ext. aufl." "Zweistoff LNG/Diesel" "Verfl?ssigtes Erdgas (LNG)" "Andere" ) .
+   samm-c:values ( "Unbekannt" "Diesel" "Benzin" "Vielstoff" "Elektro" "Benzin/Fl?ssiggas" "Benzin/komp.Erdgas" "Hybr.Benzin/E" "Erdgas NG" "Hybr.Diesel/E" "Wasserstoff" "Hybr.Wasserst./E" "Wasserstoff/Benzin" "Wasserst./Benzin/E" "BZ/Wasserstoff" "BZ/Benzin" "BZ/Methanol" "BZ/Ethanol" "Hybr.Vielstoff/E" "Methan" "Benzin/Methan" "Hybr.Erdgas/E" "Benzin/Ethanol" "Hybr.B/E ext.aufl." "Hybr.D/E ext.aufl." "Hybr.LPG/E ext.aufl." "Hybr.W/E ext.aufl." "Hybr.V/E ext.aufl." "Hybr.NG/E ext.aufl." "Hybr.Wod.B/Eext.aufl" "Wasserstoff/NG" "Hybr.W/NG/E ext.aufl" "Ethanol" "Hybr.BZ/W/E" "Hybr.BZ/W/E ext. aufl." "Zweistoff LNG/Diesel" "Andere" "Fluessiggas" "Hybr.Fluessiggas/E" "Verfluessigtes Erdgas(LNG)" ) .
 
 :FuelNHTSA a samm-c:Enumeration ;
    samm:preferredName "Fuel type (NHTSA)"@en ;

--- a/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
+++ b/io.catenax.vehicle.product_description/3.0.0/ProductDescription.ttl
@@ -7,6 +7,22 @@
 # Copyright (c) 2023 Siemens AG
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
+# Copyrights of version 2.0.0 and 1.0.0:
+# Copyright (c) 2022 Allgemeine Deutsche Automobil-Club (ADAC) e.V
+# Copyright (c) 2022 Badische Anilin und Sodafabrik societates Europaea
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022 Deutsches Zentrum für Luft- und Raumfahrt e. V. (DLR)
+# Copyright (c) 2022 Henkel AG & Co. KGaA
+# Copyright (c) 2022 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. für ihre Institute IPK und IPK
+# Copyright (c) 2022 LRP Autorecycling Leipzig GmbH
+# Copyright (c) 2022 Mercedes Benz AG
+# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022 T-Systems International GmbH
+# Copyright (c) 2022 Volkswagen AG
+# Copyright (c) 2022 ZF Friedrichshafen AG
+#
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
 #

--- a/io.catenax.vehicle.product_description/3.0.0/metadata.json
+++ b/io.catenax.vehicle.product_description/3.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.vehicle.product_description/RELEASE_NOTES.md
+++ b/io.catenax.vehicle.product_description/RELEASE_NOTES.md
@@ -3,6 +3,13 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
+## [3.0.0] - 2023-05-16
+### Added
+Model in version 3.0.0 updated to SAMM version 2.0.0
+- model now uses SAMM 2.0
+- linkage between entities changed: Vehicle entity is now root, enties OEM, Body,Equipment, Production, Sale, Engines and Fuel are children of Vehicle
+
+
 ## [2.0.0] - 2022-12-13
 ### Added
 The new aspect model enhances the version 1.0.0 with

--- a/io.catenax.vehicle.product_description/RELEASE_NOTES.md
+++ b/io.catenax.vehicle.product_description/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
-## [3.0.0] - 2023-05-16
+## [3.0.0] - 2023-06-26
 ### Added
 Model in version 3.0.0 updated to SAMM version 2.0.0
 - model now uses SAMM 2.0


### PR DESCRIPTION
## Description
- model updated to SAMM:2.0.0. This is needed that the model can be used as external reference in 
PR https://github.com/eclipse-tractusx/sldt-semantic-models/pull/175
- entities relinked - see readme.md for details

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "name" and "description"** in English language. 
- [x] **no duplicate names or preferredNames** within an Aspect (e.g. a Property and the referenced Characteristic should not have the same name)
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
