### PR TITLE
Serial part 1.0.1

### DIFF
--- a/io.catenax.serial_part/1.0.1/SerialPart.ttl
+++ b/io.catenax.serial_part/1.0.1/SerialPart.ttl
@@ -1,0 +1,207 @@
+#######################################################################
+# Copyright (c) 2022,2023 BASF SE
+# Copyright (c) 2022,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022,2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright (c) 2022,2023 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2022,2023 Henkel AG & Co. KGaA
+# Copyright (c) 2022,2023 Mercedes Benz AG
+# Copyright (c) 2022,2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2022,2023 SAP SE
+# Copyright (c) 2022,2023 Siemens AG
+# Copyright (c) 2022,2023 T-Systems International GmbH
+# Copyright (c) 2022,2023 ZF Friedrichshafen AG
+# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:bamm:io.catenax.serial_part:1.0.0#> .
+
+:SerialPart a bamm:Aspect ;
+   bamm:preferredName "Serial Part"@en ;
+   bamm:description "A serialized part is an instantiation of a (design-) part, where the particular instantiation can be uniquely identified by means of a serial number or a similar identifier (e.g. VAN) or a combination of multiple identifiers (e.g. combination of manufacturer, date and number)"@en ;
+   bamm:properties ( :catenaXId :localIdentifiers :manufacturingInformation :partTypeInformation ) ;
+   bamm:operations ( ) ;
+   bamm:events ( ) .
+
+:catenaXId a bamm:Property ;
+   bamm:preferredName "Catena-X ID"@en ;
+   bamm:description "The fully anonymous Catena-X ID of the serialized part, valid for the Catena-X dataspace."@en ;
+   bamm:characteristic :CatenaXIdTrait ;
+   bamm:exampleValue "urn:uuid:580d3adf-1981-44a0-a214-13d6ceed9379" .
+
+:localIdentifiers a bamm:Property ;
+   bamm:preferredName "Local Identifiers"@en ;
+   bamm:description "A local identifier enables identification of a part in a specific dataspace, but is not unique in Catena-X dataspace. Multiple local identifiers may exist."@en ;
+   bamm:characteristic :LocalIdentifierCharacteristic .
+
+:manufacturingInformation a bamm:Property ;
+   bamm:preferredName "Manufacturing Information"@en ;
+   bamm:description "Information from manufacturing process, such as manufacturing date and manufacturing country"@en ;
+   bamm:characteristic :ManufacturingCharacteristic .
+
+:partTypeInformation a bamm:Property ;
+   bamm:preferredName "Part Type Information"@en ;
+   bamm:description "The part type from which the serialized part has been instantiated"@en ;
+   bamm:characteristic :PartTypeInformationCharacteristic .
+
+:CatenaXIdTrait a bamm-c:Trait ;
+   bamm:preferredName "Catena-X ID Trait"@en ;
+   bamm:description "Trait to ensure data format for Catena-X ID"@en ;
+   bamm-c:baseCharacteristic :Uuidv4Characteristic ;
+   bamm-c:constraint :Uuidv4RegularExpression .
+
+:LocalIdentifierCharacteristic a bamm-c:Set ;
+   bamm:preferredName "Local Identifier Characteristic"@en ;
+   bamm:description "A single serialized part may have multiple attributes, that uniquely identify a that part in a specific dataspace (e.g. the manufacturer`s dataspace)"@en ;
+   bamm:dataType :KeyValueList .
+
+:ManufacturingCharacteristic a bamm:Characteristic ;
+   bamm:preferredName "Manufacturing Characteristic"@en ;
+   bamm:description "Characteristic to describe manufacturing related data"@en ;
+   bamm:dataType :ManufacturingEntity .
+
+:PartTypeInformationCharacteristic a bamm:Characteristic ;
+   bamm:preferredName "Part Type Information Characteristic"@en ;
+   bamm:description "The characteristics of the part type"@en ;
+   bamm:dataType :PartTypeInformationEntity .
+
+:Uuidv4Characteristic a bamm:Characteristic ;
+   bamm:preferredName "UUIDv4 Characteristic"@en ;
+   bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en ;
+   bamm:dataType xsd:string .
+
+:Uuidv4RegularExpression a bamm-c:RegularExpressionConstraint ;
+   bamm:preferredName "Catena-X Id Regular Expression"@en ;
+   bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en ;
+   bamm:see <https://datatracker.ietf.org/doc/html/rfc4122> ;
+   bamm:value "(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)" .
+
+:KeyValueList a bamm:Entity ;
+   bamm:preferredName "Key Value List"@en ;
+   bamm:description "A list of key value pairs for local identifiers, which are composed of a key and a corresponding value."@en ;
+   bamm:properties ( :key :value ) .
+
+:ManufacturingEntity a bamm:Entity ;
+   bamm:preferredName "Manufacturing Entity"@en ;
+   bamm:description "Encapsulates the manufacturing relevant attributes"@en ;
+   bamm:properties ( :date [ bamm:property :country; bamm:optional true ] ) .
+
+:PartTypeInformationEntity a bamm:Entity ;
+   bamm:preferredName "Part Type Information Entity"@en ;
+   bamm:description "Encapsulation for data related to the part type"@en ;
+   bamm:properties ( :manufacturerPartId [ bamm:property :customerPartId; bamm:optional true ] :nameAtManufacturer [ bamm:property :nameAtCustomer; bamm:optional true ] :classification ) .
+
+:key a bamm:Property ;
+   bamm:preferredName "Identifier Key"@en ;
+   bamm:description "The key of a local identifier. "@en ;
+   bamm:characteristic :KeyCharacteristic ;
+   bamm:exampleValue "PartInstanceID" .
+
+:value a bamm:Property ;
+   bamm:preferredName "Identifier Value"@en ;
+   bamm:description "The value of an identifier."@en ;
+   bamm:characteristic :ValueCharacteristic ;
+   bamm:exampleValue "SN12345678" .
+
+:date a bamm:Property ;
+   bamm:preferredName "Production Date"@en ;
+   bamm:description "Timestamp of the manufacturing date as the final step in production process (e.g. final quality check, ready-for-shipment event)"@en ;
+   bamm:characteristic bamm-c:Timestamp ;
+   bamm:exampleValue "2022-02-04T14:48:54"^^xsd:dateTime .
+
+:country a bamm:Property ;
+   bamm:preferredName "Country code"@en ;
+   bamm:description "Country code where the part was manufactured"@en ;
+   bamm:characteristic :ProductionCountryCodeTrait ;
+   bamm:exampleValue "HUR" .
+
+:manufacturerPartId a bamm:Property ;
+   bamm:preferredName "Manufacturer Part ID"@en ;
+   bamm:description "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part (as designed) in the manufacturer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number."@en ;
+   bamm:characteristic :PartIdCharacteristic ;
+   bamm:exampleValue "123-0.740-3434-A" .
+
+:customerPartId a bamm:Property ;
+   bamm:preferredName "Customer Part ID"@en ;
+   bamm:description "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part (as designed) in the customer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number."@en ;
+   bamm:characteristic :PartIdCharacteristic ;
+   bamm:exampleValue "PRT-12345" .
+
+:nameAtManufacturer a bamm:Property ;
+   bamm:preferredName "Name at Manufacturer"@en ;
+   bamm:description "Name of the part as assigned by the manufacturer"@en ;
+   bamm:characteristic :PartNameCharacteristic ;
+   bamm:exampleValue "Mirror left" .
+
+:nameAtCustomer a bamm:Property ;
+   bamm:preferredName "Name at Customer"@en ;
+   bamm:description "Name of the part as assigned by the customer"@en ;
+   bamm:characteristic :PartNameCharacteristic ;
+   bamm:exampleValue "side element A" .
+
+:classification a bamm:Property ;
+   bamm:preferredName "Classifcation"@en ;
+   bamm:description "The classification of the part type according to STEP standard definition"@en ;
+   bamm:characteristic :ClassificationCharacteristic ;
+   bamm:exampleValue "software" .
+
+:KeyCharacteristic a bamm:Characteristic ;
+   bamm:preferredName "Key Characteristic"@en ;
+   bamm:description "The key characteristic of a local identifier. A specific subset of keys is predefined, but additionally any other custom key is allowed. Predefined keys (to be used when applicable):\n- \"manufacturerId\" - The Business Partner Number (BPN) of the manufacturer. Value: BPN-Nummer\n- \"partInstanceId\" - The identifier of the manufacturer for the serialized instance of the part, e.g. the serial number\n- \"batchId\" - The identifier of the batch, to which the serialzed part belongs\n- \"van\" - The anonymized vehicle identification number (VIN). Value: anonymized VIN according to OEM anonymization rules. Note: If the key \"van\" is available, \"partInstanceId\" must also be available and hold the identical value."@en ;
+   bamm:dataType xsd:string .
+
+:ValueCharacteristic a bamm:Characteristic ;
+   bamm:preferredName "Value Characteristic"@en ;
+   bamm:description "The value of an identifier."@en ;
+   bamm:dataType xsd:string .
+
+:ProductionCountryCodeTrait a bamm-c:Trait ;
+   bamm:preferredName "Production Country Code Trait"@en ;
+   bamm:description "Trait to ensure standard data format for country code"@en ;
+   bamm-c:baseCharacteristic :CountryCodeCharacteristic ;
+   bamm-c:constraint :CountryCodeRegularExpression .
+
+:PartIdCharacteristic a bamm:Characteristic ;
+   bamm:preferredName "Part ID Characteristic"@en ;
+   bamm:description "The part ID is a multi-character string, ususally assigned by an ERP system"@en ;
+   bamm:dataType xsd:string .
+
+:PartNameCharacteristic a bamm:Characteristic ;
+   bamm:preferredName "Part Name Characteristic"@en ;
+   bamm:description "Part Name in string format from the respective system in the value chain"@en ;
+   bamm:dataType xsd:string .
+
+:ClassificationCharacteristic a bamm-c:Enumeration ;
+   bamm:preferredName "Classification Characteristic"@en ;
+   bamm:description "A part type must be placed into one of the following classes: 'component', 'product', 'software', 'assembly', 'tool', or 'raw material'."@en ;
+   bamm:see <https://www.iso.org/standard/84667.html> ;
+   bamm:dataType xsd:string ;
+   bamm-c:values ( "product" "raw material" "software" "assembly" "tool" "component" ) .
+
+:CountryCodeCharacteristic a bamm:Characteristic ;
+   bamm:preferredName "Country Code Characteristic"@en ;
+   bamm:description "ISO 3166-1 alpha-3 - three-letter country codes "@en ;
+   bamm:see <https://www.iso.org/iso-3166-country-codes.html> ;
+   bamm:dataType xsd:string .
+
+:CountryCodeRegularExpression a bamm-c:RegularExpressionConstraint ;
+   bamm:preferredName "Country Code Regular Expression"@en ;
+   bamm:description "Regular Expression that ensures a three-letter code "@en ;
+   bamm:value "^[A-Z][A-Z][A-Z]$" .
+

--- a/io.catenax.serial_part/1.0.1/SerialPart.ttl
+++ b/io.catenax.serial_part/1.0.1/SerialPart.ttl
@@ -111,7 +111,7 @@
    bamm:preferredName "Identifier Key"@en ;
    bamm:description "The key of a local identifier. "@en ;
    bamm:characteristic :KeyCharacteristic ;
-   bamm:exampleValue "PartInstanceID" .
+   bamm:exampleValue "partInstanceID" .
 
 :value a bamm:Property ;
    bamm:preferredName "Identifier Value"@en ;

--- a/io.catenax.serial_part/1.0.1/SerialPart.ttl
+++ b/io.catenax.serial_part/1.0.1/SerialPart.ttl
@@ -30,7 +30,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:bamm:io.catenax.serial_part:1.0.0#> .
+@prefix : <urn:bamm:io.catenax.serial_part:1.0.1#> .
 
 :SerialPart a bamm:Aspect ;
    bamm:preferredName "Serial Part"@en ;

--- a/io.catenax.serial_part/1.0.1/metadata.json
+++ b/io.catenax.serial_part/1.0.1/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.serial_part/RELEASE_NOTES.md
+++ b/io.catenax.serial_part/RELEASE_NOTES.md
@@ -3,6 +3,16 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.1]
+### Added
+n/a
+
+### Changed
+- fixed casing in example value for `key` of `localIdentifier` to lower case
+
+### Removed
+n/a
+
 ## [1.0.0]
 ### Added
 - renamed model from `io.catenax.serial_part_typization:2.0.0#SerialPartTypization`
@@ -11,3 +21,4 @@ All notable changes to this model will be documented in this file.
 - changed several descriptions due to aspect renaming
 
 ### Removed
+n/a


### PR DESCRIPTION
## Description
Example value of property key has a mistake in camel casing resulting in wrong JSON example.
fixed casing of example value to `partInstanceId`

Closes #208

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "name" and "description"** in English language. 
- [x] **no duplicate names or preferredNames** within an Aspect (e.g. a Property and the referenced Characteristic should not have the same name)
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
