### PR TITLE
first version of UnsubscribeShopfloorInformation

### DIFF
--- a/io.catenax.mp_standard_unsubscribe/1.0.0/UnsubscribeShopfloorInformation.ttl
+++ b/io.catenax.mp_standard_unsubscribe/1.0.0/UnsubscribeShopfloorInformation.ttl
@@ -1,0 +1,42 @@
+##########################################################################################
+# Copyright (c) 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e. V.
+# Copyright (c) 2023 Siemens AG
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+##########################################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.mp_standard_unsubscribe:1.0.0#> .
+@prefix ext-header: <urn:samm:io.catenax.messaging_header:1.0.0#> .
+
+:UnsubscribeShopfloorInformation a samm:Aspect ;
+   samm:preferredName "UnsubscribeShopfloorInformation"@en ;
+   samm:description "Message to unsubscribe the cyclic or notification communication mode of the GetShopfloorInformation request"@en ;
+   samm:properties ( :unsubscribeMessage ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:unsubscribeMessage a samm:Property ;
+   samm:preferredName "unsubscribeMessage"@en ;
+   samm:description "Message from a customer to unsubscribe the GetShopfloorInformation"@en ;
+   samm:characteristic :CXHeaderCharacteristic .
+
+:CXHeaderCharacteristic a samm:Characteristic ;
+   samm:preferredName "CXHeaderCharacteristic"@en ;
+   samm:description "all information required for a header specified by CX"@en ;
+   samm:dataType ext-header:MessageHeader .
+

--- a/io.catenax.mp_standard_unsubscribe/1.0.0/metadata.json
+++ b/io.catenax.mp_standard_unsubscribe/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release" }

--- a/io.catenax.mp_standard_unsubscribe/RELEASE_NOTES.md
+++ b/io.catenax.mp_standard_unsubscribe/RELEASE_NOTES.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this model will be documented in this file.
+
+## [1.0.0]
+
+- initial version of the aspect model for UnsubscribeShopfloorInformation


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

Closes #232

requires use of header https://github.com/eclipse-tractusx/sldt-semantic-models/pull/227 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] The release date in the Release Note is set to the date of the MS3 approval
