### PR TITLE
chore: add .tractusx metafile

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,6 @@
+product: "Semantic Models"
+leadingRepository: "https://github.com/eclipse-tractusx/sldt-semantic-models"
+repositories:
+- name: "sldt-semantic-models"
+  usage: "reference implementation of SLDT Semantic Models"
+  url: "https://github.com/eclipse-tractusx/sldt-semantic-models"

--- a/.tractusx
+++ b/.tractusx
@@ -2,5 +2,5 @@ product: "Semantic Models"
 leadingRepository: "https://github.com/eclipse-tractusx/sldt-semantic-models"
 repositories:
 - name: "sldt-semantic-models"
-  usage: "reference implementation of SLDT Semantic Models"
+  usage: "SLDT Semantic Models"
   url: "https://github.com/eclipse-tractusx/sldt-semantic-models"


### PR DESCRIPTION
## Addition to our TRG's

This PR adds an initial version of the `.tractusx` metadata file like described in [TRG 2.05](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5).
If there are any other repositories, that are connected to the Semantic Models, that together form a product, please point that out or add the connected repos later on

Fixes #265  
