### PR TITLE
Adding first version of the manufacturing capability aspect model.

### DIFF
--- a/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
+++ b/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
@@ -1,6 +1,6 @@
 #######################################################################
 # Copyright (c) 2023 Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
-# Copyright (c) 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
+++ b/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
@@ -1,5 +1,6 @@
 #######################################################################
 # Copyright (c) 2023 Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
+++ b/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
@@ -1,162 +1,162 @@
-@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
-@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
-@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
-@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.manufacturing_capibility:1.0.0#> .
+@prefix : <urn:bamm:io.catenax.manufacturing_capability:1.0.0#> .
 
-:ManufacturingCapabilityAspectModel a samm:Aspect ;
-   samm:preferredName "Manufacturing Capability Aspect Model"@en ;
-   samm:description "An aspect model representing manufacturing capabilities, based on the concepts for products, processes, resources and capabilities, as well as their relations to eachother."@en ;
-   samm:properties ( :processSet :resourceSet :productSet :capabilitySet :capabilityConstraintSet ) ;
-   samm:operations ( ) ;
-   samm:events ( ) .
+:ManufacturingCapability a bamm:Aspect ;
+   bamm:preferredName "Manufacturing Capability Aspect Model"@en ;
+   bamm:description "An aspect model representing manufacturing capabilities, based on the concepts for products, processes, resources and capabilities, as well as their relations to eachother."@en ;
+   bamm:properties ( :processSet :resourceSet :productSet :capabilitySet :capabilityConstraintSet ) ;
+   bamm:operations ( ) ;
+   bamm:events ( ) .
 
-:processSet a samm:Property ;
-   samm:preferredName "process set"@en ;
-   samm:description "Set of production-relevant activities at any level of granularity that might affect materials and is performed by resources."@en ;
-   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
-   samm:characteristic :ProcessSetCharacteristic .
+:processSet a bamm:Property ;
+   bamm:preferredName "process set"@en ;
+   bamm:description "Set of production-relevant activities at any level of granularity that might affect materials and is performed by resources."@en ;
+   bamm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
+   bamm:characteristic :ProcessSetCharacteristic .
 
-:resourceSet a samm:Property ;
-   samm:preferredName "resource set"@en ;
-   samm:description "Set of entities capable of performing functions specified as capabilities."@en ;
-   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
-   samm:characteristic :ResourceSetCharacteristic .
+:resourceSet a bamm:Property ;
+   bamm:preferredName "resource set"@en ;
+   bamm:description "Set of entities capable of performing functions specified as capabilities."@en ;
+   bamm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
+   bamm:characteristic :ResourceSetCharacteristic .
 
-:productSet a samm:Property ;
-   samm:preferredName "product set"@en ;
-   samm:description "Set of physical objects being used as an input or created as an output of a production process."@en ;
-   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
-   samm:characteristic :ProductSetCharacteristic .
+:productSet a bamm:Property ;
+   bamm:preferredName "product set"@en ;
+   bamm:description "Set of physical objects being used as an input or created as an output of a production process."@en ;
+   bamm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
+   bamm:characteristic :ProductSetCharacteristic .
 
-:capabilitySet a samm:Property ;
-   samm:preferredName "capability set"@en ;
-   samm:description "Set of implementation-independent specifications of functions in industrial production to achieve an effect in the physical or virtual world."@en ;
-   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
-   samm:characteristic :CapabilitySetCharacteristic .
+:capabilitySet a bamm:Property ;
+   bamm:preferredName "capability set"@en ;
+   bamm:description "Set of implementation-independent specifications of functions in industrial production to achieve an effect in the physical or virtual world."@en ;
+   bamm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
+   bamm:characteristic :CapabilitySetCharacteristic .
 
-:capabilityConstraintSet a samm:Property ;
-   samm:preferredName "capability constraint set"@en ;
-   samm:description "Set of conditions imposed on capabilities which further detail their applicability."@en ;
-   samm:characteristic :CapabilityConstraintSetCharacteristic .
+:capabilityConstraintSet a bamm:Property ;
+   bamm:preferredName "capability constraint set"@en ;
+   bamm:description "Set of conditions imposed on capabilities which further detail their applicability."@en ;
+   bamm:characteristic :CapabilityConstraintSetCharacteristic .
 
-:ProcessSetCharacteristic a samm-c:Set ;
-   samm:preferredName "Process Set Characteristic"@en ;
-   samm:description "Characteristic for a set of process representations."@en ;
-   samm:dataType :ProcessEntity .
+:ProcessSetCharacteristic a bamm-c:Set ;
+   bamm:preferredName "Process Set Characteristic"@en ;
+   bamm:description "Characteristic for a set of process representations."@en ;
+   bamm:dataType :ProcessEntity .
 
-:ResourceSetCharacteristic a samm-c:Set ;
-   samm:preferredName "Resource Set Characteristic"@en ;
-   samm:description "Characteristic for a set of resource representations."@en ;
-   samm:dataType :ResourceEntity .
+:ResourceSetCharacteristic a bamm-c:Set ;
+   bamm:preferredName "Resource Set Characteristic"@en ;
+   bamm:description "Characteristic for a set of resource representations."@en ;
+   bamm:dataType :ResourceEntity .
 
-:ProductSetCharacteristic a samm-c:Set ;
-   samm:preferredName "Product Set Characteristic"@en ;
-   samm:description "Characteristic for a set of productrepresentations."@en ;
-   samm:dataType :ProductEntity .
+:ProductSetCharacteristic a bamm-c:Set ;
+   bamm:preferredName "Product Set Characteristic"@en ;
+   bamm:description "Characteristic for a set of productrepresentations."@en ;
+   bamm:dataType :ProductEntity .
 
-:CapabilitySetCharacteristic a samm-c:Set ;
-   samm:preferredName "Capability Set Characteristic"@en ;
-   samm:description "Characteristic for a set of capability representations."@en ;
-   samm:dataType :CapabilityEntity .
+:CapabilitySetCharacteristic a bamm-c:Set ;
+   bamm:preferredName "Capability Set Characteristic"@en ;
+   bamm:description "Characteristic for a set of capability representations."@en ;
+   bamm:dataType :CapabilityEntity .
 
-:CapabilityConstraintSetCharacteristic a samm-c:Set ;
-   samm:preferredName "Capability Constraint Set Characteristic"@en ;
-   samm:description "Characteristic for a set of capability constraint representations."@en ;
-   samm:dataType :CapabilityConstraintEntity .
+:CapabilityConstraintSetCharacteristic a bamm-c:Set ;
+   bamm:preferredName "Capability Constraint Set Characteristic"@en ;
+   bamm:description "Characteristic for a set of capability constraint representations."@en ;
+   bamm:dataType :CapabilityConstraintEntity .
 
-:PropertySetCharacteristic a samm-c:Set ;
-   samm:preferredName "Property Set Characteristic"@en ;
-   samm:description "Characteristic for a set of property representations."@en ;
-   samm:dataType :PropertyEntity .
+:PropertySetCharacteristic a bamm-c:Set ;
+   bamm:preferredName "Property Set Characteristic"@en ;
+   bamm:description "Characteristic for a set of property representations."@en ;
+   bamm:dataType :PropertyEntity .
 
-:ProcessEntity a samm:Entity ;
-   samm:extends :ElementAbstractEntity ;
-   samm:preferredName "ProcessEntity"@en ;
-   samm:description "Element containing the SAMM properties of a process."@en ;
-   samm:properties (:hasInput :hasOutput) .
+:ProcessEntity a bamm:Entity ;
+   bamm:extends :ElementAbstractEntity ;
+   bamm:preferredName "ProcessEntity"@en ;
+   bamm:description "Element containing the bamm properties of a process."@en ;
+   bamm:properties (:hasInput :hasOutput) .
 
-:ResourceEntity a samm:Entity ;
-   samm:extends :ElementAbstractEntity ;
-   samm:preferredName "Resource Entity"@en ;
-   samm:description "Element containing the SAMM properties of a resource."@en ;
-   samm:properties ( :provides ) .
+:ResourceEntity a bamm:Entity ;
+   bamm:extends :ElementAbstractEntity ;
+   bamm:preferredName "Resource Entity"@en ;
+   bamm:description "Element containing the bamm properties of a resource."@en ;
+   bamm:properties ( :provides ) .
 
-:ProductEntity a samm:Entity ;
-   samm:extends :ElementAbstractEntity ;
-   samm:preferredName "Product Entity"@en ;
-   samm:description "Element containing the SAMM properties of a product."@en ;
-   samm:properties ( :productLabel ) .
+:ProductEntity a bamm:Entity ;
+   bamm:extends :ElementAbstractEntity ;
+   bamm:preferredName "Product Entity"@en ;
+   bamm:description "Element containing the bamm properties of a product."@en ;
+   bamm:properties ( :productLabel ) .
 
-:CapabilityEntity a samm:Entity ;
-   samm:extends :ElementAbstractEntity ;
-   samm:preferredName "Capability Entity"@en ;
-   samm:description "Element containing the SAMM properties of a capability."@en ;
-   samm:properties ( :capabilityLabel) .
+:CapabilityEntity a bamm:Entity ;
+   bamm:extends :ElementAbstractEntity ;
+   bamm:preferredName "Capability Entity"@en ;
+   bamm:description "Element containing the bamm properties of a capability."@en ;
+   bamm:properties ( :capabilityLabel) .
 
-:CapabilityConstraintEntity a samm:Entity ;
-   samm:preferredName "Capability Constraint Entity"@en ;
-   samm:description "Element containing the SAMM properties of a capability constraint."@en ;
-   samm:properties ( :references ) .
+:CapabilityConstraintEntity a bamm:Entity ;
+   bamm:preferredName "Capability Constraint Entity"@en ;
+   bamm:description "Element containing the bamm properties of a capability constraint."@en ;
+   bamm:properties ( :references ) .
 
-:ElementAbstractEntity a samm:AbstractEntity ;
-   samm:preferredName "Element Abstract Entity"@en ;
-   samm:description "Abstract Entity containing the SAMM properties every process, resource, product and capability entity shall contain."@en ;
-   samm:properties (:propertySet ) .
+:ElementAbstractEntity a bamm:AbstractEntity ;
+   bamm:preferredName "Element Abstract Entity"@en ;
+   bamm:description "Abstract Entity containing the bamm properties every process, resource, product and capability entity shall contain."@en ;
+   bamm:properties (:propertySet ) .
 
-:hasInput a samm:Property ;
-   samm:preferredName "has input"@en ;
-   samm:description "Relation between a process and its input products."@en ;
-   samm:characteristic :ProductSetCharacteristic .
+:hasInput a bamm:Property ;
+   bamm:preferredName "has input"@en ;
+   bamm:description "Relation between a process and its input products."@en ;
+   bamm:characteristic :ProductSetCharacteristic .
 
-:hasOutput a samm:Property ;
-   samm:preferredName "has output"@en ;
-   samm:description "Relation between a process and its output products."@en ;
-   samm:characteristic :ProductSetCharacteristic .
+:hasOutput a bamm:Property ;
+   bamm:preferredName "has output"@en ;
+   bamm:description "Relation between a process and its output products."@en ;
+   bamm:characteristic :ProductSetCharacteristic .
 
-:requires a samm:Property ;
-   samm:preferredName "requires"@en ;
-   samm:description "Relation between a process and capabilities it requires."@en ;
-   samm:characteristic :CapabilitySetCharacteristic .
+:requires a bamm:Property ;
+   bamm:preferredName "requires"@en ;
+   bamm:description "Relation between a process and capabilities it requires."@en ;
+   bamm:characteristic :CapabilitySetCharacteristic .
 
-:provides a samm:Property ;
-   samm:preferredName "provides"@en ;
-   samm:description "Relation between a resource and capabilities it provides."@en ;
-   samm:characteristic :CapabilitySetCharacteristic .
+:provides a bamm:Property ;
+   bamm:preferredName "provides"@en ;
+   bamm:description "Relation between a resource and capabilities it provides."@en ;
+   bamm:characteristic :CapabilitySetCharacteristic .
 
-:productLabel a samm:Property ;
-   samm:preferredName "product label"@en ;
-   samm:description "Human readable label of a product, e.g. the name."@en ;
-   samm:exampleValue "wheel suspension"@en;
-   samm:characteristic samm-c:MultiLanguageText .
+:productLabel a bamm:Property ;
+   bamm:preferredName "product label"@en ;
+   bamm:description "Human readable label of a product, e.g. the name."@en ;
+   bamm:exampleValue "wheel suspension"@en;
+   bamm:characteristic bamm-c:MultiLanguageText .
 
-:capabilityLabel a samm:Property ;
-   samm:preferredName "capability label"@en ;
-   samm:description "Human readable label of a capability"@en ;
-   samm:exampleValue "drilling"@en;
-   samm:characteristic samm-c:MultiLanguageText .
+:capabilityLabel a bamm:Property ;
+   bamm:preferredName "capability label"@en ;
+   bamm:description "Human readable label of a capability"@en ;
+   bamm:exampleValue "drilling"@en;
+   bamm:characteristic bamm-c:MultiLanguageText .
 
-:references a samm:Property ;
-   samm:preferredName "references"@en ;
-   samm:description "Relation between a capability constraint and its properties."@en ;
-   samm:characteristic :PropertySetCharacteristic .
+:references a bamm:Property ;
+   bamm:preferredName "references"@en ;
+   bamm:description "Relation between a capability constraint and its properties."@en ;
+   bamm:characteristic :PropertySetCharacteristic .
 
-:PropertyEntity a samm:Entity ;
-   samm:preferredName "Property Entity"@en ;
-   samm:description "Element containing the SAMM properties of a property."@en ;
-   samm:properties ( :propertyLabel ) .
+:PropertyEntity a bamm:Entity ;
+   bamm:preferredName "Property Entity"@en ;
+   bamm:description "Element containing the bamm properties of a property."@en ;
+   bamm:properties ( :propertyLabel ) .
 
-:propertyLabel a samm:Property ;
-   samm:preferredName "property label"@en ;
-   samm:description "Human readable label of a property."@en ;
-   samm:exampleValue "diameter"@en;
-   samm:characteristic samm-c:MultiLanguageText .
+:propertyLabel a bamm:Property ;
+   bamm:preferredName "property label"@en ;
+   bamm:description "Human readable label of a property."@en ;
+   bamm:exampleValue "diameter"@en;
+   bamm:characteristic bamm-c:MultiLanguageText .
 
-:propertySet a samm:Property ;
-   samm:preferredName "property set"@en ;
-   samm:description "Set of qualities or characteristics inherent in or ascribed to process, resource, product or capability entities."@en ;
-   samm:characteristic :PropertySetCharacteristic .
+:propertySet a bamm:Property ;
+   bamm:preferredName "property set"@en ;
+   bamm:description "Set of qualities or characteristics inherent in or ascribed to process, resource, product or capability entities."@en ;
+   bamm:characteristic :PropertySetCharacteristic .
 

--- a/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
+++ b/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
@@ -1,0 +1,162 @@
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.manufacturing_capibility:1.0.0#> .
+
+:ManufacturingCapabilityAspectModel a samm:Aspect ;
+   samm:preferredName "Manufacturing Capability Aspect Model"@en ;
+   samm:description "An aspect model representing manufacturing capabilities, based on the concepts for products, processes, resources and capabilities, as well as their relations to eachother."@en ;
+   samm:properties ( :processSet :resourceSet :productSet :capabilitySet :capabilityConstraintSet ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:processSet a samm:Property ;
+   samm:preferredName "process set"@en ;
+   samm:description "Set of production-relevant activities at any level of granularity that might affect materials and is performed by resources."@en ;
+   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
+   samm:characteristic :ProcessSetCharacteristic .
+
+:resourceSet a samm:Property ;
+   samm:preferredName "resource set"@en ;
+   samm:description "Set of entities capable of performing functions specified as capabilities."@en ;
+   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
+   samm:characteristic :ResourceSetCharacteristic .
+
+:productSet a samm:Property ;
+   samm:preferredName "product set"@en ;
+   samm:description "Set of physical objects being used as an input or created as an output of a production process."@en ;
+   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
+   samm:characteristic :ProductSetCharacteristic .
+
+:capabilitySet a samm:Property ;
+   samm:preferredName "capability set"@en ;
+   samm:description "Set of implementation-independent specifications of functions in industrial production to achieve an effect in the physical or virtual world."@en ;
+   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
+   samm:characteristic :CapabilitySetCharacteristic .
+
+:capabilityConstraintSet a samm:Property ;
+   samm:preferredName "capability constraint set"@en ;
+   samm:description "Set of conditions imposed on capabilities which further detail their applicability."@en ;
+   samm:characteristic :CapabilityConstraintSetCharacteristic .
+
+:ProcessSetCharacteristic a samm-c:Set ;
+   samm:preferredName "Process Set Characteristic"@en ;
+   samm:description "Characteristic for a set of process representations."@en ;
+   samm:dataType :ProcessEntity .
+
+:ResourceSetCharacteristic a samm:Characteristic ;
+   samm:preferredName "Resource Set Characteristic"@en ;
+   samm:description "Characteristic for a set of resource representations."@en ;
+   samm:dataType :ResourceEntity .
+
+:ProductSetCharacteristic a samm-c:Set ;
+   samm:preferredName "Product Set Characteristic"@en ;
+   samm:description "Characteristic for a set of productrepresentations."@en ;
+   samm:dataType :ProductEntity .
+
+:CapabilitySetCharacteristic a samm-c:Set ;
+   samm:preferredName "Capability Set Characteristic"@en ;
+   samm:description "Characteristic for a set of capability representations."@en ;
+   samm:dataType :CapabilityEntity .
+
+:CapabilityConstraintSetCharacteristic a samm-c:Set ;
+   samm:preferredName "Capability Constraint Set Characteristic"@en ;
+   samm:description "Characteristic for a set of capability constraint representations."@en ;
+   samm:dataType :CapabilityConstraintEntity .
+
+:PropertySetCharacteristic a samm-c:Set ;
+   samm:preferredName "Property Set Characteristic"@en ;
+   samm:description "Characteristic for a set of property representations."@en ;
+   samm:dataType :PropertyEntity .
+
+:ProcessEntity a samm:Entity ;
+   samm:extends :ElementAbstractEntity ;
+   samm:preferredName "ProcessEntity"@en ;
+   samm:description "Element containing the SAMM properties of a process."@en ;
+   samm:properties (:hasInput :hasOutput) .
+
+:ResourceEntity a samm:Entity ;
+   samm:extends :ElementAbstractEntity ;
+   samm:preferredName "Resource Entity"@en ;
+   samm:description "Element containing the SAMM properties of a resource."@en ;
+   samm:properties ( :provides ) .
+
+:ProductEntity a samm:Entity ;
+   samm:extends :ElementAbstractEntity ;
+   samm:preferredName "Product Entity"@en ;
+   samm:description "Element containing the SAMM properties of a product."@en ;
+   samm:properties ( :productLabel ) .
+
+:CapabilityEntity a samm:Entity ;
+   samm:extends :ElementAbstractEntity ;
+   samm:preferredName "Capability Entity"@en ;
+   samm:description "Element containing the SAMM properties of a capability."@en ;
+   samm:properties ( :capabilityLabel) .
+
+:CapabilityConstraintEntity a samm:Entity ;
+   samm:preferredName "Capability Constraint Entity"@en ;
+   samm:description "Element containing the SAMM properties of a capability constraint."@en ;
+   samm:properties ( :references ) .
+
+:ElementAbstractEntity a samm:AbstractEntity ;
+   samm:preferredName "Element Abstract Entity"@en ;
+   samm:description "Abstract Entity containing the SAMM properties every process, resource, product and capability entity shall contain."@en ;
+   samm:properties (:propertySet ) .
+
+:hasInput a samm:Property ;
+   samm:preferredName "has input"@en ;
+   samm:description "Relation between a process and its input products."@en ;
+   samm:characteristic :ProductSetCharacteristic .
+
+:hasOutput a samm:Property ;
+   samm:preferredName "has output"@en ;
+   samm:description "Relation between a process and its output products."@en ;
+   samm:characteristic :ProductSetCharacteristic .
+
+:requires a samm:Property ;
+   samm:preferredName "requires"@en ;
+   samm:description "Relation between a process and capabilities it requires."@en ;
+   samm:characteristic :CapabilitySetCharacteristic .
+
+:provides a samm:Property ;
+   samm:preferredName "provides"@en ;
+   samm:description "Relation between a resource and capabilities it provides."@en ;
+   samm:characteristic :CapabilitySetCharacteristic .
+
+:productLabel a samm:Property ;
+   samm:preferredName "product label"@en ;
+   samm:description "Human readable label of a product, e.g. the name."@en ;
+   samm:exampleValue "wheel suspension"@en;
+   samm:characteristic samm-c:MultiLanguageText .
+
+:capabilityLabel a samm:Property ;
+   samm:preferredName "capability label"@en ;
+   samm:description "Human readable label of a capability"@en ;
+   samm:exampleValue "drilling"@en;
+   samm:characteristic samm-c:MultiLanguageText .
+
+:references a samm:Property ;
+   samm:preferredName "references"@en ;
+   samm:description "Relation between a capability constraint and its properties."@en ;
+   samm:characteristic :PropertySetCharacteristic .
+
+:PropertyEntity a samm:Entity ;
+   samm:preferredName "Property Entity"@en ;
+   samm:description "Element containing the SAMM properties of a property."@en ;
+   samm:properties ( :propertyLabel ) .
+
+:propertyLabel a samm:Property ;
+   samm:preferredName "property label"@en ;
+   samm:description "Human readable label of a property."@en ;
+   samm:exampleValue "diameter"@en;
+   samm:characteristic samm-c:MultiLanguageText .
+
+:propertySet a samm:Property ;
+   samm:preferredName "property set"@en ;
+   samm:description "Set of qualities or characteristics inherent in or ascribed to process, resource, product or capability entities."@en ;
+   samm:characteristic :PropertySetCharacteristic .
+

--- a/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
+++ b/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
@@ -48,7 +48,7 @@
    samm:description "Characteristic for a set of process representations."@en ;
    samm:dataType :ProcessEntity .
 
-:ResourceSetCharacteristic a samm:Characteristic ;
+:ResourceSetCharacteristic a samm-c:Set ;
    samm:preferredName "Resource Set Characteristic"@en ;
    samm:description "Characteristic for a set of resource representations."@en ;
    samm:dataType :ResourceEntity .

--- a/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
+++ b/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
@@ -92,7 +92,7 @@
    bamm:extends :ElementAbstractEntity ;
    bamm:preferredName "Process Entity"@en ;
    bamm:description "Element containing the bamm properties of a process."@en ;
-   bamm:properties (:hasInput :hasOutput) .
+   bamm:properties (:hasInput :hasOutput :requires) .
 
 :ResourceEntity a bamm:Entity ;
    bamm:extends :ElementAbstractEntity ;

--- a/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
+++ b/io.catenax.manufacturing_capability/1.0.0/ManufacturingCapability.ttl
@@ -1,3 +1,17 @@
+#######################################################################
+# Copyright (c) 2023 Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the 
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license, 
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
 @prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .
 @prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .
 @prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .
@@ -9,37 +23,37 @@
 
 :ManufacturingCapability a bamm:Aspect ;
    bamm:preferredName "Manufacturing Capability Aspect Model"@en ;
-   bamm:description "An aspect model representing manufacturing capabilities, based on the concepts for products, processes, resources and capabilities, as well as their relations to eachother."@en ;
+   bamm:description "An aspect model representing manufacturing capabilities, based on the concepts for products, processes, resources and capabilities, as well as their relations to each other."@en ;
    bamm:properties ( :processSet :resourceSet :productSet :capabilitySet :capabilityConstraintSet ) ;
    bamm:operations ( ) ;
    bamm:events ( ) .
 
 :processSet a bamm:Property ;
-   bamm:preferredName "process set"@en ;
+   bamm:preferredName "Process Set"@en ;
    bamm:description "Set of production-relevant activities at any level of granularity that might affect materials and is performed by resources."@en ;
    bamm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
    bamm:characteristic :ProcessSetCharacteristic .
 
 :resourceSet a bamm:Property ;
-   bamm:preferredName "resource set"@en ;
+   bamm:preferredName "Resource Set"@en ;
    bamm:description "Set of entities capable of performing functions specified as capabilities."@en ;
    bamm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
    bamm:characteristic :ResourceSetCharacteristic .
 
 :productSet a bamm:Property ;
-   bamm:preferredName "product set"@en ;
+   bamm:preferredName "Product Set"@en ;
    bamm:description "Set of physical objects being used as an input or created as an output of a production process."@en ;
    bamm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
    bamm:characteristic :ProductSetCharacteristic .
 
 :capabilitySet a bamm:Property ;
-   bamm:preferredName "capability set"@en ;
+   bamm:preferredName "Capability Set"@en ;
    bamm:description "Set of implementation-independent specifications of functions in industrial production to achieve an effect in the physical or virtual world."@en ;
    bamm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1>;
    bamm:characteristic :CapabilitySetCharacteristic .
 
 :capabilityConstraintSet a bamm:Property ;
-   bamm:preferredName "capability constraint set"@en ;
+   bamm:preferredName "Capability Constraint Set"@en ;
    bamm:description "Set of conditions imposed on capabilities which further detail their applicability."@en ;
    bamm:characteristic :CapabilityConstraintSetCharacteristic .
 
@@ -75,7 +89,7 @@
 
 :ProcessEntity a bamm:Entity ;
    bamm:extends :ElementAbstractEntity ;
-   bamm:preferredName "ProcessEntity"@en ;
+   bamm:preferredName "Process Entity"@en ;
    bamm:description "Element containing the bamm properties of a process."@en ;
    bamm:properties (:hasInput :hasOutput) .
 
@@ -108,39 +122,39 @@
    bamm:properties (:propertySet ) .
 
 :hasInput a bamm:Property ;
-   bamm:preferredName "has input"@en ;
+   bamm:preferredName "Has Input"@en ;
    bamm:description "Relation between a process and its input products."@en ;
    bamm:characteristic :ProductSetCharacteristic .
 
 :hasOutput a bamm:Property ;
-   bamm:preferredName "has output"@en ;
+   bamm:preferredName "Has Output"@en ;
    bamm:description "Relation between a process and its output products."@en ;
    bamm:characteristic :ProductSetCharacteristic .
 
 :requires a bamm:Property ;
-   bamm:preferredName "requires"@en ;
+   bamm:preferredName "Requires"@en ;
    bamm:description "Relation between a process and capabilities it requires."@en ;
    bamm:characteristic :CapabilitySetCharacteristic .
 
 :provides a bamm:Property ;
-   bamm:preferredName "provides"@en ;
+   bamm:preferredName "Provides"@en ;
    bamm:description "Relation between a resource and capabilities it provides."@en ;
    bamm:characteristic :CapabilitySetCharacteristic .
 
 :productLabel a bamm:Property ;
-   bamm:preferredName "product label"@en ;
+   bamm:preferredName "Product Label"@en ;
    bamm:description "Human readable label of a product, e.g. the name."@en ;
    bamm:exampleValue "wheel suspension"@en;
    bamm:characteristic bamm-c:MultiLanguageText .
 
 :capabilityLabel a bamm:Property ;
-   bamm:preferredName "capability label"@en ;
+   bamm:preferredName "Capability Label"@en ;
    bamm:description "Human readable label of a capability"@en ;
    bamm:exampleValue "drilling"@en;
    bamm:characteristic bamm-c:MultiLanguageText .
 
 :references a bamm:Property ;
-   bamm:preferredName "references"@en ;
+   bamm:preferredName "References"@en ;
    bamm:description "Relation between a capability constraint and its properties."@en ;
    bamm:characteristic :PropertySetCharacteristic .
 
@@ -150,13 +164,13 @@
    bamm:properties ( :propertyLabel ) .
 
 :propertyLabel a bamm:Property ;
-   bamm:preferredName "property label"@en ;
+   bamm:preferredName "Property Label"@en ;
    bamm:description "Human readable label of a property."@en ;
    bamm:exampleValue "diameter"@en;
    bamm:characteristic bamm-c:MultiLanguageText .
 
 :propertySet a bamm:Property ;
-   bamm:preferredName "property set"@en ;
+   bamm:preferredName "Property Set"@en ;
    bamm:description "Set of qualities or characteristics inherent in or ascribed to process, resource, product or capability entities."@en ;
    bamm:characteristic :PropertySetCharacteristic .
 

--- a/io.catenax.manufacturing_capability/1.0.0/metadata.json
+++ b/io.catenax.manufacturing_capability/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.manufacturing_capability/RELEASE_NOTES.md
+++ b/io.catenax.manufacturing_capability/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [Unreleased]
+
+## [1.0.0] - 2023-06-14
+### Added
+- initial model
+
+### Changed
+n/a
+
+### Removed
+

--- a/io.catenax.manufacturing_capability/RELEASE_NOTES.md
+++ b/io.catenax.manufacturing_capability/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
-## [1.0.0] - 2023-06-14
+## [1.0.0] - 2023-07-03
 ### Added
 - initial model
 


### PR DESCRIPTION
## Description
This PR introduces the first version (1.0.0) of the manufacturing capability aspect model.

Refers to #158 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "name" and "description"** in English language. 
- [x] **no duplicate names or preferredNames** within an Aspect (e.g. a Property and the referenced Characteristic should not have the same name)
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
