### PR TITLE
Batch 2.0.0

### DIFF
--- a/io.catenax.batch/2.0.0/Batch.ttl
+++ b/io.catenax.batch/2.0.0/Batch.ttl
@@ -1,0 +1,180 @@
+#######################################################################
+# Copyright (c) 2022,2023 BASF SE
+# Copyright (c) 2022,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022,2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright (c) 2022,2023 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2022,2023 Henkel AG & Co. KGaA
+# Copyright (c) 2022,2023 Mercedes Benz AG
+# Copyright (c) 2022,2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2022,2023 SAP SE
+# Copyright (c) 2022,2023 Siemens AG
+# Copyright (c) 2022,2023 T-Systems International GmbH
+# Copyright (c) 2022,2023 ZF Friedrichshafen AG
+# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#>.
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#>.
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#>.
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:samm:io.catenax.batch:2.0.0#>.
+@prefix ext-batch: <urn:samm:io.catenax.batch:1.0.2#>.
+@prefix ext-batch2: <urn:samm:io.catenax.batch:1.0.3#>.
+
+:Batch a samm:Aspect;
+    samm:preferredName "Batch"@en;
+    samm:description "A batch is a quantity of (semi-) finished products or (raw) material product that have been produced under the same circumstances (e.g. same production location), as specified groups or amounts, within a certain time frame. Every batch can differ in the number or amount of products. Different batches can have varied specifications, e.g., different colors. A batch is identified via a Batch ID."@en;
+    samm:properties (:catenaXId :localIdentifiers :manufacturingInformation :partTypeInformation);
+    samm:operations ();
+    samm:events ().
+:catenaXId a samm:Property;
+    samm:preferredName "Catena-X Identifier"@en;
+    samm:description "The fully anonymous Catena-X ID of the batch, valid for the Catena-X dataspace."@en;
+    samm:characteristic :CatenaXIdTrait;
+    samm:exampleValue "580d3adf-1981-44a0-a214-13d6ceed9379".
+:localIdentifiers a samm:Property;
+    samm:preferredName "Local Identifiers"@en;
+    samm:description "A local identifier enables identification of a part in a specific dataspace, but is not unique in Catena-X dataspace. Multiple local identifiers may exist."@en;
+    samm:characteristic :LocalIdentifierCharacteristic.
+:manufacturingInformation a samm:Property;
+    samm:preferredName "Manufacturing Information"@en;
+    samm:description "Information from manufacturing process, such as manufacturing date and manufacturing country"@en;
+    samm:characteristic :ManufacturingCharacteristic.
+:partTypeInformation a samm:Property;
+    samm:preferredName "Part Type Information"@en;
+    samm:description "The part type of which the batch has been instantiated of."@en;
+    samm:characteristic :PartTypeInformationCharacteristic.
+:CatenaXIdTrait a samm-c:Trait;
+    samm:preferredName "Catena-X ID Trait"@en;
+    samm:description "Trait to ensure data format for Catena-X ID"@en;
+    samm-c:baseCharacteristic :UUIDv4;
+    samm-c:constraint :UUIDv4RegularExpression.
+:LocalIdentifierCharacteristic a samm-c:Set;
+    samm:preferredName "Local Identifier Characteristic"@en;
+    samm:description "A batch may have multiple attributes, which uniquely identify that batch in a specific dataspace (e.g. the manufacturer`s dataspace)"@en;
+    samm:dataType :KeyValueList.
+:ManufacturingCharacteristic a samm:Characteristic;
+    samm:preferredName "Manufacturing Characteristic"@en;
+    samm:description "Characteristic to describe manufacturing related data"@en;
+    samm:dataType :ManufacturingEntity.
+:PartTypeInformationCharacteristic a samm:Characteristic;
+    samm:preferredName "Part Type Information Characteristic"@en;
+    samm:description "The characteristics of the part type"@en;
+    samm:dataType :PartTypeInformationEntity.
+:UUIDv4 a samm:Characteristic;
+    samm:preferredName "UUIDv4"@en;
+    samm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    samm:dataType xsd:string.
+:UUIDv4RegularExpression a samm-c:RegularExpressionConstraint;
+    samm:preferredName "Catena-X Id Regular Expression"@en;
+    samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en;
+    samm:see <https://datatracker.ietf.org/doc/html/rfc4122>;
+    samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)".
+:KeyValueList a samm:Entity;
+    samm:preferredName "Key Value List"@en;
+    samm:description "A list of key value pairs for local identifiers, which are composed of a key and a corresponding value."@en;
+    samm:properties (:key :value).
+:ManufacturingEntity a samm:Entity;
+    samm:preferredName "Manufacturing Entity"@en;
+    samm:description "Encapsulates the manufacturing relevant attributes"@en;
+    samm:properties (:date [
+  samm:property :country;
+  samm:optional "true"^^xsd:boolean
+]).
+:PartTypeInformationEntity a samm:Entity;
+    samm:preferredName "Part Type Information Entity"@en;
+    samm:description "Encapsulation for data related to the part type"@en;
+    samm:properties (:manufacturerPartId :nameAtManufacturer :classification).
+:key a samm:Property;
+    samm:preferredName "Identifier Key"@en;
+    samm:description "The key of a local identifier. "@en;
+    samm:characteristic :KeyTrait;
+    samm:exampleValue "BatchID".
+:value a samm:Property;
+    samm:preferredName "Identifier Value"@en;
+    samm:description "The value of an identifier."@en;
+    samm:characteristic :ValueCharacteristic;
+    samm:exampleValue "BID12345678".
+:date a samm:Property;
+    samm:preferredName "Production Date"@en;
+    samm:description "Timestamp of the manufacturing date as the final step in production process (e.g. final quality check, ready-for-shipment event)"@en;
+    samm:characteristic samm-c:Timestamp;
+    samm:exampleValue "2022-02-04T14:48:54"^^xsd:dateTime.
+:country a samm:Property;
+    samm:preferredName "Country code"@en;
+    samm:description "Country code where the part was manufactured"@en;
+    samm:characteristic :ProductionCountryCodeTrait;
+    samm:exampleValue "HUR".
+:manufacturerPartId a samm:Property;
+    samm:preferredName "Manufacturer Part ID"@en;
+    samm:description "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part (as designed) in the manufacturer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number or batch number."@en;
+    samm:characteristic :PartIdCharacteristic;
+    samm:exampleValue "123-0.740-3434-A".
+:nameAtManufacturer a samm:Property;
+    samm:preferredName "Name at Manufacturer"@en;
+    samm:description "Name of the part as assigned by the manufacturer"@en;
+    samm:characteristic :PartNameCharacteristic;
+    samm:exampleValue "Mirror left".
+:classification a samm:Property;
+    samm:preferredName "Classifcation"@en;
+    samm:description "The classification of the part type according to STEP standard definition"@en;
+    samm:characteristic :ClassificationCharacteristic;
+    samm:exampleValue "raw material".
+:KeyTrait a samm-c:Trait;
+    samm:preferredName "Key Trait "@en;
+    samm:description "Trait that ensures the usage of predefined keys. "@en;
+    samm-c:baseCharacteristic :KeyCharacteristic;
+    samm-c:constraint ext-batch2:KeyRegularExpression.
+:ValueCharacteristic a samm:Characteristic;
+    samm:preferredName "Value Characteristic"@en;
+    samm:description "The value of an identifier."@en;
+    samm:dataType xsd:string.
+:ProductionCountryCodeTrait a samm-c:Trait;
+    samm:preferredName "Production Country Code Trait"@en;
+    samm:description "Trait to ensure standard data format for country code"@en;
+    samm-c:baseCharacteristic :CountryCodeCharacteristic;
+    samm-c:constraint :CountryCodeRegularExpression.
+:PartIdCharacteristic a samm:Characteristic;
+    samm:preferredName "Part ID Characteristic"@en;
+    samm:description "The part ID is a multi-character string, ususally assigned by an ERP system"@en;
+    samm:dataType xsd:string.
+:PartNameCharacteristic a samm:Characteristic;
+    samm:preferredName "Part Name Characteristic"@en;
+    samm:description "Part Name in string format from the respective system in the value chain"@en;
+    samm:dataType xsd:string.
+:ClassificationCharacteristic a samm-c:Enumeration;
+    samm:preferredName "Classification Characteristic"@en;
+    samm:description "A part type must be placed into one of the following classes: 'component', 'product', 'software', ?assembly?, 'tool', or 'raw material'."@en;
+    samm:dataType xsd:string;
+    samm:see <http://private.pdm-if.org/pdm-if/Frecommended-practices1>;
+    samm-c:values ("product" "raw material" "software" "assembly" "tool" "component").
+:KeyCharacteristic a samm:Characteristic;
+    samm:preferredName "Key Characteristic"@en;
+    samm:description "The key characteristic of a local identifier. A specific subset of keys is predefined. Custom keys are not allowed. Predefined keys:\n- \"manufacturerId\" - The Business Partner Number (BPN) of the manufacturer. Value: BPN-Nummer\n- \"batchId\" - The identifier of the batch, to which the serialzed part belongs"@en;
+    samm:dataType xsd:string.
+ext-batch2:KeyRegularExpression a samm-c:RegularExpressionConstraint;
+    samm:preferredName "Key Regular Expression"@en;
+    samm:description "Constraint that ensures that the predefined keys are used. "@en;
+    samm:value "^(manufacturerId|batchId)$".
+:CountryCodeCharacteristic a samm:Characteristic;
+    samm:preferredName "Country Code Characteristic"@en;
+    samm:description "ISO 3166-1 alpha-3 ? three-letter country codes "@en;
+    samm:dataType xsd:string;
+    samm:see <https://www.iso.org/iso-3166-country-codes.html>.
+:CountryCodeRegularExpression a samm-c:RegularExpressionConstraint;
+    samm:preferredName "Country Code Regular Expression"@en;
+    samm:description "Regular Expression that ensures a three-letter code "@en;
+    samm:value "^[A-Z][A-Z][A-Z]$".

--- a/io.catenax.batch/2.0.0/Batch.ttl
+++ b/io.catenax.batch/2.0.0/Batch.ttl
@@ -135,7 +135,7 @@
     samm:preferredName "Key Trait"@en;
     samm:description "Trait that ensures the usage of predefined keys."@en;
     samm-c:baseCharacteristic :KeyCharacteristic;
-    samm-c:constraint ext-batch2:KeyRegularExpression.
+    samm-c:constraint :KeyRegularExpression.
 :ValueCharacteristic a samm:Characteristic;
     samm:preferredName "Value Characteristic"@en;
     samm:description "The value of an identifier."@en;
@@ -163,7 +163,7 @@
     samm:preferredName "Key Characteristic"@en;
     samm:description "The key characteristic of a local identifier. A specific subset of keys is predefined. Custom keys are not allowed. Predefined keys:\n- \"manufacturerId\" - The Business Partner Number (BPN) of the manufacturer. Value: BPN-Nummer\n- \"batchId\" - The identifier of the batch, to which the serialzed part belongs"@en;
     samm:dataType xsd:string.
-ext-batch2:KeyRegularExpression a samm-c:RegularExpressionConstraint;
+:KeyRegularExpression a samm-c:RegularExpressionConstraint;
     samm:preferredName "Key Regular Expression"@en;
     samm:description "Constraint that ensures that the predefined keys are used."@en;
     samm:value "^(manufacturerId|batchId)$".

--- a/io.catenax.batch/2.0.0/Batch.ttl
+++ b/io.catenax.batch/2.0.0/Batch.ttl
@@ -100,9 +100,9 @@
     samm:properties (:manufacturerPartId :nameAtManufacturer :classification).
 :key a samm:Property;
     samm:preferredName "Identifier Key"@en;
-    samm:description "The key of a local identifier. "@en;
+    samm:description "The key of a local identifier."@en;
     samm:characteristic :KeyTrait;
-    samm:exampleValue "BatchID".
+    samm:exampleValue "batchID".
 :value a samm:Property;
     samm:preferredName "Identifier Value"@en;
     samm:description "The value of an identifier."@en;
@@ -134,8 +134,8 @@
     samm:characteristic :ClassificationCharacteristic;
     samm:exampleValue "raw material".
 :KeyTrait a samm-c:Trait;
-    samm:preferredName "Key Trait "@en;
-    samm:description "Trait that ensures the usage of predefined keys. "@en;
+    samm:preferredName "Key Trait"@en;
+    samm:description "Trait that ensures the usage of predefined keys."@en;
     samm-c:baseCharacteristic :KeyCharacteristic;
     samm-c:constraint ext-batch2:KeyRegularExpression.
 :ValueCharacteristic a samm:Characteristic;
@@ -157,7 +157,7 @@
     samm:dataType xsd:string.
 :ClassificationCharacteristic a samm-c:Enumeration;
     samm:preferredName "Classification Characteristic"@en;
-    samm:description "A part type must be placed into one of the following classes: 'component', 'product', 'software', ?assembly?, 'tool', or 'raw material'."@en;
+    samm:description "A part type must be placed into one of the following classes: 'component', 'product', 'software', 'assembly', 'tool', or 'raw material'."@en;
     samm:dataType xsd:string;
     samm:see <http://private.pdm-if.org/pdm-if/Frecommended-practices1>;
     samm-c:values ("product" "raw material" "software" "assembly" "tool" "component").
@@ -167,14 +167,14 @@
     samm:dataType xsd:string.
 ext-batch2:KeyRegularExpression a samm-c:RegularExpressionConstraint;
     samm:preferredName "Key Regular Expression"@en;
-    samm:description "Constraint that ensures that the predefined keys are used. "@en;
+    samm:description "Constraint that ensures that the predefined keys are used."@en;
     samm:value "^(manufacturerId|batchId)$".
 :CountryCodeCharacteristic a samm:Characteristic;
     samm:preferredName "Country Code Characteristic"@en;
-    samm:description "ISO 3166-1 alpha-3 ? three-letter country codes "@en;
+    samm:description "ISO 3166-1 alpha-3 ? three-letter country codes"@en;
     samm:dataType xsd:string;
     samm:see <https://www.iso.org/iso-3166-country-codes.html>.
 :CountryCodeRegularExpression a samm-c:RegularExpressionConstraint;
     samm:preferredName "Country Code Regular Expression"@en;
-    samm:description "Regular Expression that ensures a three-letter code "@en;
-    samm:value "^[A-Z][A-Z][A-Z]$".
+    samm:description "Regular Expression that ensures a three-letter code"@en;
+    samm:value "^[A-Z]{3}$".

--- a/io.catenax.batch/2.0.0/Batch.ttl
+++ b/io.catenax.batch/2.0.0/Batch.ttl
@@ -31,8 +31,6 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 @prefix : <urn:samm:io.catenax.batch:2.0.0#>.
-@prefix ext-batch: <urn:samm:io.catenax.batch:1.0.2#>.
-@prefix ext-batch2: <urn:samm:io.catenax.batch:1.0.3#>.
 
 :Batch a samm:Aspect;
     samm:preferredName "Batch"@en;

--- a/io.catenax.batch/2.0.0/Batch.ttl
+++ b/io.catenax.batch/2.0.0/Batch.ttl
@@ -100,7 +100,7 @@
     samm:preferredName "Identifier Key"@en;
     samm:description "The key of a local identifier."@en;
     samm:characteristic :KeyTrait;
-    samm:exampleValue "batchID".
+    samm:exampleValue "batchId".
 :value a samm:Property;
     samm:preferredName "Identifier Value"@en;
     samm:description "The value of an identifier."@en;

--- a/io.catenax.batch/2.0.0/metadata.json
+++ b/io.catenax.batch/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{"status": "release"}

--- a/io.catenax.batch/RELEASE_NOTES.md
+++ b/io.catenax.batch/RELEASE_NOTES.md
@@ -8,10 +8,10 @@ All notable changes to this model will be documented in this file.
 
 ### Changed
 - changed description of KeyCharacteristic
-- 
+
 ### Removed
 - properties customerId and nameAtCustomer
-- 
+
 ## [1.0.2] - 2022-11-23
 ### Added
 - initial model

--- a/io.catenax.batch/RELEASE_NOTES.md
+++ b/io.catenax.batch/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
-## [2.0.0] - 2022-08-23
+## [2.0.0] - 2023-09-04
 ### Added
 - added KeyRegularExpression
 

--- a/io.catenax.batch/RELEASE_NOTES.md
+++ b/io.catenax.batch/RELEASE_NOTES.md
@@ -2,7 +2,16 @@
 All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
+## [2.0.0] - 2022-08-23
+### Added
+- added KeyRegularExpression
 
+### Changed
+- changed description of KeyCharacteristic
+- 
+### Removed
+- properties customerId and nameAtCustomer
+- 
 ## [1.0.2] - 2022-11-23
 ### Added
 - initial model


### PR DESCRIPTION
## Description
Updated to Batch 2.0.0. Added Regular expression for KeyCharacteristic and removed properties nameAtCustomer and customerId for compliance reasons. 

 -->

Closes #281

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] The release date in the Release Note is set to the date of the MS3 approval
