### PR TITLE
[Model Update]: SingleLevelBomAsBuilt 

### DIFF
--- a/io.catenax.single_level_bom_as_built/2.0.0/SingleLevelBomAsBuilt
+++ b/io.catenax.single_level_bom_as_built/2.0.0/SingleLevelBomAsBuilt
@@ -1,0 +1,152 @@
+#######################################################################
+# Copyright (c) 2022,2023 BASF SE
+# Copyright (c) 2022,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022,2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright (c) 2022,2023 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2022,2023 Henkel AG & Co. KGaA
+# Copyright (c) 2022,2023 Mercedes Benz AG
+# Copyright (c) 2022,2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2022,2023 SAP SE
+# Copyright (c) 2022,2023 Siemens AG
+# Copyright (c) 2022,2023 T-Systems International GmbH
+# Copyright (c) 2022,2023 ZF Friedrichshafen AG
+# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.single_level_bom_as_built:2.0.0#> .
+@prefix undefined: <urn:samm:io.catenax.single_level_bom_as_built:2.0.0#> .
+
+:SingleLevelBomAsBuilt a samm:Aspect ;
+   samm:preferredName "Single Level Bill of Material as Built"@en ;
+   samm:description "The single-level bill of material represents one sub-level of an assembly and does not include any lower-level subassemblies. The as-built lifecycle references all child items as manufactured by the manufacturer referencing only child items in an as-built lifecycle themselves (e.g. serial parts or batches), unless parts can only be tracked by an part ID (on a type level).\n\nIf it is unclear which item has been built-in into the parent item, all potential parts must be listed. This is the case when, e.g. the same item is supplied by two suppliers and the item is only tracked by a customer part ID during assembly, these items can not be differentiated from each other.\n"@en ;
+   samm:properties ( :catenaXId :childItems ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:catenaXId a samm:Property ;
+   samm:preferredName "Catena-X ID"@en ;
+   samm:description "The Catena-X ID of the given part (e.g. the assembly), valid for the Catena-X dataspace."@en ;
+   samm:characteristic :CatenaXIdTraitCharacteristic ;
+   samm:exampleValue "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d" .
+
+:childItems a samm:Property ;
+   samm:preferredName "Child Items"@en ;
+   samm:description "Set of child items, of which the given parent item is assembled by (one structural level down)."@en ;
+   samm:characteristic :SetOfChildItemsCharacteristic .
+
+:CatenaXIdTraitCharacteristic a samm-c:Trait ;
+   samm:description "Trait to ensure UUID v4 data format"@en ;
+   samm-c:baseCharacteristic :Uuidv4Characteristic ;
+   samm-c:constraint :Uuidv4RegularExpression .
+
+:SetOfChildItemsCharacteristic a samm-c:Set ;
+   samm:preferredName "Set of Child Items"@en ;
+   samm:description "Set of child items the parent item is assembled by (one structural level down)."@en ;
+   samm:dataType :ChildData .
+
+:Uuidv4Characteristic a samm:Characteristic ;
+   samm:preferredName "UUID v4 Characteristic"@en ;
+   samm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en ;
+   samm:see <https://tools.ietf.org/html/rfc4122> ;
+   samm:dataType xsd:string .
+
+:Uuidv4RegularExpression a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Catena-X Id Regular Expression"@en ;
+   samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en ;
+   samm:see <https://datatracker.ietf.org/doc/html/rfc4122> ;
+   samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)" .
+
+:ChildData a samm:Entity ;
+   samm:preferredName "Child Data"@en ;
+   samm:description "Catena-X ID and meta data of the assembled child item."@en ;
+   samm:properties ( :createdOn :quantity [ samm:property :lastModifiedOn; samm:optional true ] :catenaXId [ samm:property :businessPartner; samm:optional true ] :hasAlternatives ) .
+
+:createdOn a samm:Property ;
+   samm:preferredName "Created On"@en ;
+   samm:description "Timestamp when the relation between the parent item and the child item was created, e.g. when the serialized child part was assembled into the given part."@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
+
+:quantity a samm:Property ;
+   samm:preferredName "Quantity"@en ;
+   samm:description "Quantity of which the child item is assembled into the parent item. In general it is '1' for serialized parts."@en ;
+   samm:characteristic :QuantityCharacteristic .
+
+:lastModifiedOn a samm:Property ;
+   samm:preferredName "Last Modification Date"@en ;
+   samm:description "Timestamp when the assembly relationship between parent item and child item was last modified."@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
+
+:businessPartner a samm:Property ;
+   samm:preferredName "Business Partner"@en ;
+   samm:description "The supplier of the given child item."@en ;
+   samm:characteristic :BpnTrait ;
+   samm:exampleValue "BPNL50096894aNXY" .
+
+:hasAlternatives a samm:Property ;
+   samm:preferredName "Has Alternatives"@en ;
+   samm:description "Expresses wether the part is built-in or wether it is one of several options. If the value is false, it can be assumend this exact item is built-in. If the value is true, it is unknown wether this or an alternative item is built-in.\nThis is the case when, e.g. the same item is supplied by two suppliers, the item is only tracked by a customer part ID during assembly. Thus, these items can not be differentiated from each other.\n\n"@en ;
+   samm:characteristic undefined:Boolean .
+
+:QuantityCharacteristic a samm-c:Quantifiable ;
+   samm:description "Describes the quantity in which the child item is assembled in the given parent item by providing a quantity value and the measurement unit in which the quantity is measured."@en ;
+   samm:dataType :Quantity .
+
+:BpnTrait a samm-c:Trait ;
+   samm:preferredName "BPN Business Partner Number Trait"@en ;
+   samm-c:baseCharacteristic :BpnCharacteristic ;
+   samm-c:constraint :BpnConstraint .
+
+undefined:Boolean a samm:Characteristic ;
+   samm:preferredName "Boolean"@en ;
+   samm:description "Represents a boolean value (i.e. a \"flag\")."@en ;
+   samm:dataType xsd:boolean .
+
+:Quantity a samm:Entity ;
+   samm:description "Comprises the number of objects and the unit of measurement for the respective child objects"@en ;
+   samm:properties ( :quantityNumber :measurementUnit ) .
+
+:BpnCharacteristic a samm:Characteristic ;
+   samm:preferredName "BPN Characteristic"@en ;
+   samm:dataType xsd:string .
+
+:BpnConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "BPN Constraint"@en ;
+   samm:description "Business Partner Number Regular Expression allowing only BPNL which stands for a legal entity."@en ;
+   samm:value "^(BPNL)([0-9]{8})([a-zA-Z0-9]{4})$" .
+
+:quantityNumber a samm:Property ;
+   samm:preferredName "Quantity Number"@en ;
+   samm:description "The number of objects related to the measurement unit"@en ;
+   samm:characteristic :NumberOfObjects ;
+   samm:exampleValue "2.5"^^xsd:double .
+
+:measurementUnit a samm:Property ;
+   samm:description "Unit of Measurement for the quantity of serialized objects"@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.0.0/appendix/unitcatalog.html> ;
+   samm:characteristic samm-c:UnitReference ;
+   samm:exampleValue "unit:litre"^^samm:curie .
+
+:NumberOfObjects a samm:Characteristic ;
+   samm:description "Quantifiable number of objects in reference to the measurementUnit"@en ;
+   samm:dataType xsd:double .
+

--- a/io.catenax.single_level_bom_as_built/2.0.0/SingleLevelBomAsBuilt.ttl
+++ b/io.catenax.single_level_bom_as_built/2.0.0/SingleLevelBomAsBuilt.ttl
@@ -75,7 +75,7 @@
 :ChildData a samm:Entity ;
    samm:preferredName "Child Data"@en ;
    samm:description "Catena-X ID and meta data of the assembled child item."@en ;
-   samm:properties ( :createdOn :quantity [ samm:property :lastModifiedOn; samm:optional true ] :catenaXId [ samm:property :businessPartner; samm:optional true ] :hasAlternatives ) .
+   samm:properties ( :createdOn :quantity [ samm:property :lastModifiedOn; samm:optional true ] :catenaXId [ samm:property :businessPartner; samm:optional false ] :hasAlternatives ) .
 
 :createdOn a samm:Property ;
    samm:preferredName "Created On"@en ;

--- a/io.catenax.single_level_bom_as_built/2.0.0/SingleLevelBomAsBuilt.ttl
+++ b/io.catenax.single_level_bom_as_built/2.0.0/SingleLevelBomAsBuilt.ttl
@@ -23,7 +23,6 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
-
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
@@ -104,7 +103,7 @@
 :hasAlternatives a samm:Property ;
    samm:preferredName "Has Alternatives"@en ;
    samm:description "Expresses wether the part is built-in or wether it is one of several options. If the value is false, it can be assumend this exact item is built-in. If the value is true, it is unknown wether this or an alternative item is built-in.\nThis is the case when, e.g. the same item is supplied by two suppliers, the item is only tracked by a customer part ID during assembly. Thus, these items can not be differentiated from each other.\n\n"@en ;
-   samm:characteristic undefined:Boolean .
+   samm:characteristic :HasAlternativesCharacteristic .
 
 :QuantityCharacteristic a samm-c:Quantifiable ;
    samm:description "Describes the quantity in which the child item is assembled in the given parent item by providing a quantity value and the measurement unit in which the quantity is measured."@en ;
@@ -114,6 +113,11 @@
    samm:preferredName "BPN Business Partner Number Trait"@en ;
    samm-c:baseCharacteristic :BpnCharacteristic ;
    samm-c:constraint :BpnConstraint .
+
+:HasAlternativesCharacteristic a samm:Characteristic ;
+   samm:preferredName "Has Alternatives Characteristic"@en ;
+   samm:description "Describes the value whether the child data has alternatives."@en ;
+   samm:dataType xsd:boolean .
 
 :Quantity a samm:Entity ;
    samm:description "Comprises the number of objects and the unit of measurement for the respective child objects"@en ;

--- a/io.catenax.single_level_bom_as_built/2.0.0/SingleLevelBomAsBuilt.ttl
+++ b/io.catenax.single_level_bom_as_built/2.0.0/SingleLevelBomAsBuilt.ttl
@@ -32,7 +32,6 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <urn:samm:io.catenax.single_level_bom_as_built:2.0.0#> .
-@prefix undefined: <urn:samm:io.catenax.single_level_bom_as_built:2.0.0#> .
 
 :SingleLevelBomAsBuilt a samm:Aspect ;
    samm:preferredName "Single Level Bill of Material as Built"@en ;
@@ -115,11 +114,6 @@
    samm:preferredName "BPN Business Partner Number Trait"@en ;
    samm-c:baseCharacteristic :BpnCharacteristic ;
    samm-c:constraint :BpnConstraint .
-
-undefined:Boolean a samm:Characteristic ;
-   samm:preferredName "Boolean"@en ;
-   samm:description "Represents a boolean value (i.e. a \"flag\")."@en ;
-   samm:dataType xsd:boolean .
 
 :Quantity a samm:Entity ;
    samm:description "Comprises the number of objects and the unit of measurement for the respective child objects"@en ;

--- a/io.catenax.single_level_bom_as_built/2.0.0/metadata.json
+++ b/io.catenax.single_level_bom_as_built/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.single_level_bom_as_built/RELEASE_NOTES.md
+++ b/io.catenax.single_level_bom_as_built/RELEASE_NOTES.md
@@ -1,9 +1,7 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
-## [Unreleased]
-
-## [2.0.0]
+## [2.0.0] - 25.09.2023
 ### Added
 - property called hasAlternative
 - Boolean characteristic

--- a/io.catenax.single_level_bom_as_built/RELEASE_NOTES.md
+++ b/io.catenax.single_level_bom_as_built/RELEASE_NOTES.md
@@ -3,6 +3,18 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0]
+### Added
+- property called hasAlternative
+- Constraint called BPN and its characteristic
+
+### Changed
+- Description of the main property 'SingleLevelBomAsBuil' was adapted to the new requirements of the model
+
+### Removed
+- 
+
+
 ## [1.0.0]
 ### Added
 - renamed model from `io.catenax.assembly_part_relationship:1.1.1#AssemblyPartRelationship`

--- a/io.catenax.single_level_bom_as_built/RELEASE_NOTES.md
+++ b/io.catenax.single_level_bom_as_built/RELEASE_NOTES.md
@@ -6,7 +6,7 @@ All notable changes to this model will be documented in this file.
 ## [2.0.0]
 ### Added
 - property called hasAlternative
-- Constraint called BPN and its characteristic
+- Boolean characteristic
 
 ### Changed
 - Description of the main property 'SingleLevelBomAsBuil' was adapted to the new requirements of the model


### PR DESCRIPTION
## Description
Major change in in the SingleLevelBomAsBuilt Model. Change was needed due to the required representation of items that are not included in the AsBuilt lifecycle (e.g. Serial parts or batches). Thus, provides the possibility to add parts on a type level. 

 -->

Closes #248 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  BAMM CLI is available [here](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html) and in [GitHub](https://github.com/OpenManufacturingPlatform/sds-sdk/releases)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] The release date in the Release Note is set to the date of the MS3 approval
