### PR TITLE
Traction battery code

### DIFF
--- a/io.catenax.traction_battery_code/1.0.0/TractionBatteryCode.ttl
+++ b/io.catenax.traction_battery_code/1.0.0/TractionBatteryCode.ttl
@@ -43,12 +43,12 @@
 :tractionBatteryCode a samm:Property ;
    samm:preferredName "Traction Battery Code"@en ;
    samm:description "Traction Battery Code identifying a single traction battery component like a pack, module or cell. "@en ;
-   samm:characteristic :BatteryCodeTrait ;
+   samm:characteristic :TractionBatteryCodeTrait ;
    samm:exampleValue "X12MCPM27KLPCLX2M2382320" .
 
 :subcomponents a samm:Property ;
    samm:preferredName "Subcomponents"@en ;
-   samm:description "Subcomponents of the component, if any. The relationship between traction battery codes are as follows:\n\nIf this traction battery code is given for a cell subcomponents are not required. \nIf this traction battery code is given for a battery module a list of cells are required to be registered as subcomponents.\nIf this traction battery code is given for a battery pack a list of modules are required to be registered as subcomponents (containing each a list of cell subcomponents respectively)."@en ;
+   samm:description "Subcomponents of the component, if applicable. The relationship between traction battery codes are as follows:\n\nIf this traction battery code is given for a cell subcomponents are not required. \nIf this traction battery code is given for a battery module a list of cells are required to be registered as subcomponents.\nIf this traction battery code is given for a battery pack a list of modules are required to be registered as subcomponents (containing each a list of cell subcomponents respectively)."@en ;
    samm:characteristic :ComponentList .
 
 :productType a samm:Property ;
@@ -57,21 +57,21 @@
    samm:characteristic :ComponentTypeCharacterstic ;
    samm:exampleValue "pack" .
 
-:BatteryCodeTrait a samm-c:Trait ;
-   samm-c:baseCharacteristic :BatteryCodeCharacterisitc ;
+:TractionBatteryCodeTrait a samm-c:Trait ;
+   samm-c:baseCharacteristic :TractionBatteryCodeCharacteristic;
    samm-c:constraint :TractionBatteryCodeRegularExpression .
 
 :ComponentList a samm-c:List ;
    samm:preferredName "List of Components"@en ;
    samm:description "A list of battery components like modules or cells."@en ;
-   samm:dataType :BatteryComponent .
+   samm:dataType :TractionBatteryComponent .
 
 :ComponentTypeCharacterstic a samm-c:Enumeration ;
    samm:preferredName "Component Type Characterstic"@en ;
    samm:dataType xsd:string ;
    samm-c:values ( "pack" "module" "cell" ) .
 
-:BatteryCodeCharacterisitc a samm-c:Code ;
+:TractionBatteryCodeCharacteristic a samm-c:Code ;
    samm:preferredName "Batery Code Characteristic"@en ;
    samm:description "A code identifying a traction battery component like a pack, module or cell."@en ;
    samm:dataType xsd:string .
@@ -82,7 +82,7 @@
    samm:see <https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D818B4D3A7E05397BE0A0AB82A> ;
    samm:value "(^[A-Z0-9]{3}[PMC]{1}[A-GZ]{1}[A-Z0-9]{2}[A-Z0-9]{7}[1-9A-GH-NPR-Y]{1}[1-9A-C]{1}[0-9A-GH-NPR-Y]{1}[0-9]{7}$)|(^[A-Z0-9]{3}[PMC]{1}[A-GZ]{1}[A-Z0-9]{2}[1-9A-GH-NPR-Y]{1}[1-9A-C]{1}[0-9A-GH-NPR-Y]{1}[0-9]{7}[R]{1}[PMC]{1}$)" .
 
-:BatteryComponent a samm:Entity ;
+:TractionBatteryComponent a samm:Entity ;
    samm:preferredName "Battery Component"@en ;
    samm:description "A battery component like a cell or a module."@en ;
    samm:properties ( :tractionBatteryCode [ samm:property :subcomponents; samm:optional true ] :productType ) .

--- a/io.catenax.traction_battery_code/1.0.0/TractionBatteryCode.ttl
+++ b/io.catenax.traction_battery_code/1.0.0/TractionBatteryCode.ttl
@@ -78,7 +78,7 @@
 
 :TractionBatteryCodeRegularExpression a samm-c:RegularExpressionConstraint ;
    samm:preferredName "Traction Battery Code Regular Expression"@en ;
-   samm:description "The traction battery code as required by the National Standard of the People's Republic of China according to GB/T 34014-2017 published by the Standardization Administration of China (SAC). It can be have a length of either 24 or 18 characters."@en ;
+   samm:description "The traction battery code as required by the National Standard of the People's Republic of China according to GB/T 34014-2017 published by the Standardization Administration of China (SAC). It can have a length of either 24 or 18 characters."@en ;
    samm:see <https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D818B4D3A7E05397BE0A0AB82A> ;
    samm:value "(^[A-Z0-9]{3}[PMC]{1}[A-GZ]{1}[A-Z0-9]{2}[A-Z0-9]{7}[1-9A-GH-NPR-Y]{1}[1-9A-C]{1}[0-9A-GH-NPR-Y]{1}[0-9]{7}$)|(^[A-Z0-9]{3}[PMC]{1}[A-GZ]{1}[A-Z0-9]{2}[1-9A-GH-NPR-Y]{1}[1-9A-C]{1}[0-9A-GH-NPR-Y]{1}[0-9]{7}[R]{1}[PMC]{1}$)" .
 

--- a/io.catenax.traction_battery_code/1.0.0/TractionBatteryCode.ttl
+++ b/io.catenax.traction_battery_code/1.0.0/TractionBatteryCode.ttl
@@ -1,0 +1,89 @@
+#######################################################################
+# Copyright (c) 2023 BASF SE
+# Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright (c) 2023 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2023 Henkel AG & Co. KGaA
+# Copyright (c) 2023 Mercedes Benz AG
+# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 SAP SE
+# Copyright (c) 2023 Siemens AG
+# Copyright (c) 2023 T-Systems International GmbH
+# Copyright (c) 2023 ZF Friedrichshafen AG
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.traction_battery_code:1.0.0#> .
+
+:TractionBatteryCode a samm:Aspect ;
+   samm:preferredName "Traction Battery Code"@en ;
+   samm:description "The traction battery code is an identification code for any automotive traction battery, ultracapacitor and other reachargeble energy storage device. It allows to carry information as required by the National Standard of the People's Republic of China according to GB/T 34014-2017 published by the Standardization Administration of China (SAC)."@en ;
+   samm:see <https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D818B4D3A7E05397BE0A0AB82A> ;
+   samm:properties ( :tractionBatteryCode [ samm:property :subcomponents; samm:optional true ] :productType ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:tractionBatteryCode a samm:Property ;
+   samm:preferredName "Traction Battery Code"@en ;
+   samm:description "Traction Battery Code identifying a single traction battery component like a pack, module or cell. "@en ;
+   samm:characteristic :BatteryCodeTrait ;
+   samm:exampleValue "X12MCPM27KLPCLX2M2382320" .
+
+:subcomponents a samm:Property ;
+   samm:preferredName "Subcomponents"@en ;
+   samm:description "Subcomponents of the component, if any. The relationship between traction battery codes are as follows:\n\nIf this traction battery code is given for a cell subcomponents are not required. \nIf this traction battery code is given for a battery module a list of cells are required to be registered as subcomponents.\nIf this traction battery code is given for a battery pack a list of modules are required to be registered as subcomponents (containing each a list of cell subcomponents respectively)."@en ;
+   samm:characteristic :ComponentList .
+
+:productType a samm:Property ;
+   samm:preferredName "Product Type"@en ;
+   samm:description "The type of the battery component, e.g. a pack, a module or a cell."@en ;
+   samm:characteristic :ComponentTypeCharacterstic ;
+   samm:exampleValue "pack" .
+
+:BatteryCodeTrait a samm-c:Trait ;
+   samm-c:baseCharacteristic :BatteryCodeCharacterisitc ;
+   samm-c:constraint :TractionBatteryCodeRegularExpression .
+
+:ComponentList a samm-c:List ;
+   samm:preferredName "List of Components"@en ;
+   samm:description "A list of battery components like modules or cells."@en ;
+   samm:dataType :BatteryComponent .
+
+:ComponentTypeCharacterstic a samm-c:Enumeration ;
+   samm:preferredName "Component Type Characterstic"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "pack" "module" "cell" ) .
+
+:BatteryCodeCharacterisitc a samm-c:Code ;
+   samm:preferredName "Batery Code Characteristic"@en ;
+   samm:description "A code identifying a traction battery component like a pack, module or cell."@en ;
+   samm:dataType xsd:string .
+
+:TractionBatteryCodeRegularExpression a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Traction Battery Code Regular Expression"@en ;
+   samm:description "The traction battery code as required by the National Standard of the People's Republic of China according to GB/T 34014-2017 published by the Standardization Administration of China (SAC). It can be have a length of either 24 or 18 characters."@en ;
+   samm:see <https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D818B4D3A7E05397BE0A0AB82A> ;
+   samm:value "(^[A-Z0-9]{3}[PMC]{1}[A-GZ]{1}[A-Z0-9]{2}[A-Z0-9]{7}[1-9A-GH-NPR-Y]{1}[1-9A-C]{1}[0-9A-GH-NPR-Y]{1}[0-9]{7}$)|(^[A-Z0-9]{3}[PMC]{1}[A-GZ]{1}[A-Z0-9]{2}[1-9A-GH-NPR-Y]{1}[1-9A-C]{1}[0-9A-GH-NPR-Y]{1}[0-9]{7}[R]{1}[PMC]{1}$)" .
+
+:BatteryComponent a samm:Entity ;
+   samm:preferredName "Battery Component"@en ;
+   samm:description "A battery component like a cell or a module."@en ;
+   samm:properties ( :tractionBatteryCode [ samm:property :subcomponents; samm:optional true ] :productType ) .
+

--- a/io.catenax.traction_battery_code/1.0.0/TractionBatteryCode.ttl
+++ b/io.catenax.traction_battery_code/1.0.0/TractionBatteryCode.ttl
@@ -23,67 +23,67 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
-@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
-@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
-@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
-@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:1.0.0#> .
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:1.0.0#> .
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:1.0.0#> .
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:1.0.0#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.traction_battery_code:1.0.0#> .
+@prefix : <urn:bamm:io.catenax.traction_battery_code:1.0.0#> .
 
-:TractionBatteryCode a samm:Aspect ;
-   samm:preferredName "Traction Battery Code"@en ;
-   samm:description "The traction battery code is an identification code for any automotive traction battery, ultracapacitor and other reachargeble energy storage device. It allows to carry information as required by the National Standard of the People's Republic of China according to GB/T 34014-2017 published by the Standardization Administration of China (SAC)."@en ;
-   samm:see <https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D818B4D3A7E05397BE0A0AB82A> ;
-   samm:properties ( :tractionBatteryCode [ samm:property :subcomponents; samm:optional true ] :productType ) ;
-   samm:operations ( ) ;
-   samm:events ( ) .
+:TractionBatteryCode a bamm:Aspect ;
+   bamm:preferredName "Traction Battery Code"@en ;
+   bamm:description "The traction battery code is an identification code for any automotive traction battery, ultracapacitor and other reachargeble energy storage device. It allows to carry information as required by the National Standard of the People's Republic of China according to GB/T 34014-2017 published by the Standardization Administration of China (SAC)."@en ;
+   bamm:see <https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D818B4D3A7E05397BE0A0AB82A> ;
+   bamm:properties ( :tractionBatteryCode [ bamm:property :subcomponents; bamm:optional true ] :productType ) ;
+   bamm:operations ( ) ;
+   bamm:events ( ) .
 
-:tractionBatteryCode a samm:Property ;
-   samm:preferredName "Traction Battery Code"@en ;
-   samm:description "Traction Battery Code identifying a single traction battery component like a pack, module or cell. "@en ;
-   samm:characteristic :TractionBatteryCodeTrait ;
-   samm:exampleValue "X12MCPM27KLPCLX2M2382320" .
+:tractionBatteryCode a bamm:Property ;
+   bamm:preferredName "Traction Battery Code"@en ;
+   bamm:description "Traction Battery Code identifying a single traction battery component like a pack, module or cell. "@en ;
+   bamm:characteristic :TractionBatteryCodeTrait ;
+   bamm:exampleValue "X12MCPM27KLPCLX2M2382320" .
 
-:subcomponents a samm:Property ;
-   samm:preferredName "Subcomponents"@en ;
-   samm:description "Subcomponents of the component, if applicable. The relationship between traction battery codes are as follows:\n\nIf this traction battery code is given for a cell subcomponents are not required. \nIf this traction battery code is given for a battery module a list of cells are required to be registered as subcomponents.\nIf this traction battery code is given for a battery pack a list of modules are required to be registered as subcomponents (containing each a list of cell subcomponents respectively)."@en ;
-   samm:characteristic :ComponentList .
+:subcomponents a bamm:Property ;
+   bamm:preferredName "Subcomponents"@en ;
+   bamm:description "Subcomponents of the component, if applicable. The relationship between traction battery codes are as follows:\n\nIf this traction battery code is given for a cell subcomponents are not required. \nIf this traction battery code is given for a battery module a list of cells are required to be registered as subcomponents.\nIf this traction battery code is given for a battery pack a list of modules are required to be registered as subcomponents (containing each a list of cell subcomponents respectively)."@en ;
+   bamm:characteristic :ComponentList .
 
-:productType a samm:Property ;
-   samm:preferredName "Product Type"@en ;
-   samm:description "The type of the battery component, e.g. a pack, a module or a cell."@en ;
-   samm:characteristic :ComponentTypeCharacterstic ;
-   samm:exampleValue "pack" .
+:productType a bamm:Property ;
+   bamm:preferredName "Product Type"@en ;
+   bamm:description "The type of the battery component, e.g. a pack, a module or a cell."@en ;
+   bamm:characteristic :ComponentTypeCharacterstic ;
+   bamm:exampleValue "pack" .
 
-:TractionBatteryCodeTrait a samm-c:Trait ;
-   samm-c:baseCharacteristic :TractionBatteryCodeCharacteristic;
-   samm-c:constraint :TractionBatteryCodeRegularExpression .
+:TractionBatteryCodeTrait a bamm-c:Trait ;
+   bamm-c:baseCharacteristic :TractionBatteryCodeCharacteristic;
+   bamm-c:constraint :TractionBatteryCodeRegularExpression .
 
-:ComponentList a samm-c:List ;
-   samm:preferredName "List of Components"@en ;
-   samm:description "A list of battery components like modules or cells."@en ;
-   samm:dataType :TractionBatteryComponent .
+:ComponentList a bamm-c:List ;
+   bamm:preferredName "List of Components"@en ;
+   bamm:description "A list of battery components like modules or cells."@en ;
+   bamm:dataType :TractionBatteryComponent .
 
-:ComponentTypeCharacterstic a samm-c:Enumeration ;
-   samm:preferredName "Component Type Characterstic"@en ;
-   samm:dataType xsd:string ;
-   samm-c:values ( "pack" "module" "cell" ) .
+:ComponentTypeCharacterstic a bamm-c:Enumeration ;
+   bamm:preferredName "Component Type Characterstic"@en ;
+   bamm:dataType xsd:string ;
+   bamm-c:values ( "pack" "module" "cell" ) .
 
-:TractionBatteryCodeCharacteristic a samm-c:Code ;
-   samm:preferredName "Batery Code Characteristic"@en ;
-   samm:description "A code identifying a traction battery component like a pack, module or cell."@en ;
-   samm:dataType xsd:string .
+:TractionBatteryCodeCharacteristic a bamm-c:Code ;
+   bamm:preferredName "Batery Code Characteristic"@en ;
+   bamm:description "A code identifying a traction battery component like a pack, module or cell."@en ;
+   bamm:dataType xsd:string .
 
-:TractionBatteryCodeRegularExpression a samm-c:RegularExpressionConstraint ;
-   samm:preferredName "Traction Battery Code Regular Expression"@en ;
-   samm:description "The traction battery code as required by the National Standard of the People's Republic of China according to GB/T 34014-2017 published by the Standardization Administration of China (SAC). It can have a length of either 24 or 18 characters."@en ;
-   samm:see <https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D818B4D3A7E05397BE0A0AB82A> ;
-   samm:value "(^[A-Z0-9]{3}[PMC]{1}[A-GZ]{1}[A-Z0-9]{2}[A-Z0-9]{7}[1-9A-GH-NPR-Y]{1}[1-9A-C]{1}[0-9A-GH-NPR-Y]{1}[0-9]{7}$)|(^[A-Z0-9]{3}[PMC]{1}[A-GZ]{1}[A-Z0-9]{2}[1-9A-GH-NPR-Y]{1}[1-9A-C]{1}[0-9A-GH-NPR-Y]{1}[0-9]{7}[R]{1}[PMC]{1}$)" .
+:TractionBatteryCodeRegularExpression a bamm-c:RegularExpressionConstraint ;
+   bamm:preferredName "Traction Battery Code Regular Expression"@en ;
+   bamm:description "The traction battery code as required by the National Standard of the People's Republic of China according to GB/T 34014-2017 published by the Standardization Administration of China (SAC). It can have a length of either 24 or 18 characters."@en ;
+   bamm:see <https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D818B4D3A7E05397BE0A0AB82A> ;
+   bamm:value "(^[A-Z0-9]{3}[PMC]{1}[A-GZ]{1}[A-Z0-9]{2}[A-Z0-9]{7}[1-9A-GH-NPR-Y]{1}[1-9A-C]{1}[0-9A-GH-NPR-Y]{1}[0-9]{7}$)|(^[A-Z0-9]{3}[PMC]{1}[A-GZ]{1}[A-Z0-9]{2}[1-9A-GH-NPR-Y]{1}[1-9A-C]{1}[0-9A-GH-NPR-Y]{1}[0-9]{7}[R]{1}[PMC]{1}$)" .
 
-:TractionBatteryComponent a samm:Entity ;
-   samm:preferredName "Battery Component"@en ;
-   samm:description "A battery component like a cell or a module."@en ;
-   samm:properties ( :tractionBatteryCode [ samm:property :subcomponents; samm:optional true ] :productType ) .
+:TractionBatteryComponent a bamm:Entity ;
+   bamm:preferredName "Battery Component"@en ;
+   bamm:description "A battery component like a cell or a module."@en ;
+   bamm:properties ( :tractionBatteryCode [ bamm:property :subcomponents; bamm:optional true ] :productType ) .
 

--- a/io.catenax.traction_battery_code/1.0.0/metadata.json
+++ b/io.catenax.traction_battery_code/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.traction_battery_code/RELEASE_NOTES.md
+++ b/io.catenax.traction_battery_code/RELEASE_NOTES.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [Unreleased]
+
+
+## [1.0.0]
+### Added
+- initial model
+
+### Changed
+n/a
+
+### Removed
+n/a


### PR DESCRIPTION
## Description

The traction battery code is a requirement that the Chinese government has for every traction battery that will be exported to China. It is an identification code using a set of numerals and English letters that contain certain information meaning and indicate main attributes and uniqueness of traction battery according to GB/T 34014-2017.

The same model can be used for all three battery component types (pack, module, cell).

Closes #134 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "name" and "description"** in English language. 
- [x] **no duplicate names or preferredNames** within an Aspect (e.g. a Property and the referenced Characteristic should not have the same name)
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
