### PR TITLE
Follow up SingleLevelBomAsPlanned_2.0.0

### DIFF
--- a/io.catenax.single_level_bom_as_planned/2.0.0/SingleLevelBomAsPlanned.ttl
+++ b/io.catenax.single_level_bom_as_planned/2.0.0/SingleLevelBomAsPlanned.ttl
@@ -76,7 +76,7 @@
 :ChildData a samm:Entity;
    samm:preferredName "Child Data"@en;
    samm:description "Catena-X ID and meta data of the child part."@en;
-   samm:properties (:createdOn :quantity [samm:property :lastModifiedOn; samm:optional true][samm:property :validityPeriod; samm:optional true] :catenaXId [samm:property :businessPartner; samm:optional true]).
+   samm:properties (:createdOn :quantity [samm:property :lastModifiedOn; samm:optional true][samm:property :validityPeriod; samm:optional true] :catenaXId [samm:property :businessPartner; samm:optional false]).
 
 :createdOn a samm:Property;
    samm:preferredName "Created on"@en;

--- a/io.catenax.single_level_bom_as_planned/2.0.0/SingleLevelBomAsPlanned.ttl
+++ b/io.catenax.single_level_bom_as_planned/2.0.0/SingleLevelBomAsPlanned.ttl
@@ -23,149 +23,149 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
-@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
-@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
-@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
-@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix samm: <urn:samm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix samm-c: <urn:samm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix samm-e: <urn:samm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:samm:io.openmanufacturing:unit:2.0.0#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:bamm:io.catenax.single_level_bom_as_planned:2.0.0#> .
+@prefix : <urn:samm:io.catenax.single_level_bom_as_planned:2.0.0#> .
 
-:SingleLevelBomAsPlanned a bamm:Aspect ;
-   bamm:preferredName "Single Level Bill of Material as Planned"@en ;
-   bamm:description "The single-level bill of material (BoM) represents one sub-level of an assembly and does not include any lower-level subassemblies. In the As-Planned lifecycle state all variants are covered (\"120% BoM\").\nIf multiple versions of child parts exist that can be assembled into the same parent part, all versions of the child part are included in the BoM.\nIf there are multiple suppliers for the same child part, each supplier has an entry for their child part in the BoM."@en ;
-   bamm:properties ( :catenaXId :childItems ) ;
-   bamm:operations ( ) ;
-   bamm:events ( ) .
+:SingleLevelBomAsPlanned a samm:Aspect ;
+   samm:preferredName "Single Level Bill of Material as Planned"@en ;
+   samm:description "The single-level bill of material (BoM) represents one sub-level of an assembly and does not include any lower-level subassemblies. In the As-Planned lifecycle state all variants are covered (\"120% BoM\").\nIf multiple versions of child parts exist that can be assembled into the same parent part, all versions of the child part are included in the BoM.\nIf there are multiple suppliers for the same child part, each supplier has an entry for their child part in the BoM."@en ;
+   samm:properties ( :catenaXId :childItems ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
 
-:catenaXId a bamm:Property ;
-   bamm:preferredName "Catena-X Identifier"@en ;
-   bamm:description "The Catena-X ID of the given part (e.g. the component), valid for the Catena-X dataspace."@en ;
-   bamm:characteristic :CatenaXIdTraitCharacteristic ;
-   bamm:exampleValue "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d" .
+:catenaXId a samm:Property ;
+   samm:preferredName "Catena-X Identifier"@en ;
+   samm:description "The Catena-X ID of the given part (e.g. the component), valid for the Catena-X dataspace."@en ;
+   samm:characteristic :CatenaXIdTraitCharacteristic ;
+   samm:exampleValue "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d" .
 
-:childItems a bamm:Property ;
-   bamm:preferredName "Child Items"@en ;
-   bamm:description "Set of child items in As-Planned lifecycle phase, of which the given parent object is assembled by (one structural level down)."@en ;
-   bamm:characteristic :SetOfChildItemsCharacteristic .
+:childItems a samm:Property ;
+   samm:preferredName "Child Items"@en ;
+   samm:description "Set of child items in As-Planned lifecycle phase, of which the given parent object is assembled by (one structural level down)."@en ;
+   samm:characteristic :SetOfChildItemsCharacteristic .
 
-:CatenaXIdTraitCharacteristic a bamm-c:Trait ;
-   bamm:preferredName "Catena-X ID Trait"@en ;
-   bamm:description "Trait to ensure UUID v4 data format"@en ;
-   bamm-c:baseCharacteristic :Uuidv4Characteristic ;
-   bamm-c:constraint :Uuidv4RegularExpression .
+:CatenaXIdTraitCharacteristic a samm-c:Trait ;
+   samm:preferredName "Catena-X ID Trait"@en ;
+   samm:description "Trait to ensure UUID v4 data format"@en ;
+   samm-c:baseCharacteristic :Uuidv4Characteristic ;
+   samm-c:constraint :Uuidv4RegularExpression .
 
-:SetOfChildItemsCharacteristic a bamm-c:Set ;
-   bamm:preferredName "Set of Child Items"@en ;
-   bamm:description "Set of child items the parent object is assembled by (one structural level down)."@en ;
-   bamm:dataType :ChildData .
+:SetOfChildItemsCharacteristic a samm-c:Set ;
+   samm:preferredName "Set of Child Items"@en ;
+   samm:description "Set of child items the parent object is assembled by (one structural level down)."@en ;
+   samm:dataType :ChildData .
 
-:Uuidv4Characteristic a bamm:Characteristic ;
-   bamm:preferredName "UUID v4"@en ;
-   bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en ;
-   bamm:see <https://tools.ietf.org/html/rfc4122> ;
-   bamm:dataType xsd:string .
+:Uuidv4Characteristic a samm:Characteristic ;
+   samm:preferredName "UUID v4"@en ;
+   samm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en ;
+   samm:see <https://tools.ietf.org/html/rfc4122> ;
+   samm:dataType xsd:string .
 
-:Uuidv4RegularExpression a bamm-c:RegularExpressionConstraint ;
-   bamm:preferredName "Catena-X ID Regular Expression"@en ;
-   bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en ;
-   bamm:see <https://datatracker.ietf.org/doc/html/rfc4122> ;
-   bamm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)" .
+:Uuidv4RegularExpression a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Catena-X ID Regular Expression"@en ;
+   samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en ;
+   samm:see <https://datatracker.ietf.org/doc/html/rfc4122> ;
+   samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)" .
 
-:ChildData a bamm:Entity ;
-   bamm:preferredName "Child Data"@en ;
-   bamm:description "Catena-X ID and meta data of the child part."@en ;
-   bamm:properties ( :createdOn :quantity [ bamm:property :lastModifiedOn; bamm:optional true ] [ bamm:property :validityPeriod; bamm:optional true ] :catenaXId [ bamm:property :businessPartner; bamm:optional true ] ) .
+:ChildData a samm:Entity ;
+   samm:preferredName "Child Data"@en ;
+   samm:description "Catena-X ID and meta data of the child part."@en ;
+   samm:properties ( :createdOn :quantity [ samm:property :lastModifiedOn; samm:optional true ] [ samm:property :validityPeriod; samm:optional true ] :catenaXId [ samm:property :businessPartner; samm:optional true ] ) .
 
-:createdOn a bamm:Property ;
-   bamm:preferredName "Created on"@en ;
-   bamm:description "Timestamp when the relation between the parent part and the child part was created"@en ;
-   bamm:characteristic bamm-c:Timestamp ;
-   bamm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
+:createdOn a samm:Property ;
+   samm:preferredName "Created on"@en ;
+   samm:description "Timestamp when the relation between the parent part and the child part was created"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
 
-:quantity a bamm:Property ;
-   bamm:preferredName "Quantity"@en ;
-   bamm:description "Quantity of which the child part is assembled into the parent part."@en ;
-   bamm:characteristic :QuantityCharacteristic .
+:quantity a samm:Property ;
+   samm:preferredName "Quantity"@en ;
+   samm:description "Quantity of which the child part is assembled into the parent part."@en ;
+   samm:characteristic :QuantityCharacteristic .
 
-:lastModifiedOn a bamm:Property ;
-   bamm:preferredName "Last Modified on"@en ;
-   bamm:description "Timestamp when the relationship between parent part and child part was last modified."@en ;
-   bamm:characteristic bamm-c:Timestamp ;
-   bamm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
+:lastModifiedOn a samm:Property ;
+   samm:preferredName "Last Modified on"@en ;
+   samm:description "Timestamp when the relationship between parent part and child part was last modified."@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
 
-:validityPeriod a bamm:Property ;
-   bamm:preferredName "Validity Period"@en ;
-   bamm:description "The period of time during which the parent-child relation is valid. This relates to whether a child part can be built into the parent part at a given time.\nIf no validity period is given the relation is considered valid at any point in time."@en ;
-   bamm:characteristic :ValidityPeriodCharacteristic .
+:validityPeriod a samm:Property ;
+   samm:preferredName "Validity Period"@en ;
+   samm:description "The period of time during which the parent-child relation is valid. This relates to whether a child part can be built into the parent part at a given time.\nIf no validity period is given the relation is considered valid at any point in time."@en ;
+   samm:characteristic :ValidityPeriodCharacteristic .
 
-:businessPartner a bamm:Property ;
-   bamm:preferredName "Business Partner"@en ;
-   bamm:description "The supplier of the given child item."@en ;
-   bamm:characteristic :BpnTrait ;
-   bamm:exampleValue "BPNL50096894aNXY" .
+:businessPartner a samm:Property ;
+   samm:preferredName "Business Partner"@en ;
+   samm:description "The supplier of the given child item."@en ;
+   samm:characteristic :BpnTrait ;
+   samm:exampleValue "BPNL50096894aNXY" .
 
-:QuantityCharacteristic a bamm-c:Quantifiable ;
-   bamm:preferredName "Quantity Characteristic"@en ;
-   bamm:description "Describes the quantity in which the child part is assembled in the given parent object by providing a quantity value and the measurement unit in which the quantity is measured."@en ;
-   bamm:dataType :Quantity .
+:QuantityCharacteristic a samm-c:Quantifiable ;
+   samm:preferredName "Quantity Characteristic"@en ;
+   samm:description "Describes the quantity in which the child part is assembled in the given parent object by providing a quantity value and the measurement unit in which the quantity is measured."@en ;
+   samm:dataType :Quantity .
 
-:BpnTrait a bamm-c:Trait ;
-   bamm:preferredName "BPN Business Partner Number Trait"@en ;
-   bamm-c:baseCharacteristic :BpnCharacteristic ;
-   bamm-c:constraint :BpnConstraint .
+:BpnTrait a samm-c:Trait ;
+   samm:preferredName "BPN Business Partner Number Trait"@en ;
+   samm-c:baseCharacteristic :BpnCharacteristic ;
+   samm-c:constraint :BpnConstraint .
 
-:BpnCharacteristic a bamm:Characteristic ;
-   bamm:preferredName "BPN Characteristic"@en ;
-   bamm:dataType xsd:string .
+:BpnCharacteristic a samm:Characteristic ;
+   samm:preferredName "BPN Characteristic"@en ;
+   samm:dataType xsd:string .
 
-:BpnConstraint a bamm-c:RegularExpressionConstraint ;
-   bamm:preferredName "BPN Constraint"@en ;
-   bamm:description "Business Partner Number Regular Expression allowing only BPNL which stands for a legal entity."@en ;
-   bamm:value "^(BPNL)([0-9]{8})([a-zA-Z0-9]{4})$" .
+:BpnConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "BPN Constraint"@en ;
+   samm:description "Business Partner Number Regular Expression allowing only BPNL which stands for a legal entity."@en ;
+   samm:value "^(BPNL)([0-9]{8})([a-zA-Z0-9]{4})$" .
 
-:ValidityPeriodCharacteristic a bamm:Characteristic ;
-   bamm:preferredName "Validity Period Characteristic"@en ;
-   bamm:description "Characteristic for a validity period defined by an (optional) start and an (optional) end timestamp."@en ;
-   bamm:dataType :ValidityPeriodEntity .
+:ValidityPeriodCharacteristic a samm:Characteristic ;
+   samm:preferredName "Validity Period Characteristic"@en ;
+   samm:description "Characteristic for a validity period defined by an (optional) start and an (optional) end timestamp."@en ;
+   samm:dataType :ValidityPeriodEntity .
 
-:Quantity a bamm:Entity ;
-   bamm:preferredName "Quantity"@en ;
-   bamm:description "Comprises the number of objects and the unit of measurement for the respective child objects"@en ;
-   bamm:properties ( :quantityNumber :measurementUnit ) .
+:Quantity a samm:Entity ;
+   samm:preferredName "Quantity"@en ;
+   samm:description "Comprises the number of objects and the unit of measurement for the respective child objects"@en ;
+   samm:properties ( :quantityNumber :measurementUnit ) .
 
-:ValidityPeriodEntity a bamm:Entity ;
-   bamm:preferredName "Validity Period Entity"@en ;
-   bamm:description "If a validity period only has a start that means that the period is valid from the start date without a (yet) defined enddate and vice versa."@en ;
-   bamm:properties ( [ bamm:property :validFrom; bamm:optional true ] [ bamm:property :validTo; bamm:optional true ] ) .
+:ValidityPeriodEntity a samm:Entity ;
+   samm:preferredName "Validity Period Entity"@en ;
+   samm:description "If a validity period only has a start that means that the period is valid from the start date without a (yet) defined enddate and vice versa."@en ;
+   samm:properties ( [ samm:property :validFrom; samm:optional true ] [ samm:property :validTo; samm:optional true ] ) .
 
-:quantityNumber a bamm:Property ;
-   bamm:preferredName "Quantity Number"@en ;
-   bamm:description "The number of objects related to the measurement unit"@en ;
-   bamm:characteristic :NumberofObjects ;
-   bamm:exampleValue "2.5"^^xsd:double .
+:quantityNumber a samm:Property ;
+   samm:preferredName "Quantity Number"@en ;
+   samm:description "The number of objects related to the measurement unit"@en ;
+   samm:characteristic :NumberofObjects ;
+   samm:exampleValue "2.5"^^xsd:double .
 
-:measurementUnit a bamm:Property ;
-   bamm:preferredName "Measurement Unit"@en ;
-   bamm:description "Unit of measurement for the quantity of objects.\nIf possible, use units from the aspect meta model unit catalog, which is based on the UNECE Recommendation No. 20 \"Codes for Units of Measure used in International Trade\"."@en ;
-   bamm:see <https://eclipse-esmf.github.io/samm-specification/2.0.0/appendix/unitcatalog.html> ;
-   bamm:characteristic bamm-c:UnitReference ;
-   bamm:exampleValue "unit:litre"^^bamm:curie .
+:measurementUnit a samm:Property ;
+   samm:preferredName "Measurement Unit"@en ;
+   samm:description "Unit of measurement for the quantity of objects.\nIf possible, use units from the aspect meta model unit catalog, which is based on the UNECE Recommendation No. 20 \"Codes for Units of Measure used in International Trade\"."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.0.0/appendix/unitcatalog.html> ;
+   samm:characteristic samm-c:UnitReference ;
+   samm:exampleValue "unit:litre"^^samm:curie .
 
-:validFrom a bamm:Property ;
-   bamm:preferredName "Valid from"@en ;
-   bamm:description "Start date of validity period"@en ;
-   bamm:characteristic bamm-c:Timestamp ;
-   bamm:exampleValue "2023-03-21T08:17:29.187+01:00"^^xsd:dateTime .
+:validFrom a samm:Property ;
+   samm:preferredName "Valid from"@en ;
+   samm:description "Start date of validity period"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-03-21T08:17:29.187+01:00"^^xsd:dateTime .
 
-:validTo a bamm:Property ;
-   bamm:preferredName "Valid to"@en ;
-   bamm:description "End date of validity period"@en ;
-   bamm:characteristic bamm-c:Timestamp ;
-   bamm:exampleValue "2024-07-01T16:10:00.000+01:00"^^xsd:dateTime .
+:validTo a samm:Property ;
+   samm:preferredName "Valid to"@en ;
+   samm:description "End date of validity period"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2024-07-01T16:10:00.000+01:00"^^xsd:dateTime .
 
-:NumberofObjects a bamm:Characteristic ;
-   bamm:preferredName "Number of Objects"@en ;
-   bamm:description "Quantifiable number of objects in reference to the measurementUnit"@en ;
-   bamm:dataType xsd:double .
+:NumberofObjects a samm:Characteristic ;
+   samm:preferredName "Number of Objects"@en ;
+   samm:description "Quantifiable number of objects in reference to the measurementUnit"@en ;
+   samm:dataType xsd:double .

--- a/io.catenax.single_level_bom_as_planned/2.0.0/SingleLevelBomAsPlanned.ttl
+++ b/io.catenax.single_level_bom_as_planned/2.0.0/SingleLevelBomAsPlanned.ttl
@@ -23,149 +23,149 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
-@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
-@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
-@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
-@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.single_level_bom_as_planned:2.0.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#>.
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#>.
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#>.
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:samm:io.catenax.single_level_bom_as_planned:2.0.0#>.
 
-:SingleLevelBomAsPlanned a samm:Aspect ;
-   samm:preferredName "Single Level Bill of Material as Planned"@en ;
-   samm:description "The single-level bill of material (BoM) represents one sub-level of an assembly and does not include any lower-level subassemblies. In the As-Planned lifecycle state all variants are covered (\"120% BoM\").\nIf multiple versions of child parts exist that can be assembled into the same parent part, all versions of the child part are included in the BoM.\nIf there are multiple suppliers for the same child part, each supplier has an entry for their child part in the BoM."@en ;
-   samm:properties ( :catenaXId :childItems ) ;
-   samm:operations ( ) ;
-   samm:events ( ) .
+:SingleLevelBomAsPlanned a samm:Aspect;
+   samm:preferredName "Single Level Bill of Material as Planned"@en;
+   samm:description "The single-level bill of material (BoM) represents one sub-level of an assembly and does not include any lower-level subassemblies. In the As-Planned lifecycle state all variants are covered (\"120% BoM\").\nIf multiple versions of child parts exist that can be assembled into the same parent part, all versions of the child part are included in the BoM.\nIf there are multiple suppliers for the same child part, each supplier has an entry for their child part in the BoM."@en;
+   samm:properties (:catenaXId :childItems);
+   samm:operations ();
+   samm:events ().
 
-:catenaXId a samm:Property ;
-   samm:preferredName "Catena-X Identifier"@en ;
-   samm:description "The Catena-X ID of the given part (e.g. the component), valid for the Catena-X dataspace."@en ;
-   samm:characteristic :CatenaXIdTraitCharacteristic ;
-   samm:exampleValue "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d" .
+:catenaXId a samm:Property;
+   samm:preferredName "Catena-X Identifier"@en;
+   samm:description "The Catena-X ID of the given part (e.g. the component), valid for the Catena-X dataspace."@en;
+   samm:characteristic :CatenaXIdTraitCharacteristic;
+   samm:exampleValue "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d".
 
-:childItems a samm:Property ;
-   samm:preferredName "Child Items"@en ;
-   samm:description "Set of child items in As-Planned lifecycle phase, of which the given parent object is assembled by (one structural level down)."@en ;
-   samm:characteristic :SetOfChildItemsCharacteristic .
+:childItems a samm:Property;
+   samm:preferredName "Child Items"@en;
+   samm:description "Set of child items in As-Planned lifecycle phase, of which the given parent object is assembled by (one structural level down)."@en;
+   samm:characteristic :SetOfChildItemsCharacteristic.
 
-:CatenaXIdTraitCharacteristic a samm-c:Trait ;
-   samm:preferredName "Catena-X ID Trait"@en ;
-   samm:description "Trait to ensure UUID v4 data format"@en ;
-   samm-c:baseCharacteristic :Uuidv4Characteristic ;
-   samm-c:constraint :Uuidv4RegularExpression .
+:CatenaXIdTraitCharacteristic a samm-c:Trait;
+   samm:preferredName "Catena-X ID Trait"@en;
+   samm:description "Trait to ensure UUID v4 data format"@en;
+   samm-c:baseCharacteristic :Uuidv4Characteristic;
+   samm-c:constraint :Uuidv4RegularExpression.
 
-:SetOfChildItemsCharacteristic a samm-c:Set ;
-   samm:preferredName "Set of Child Items"@en ;
-   samm:description "Set of child items the parent object is assembled by (one structural level down)."@en ;
-   samm:dataType :ChildData .
+:SetOfChildItemsCharacteristic a samm-c:Set;
+   samm:preferredName "Set of Child Items"@en;
+   samm:description "Set of child items the parent object is assembled by (one structural level down)."@en;
+   samm:dataType :ChildData.
 
-:Uuidv4Characteristic a samm:Characteristic ;
-   samm:preferredName "UUID v4"@en ;
-   samm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en ;
-   samm:see <https://tools.ietf.org/html/rfc4122> ;
-   samm:dataType xsd:string .
+:Uuidv4Characteristic a samm:Characteristic;
+   samm:preferredName "UUID v4"@en;
+   samm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+   samm:see <https://tools.ietf.org/html/rfc4122>;
+   samm:dataType xsd:string.
 
-:Uuidv4RegularExpression a samm-c:RegularExpressionConstraint ;
-   samm:preferredName "Catena-X ID Regular Expression"@en ;
-   samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en ;
-   samm:see <https://datatracker.ietf.org/doc/html/rfc4122> ;
-   samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)" .
+:Uuidv4RegularExpression a samm-c:RegularExpressionConstraint;
+   samm:preferredName "Catena-X ID Regular Expression"@en;
+   samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en;
+   samm:see <https://datatracker.ietf.org/doc/html/rfc4122>;
+   samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)".
 
-:ChildData a samm:Entity ;
-   samm:preferredName "Child Data"@en ;
-   samm:description "Catena-X ID and meta data of the child part."@en ;
-   samm:properties ( :createdOn :quantity [ samm:property :lastModifiedOn; samm:optional true ] [ samm:property :validityPeriod; samm:optional true ] :catenaXId [ samm:property :businessPartner; samm:optional true ] ) .
+:ChildData a samm:Entity;
+   samm:preferredName "Child Data"@en;
+   samm:description "Catena-X ID and meta data of the child part."@en;
+   samm:properties (:createdOn :quantity [samm:property :lastModifiedOn; samm:optional true][samm:property :validityPeriod; samm:optional true] :catenaXId [samm:property :businessPartner; samm:optional true]).
 
-:createdOn a samm:Property ;
-   samm:preferredName "Created on"@en ;
-   samm:description "Timestamp when the relation between the parent part and the child part was created"@en ;
-   samm:characteristic samm-c:Timestamp ;
-   samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
+:createdOn a samm:Property;
+   samm:preferredName "Created on"@en;
+   samm:description "Timestamp when the relation between the parent part and the child part was created"@en;
+   samm:characteristic samm-c:Timestamp;
+   samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime.
 
-:quantity a samm:Property ;
-   samm:preferredName "Quantity"@en ;
-   samm:description "Quantity of which the child part is assembled into the parent part."@en ;
-   samm:characteristic :QuantityCharacteristic .
+:quantity a samm:Property;
+   samm:preferredName "Quantity"@en;
+   samm:description "Quantity of which the child part is assembled into the parent part."@en;
+   samm:characteristic :QuantityCharacteristic.
 
-:lastModifiedOn a samm:Property ;
-   samm:preferredName "Last Modified on"@en ;
-   samm:description "Timestamp when the relationship between parent part and child part was last modified."@en ;
-   samm:characteristic samm-c:Timestamp ;
-   samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
+:lastModifiedOn a samm:Property;
+   samm:preferredName "Last Modified on"@en;
+   samm:description "Timestamp when the relationship between parent part and child part was last modified."@en;
+   samm:characteristic samm-c:Timestamp;
+   samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime.
 
-:validityPeriod a samm:Property ;
-   samm:preferredName "Validity Period"@en ;
-   samm:description "The period of time during which the parent-child relation is valid. This relates to whether a child part can be built into the parent part at a given time.\nIf no validity period is given the relation is considered valid at any point in time."@en ;
-   samm:characteristic :ValidityPeriodCharacteristic .
+:validityPeriod a samm:Property;
+   samm:preferredName "Validity Period"@en;
+   samm:description "The period of time during which the parent-child relation is valid. This relates to whether a child part can be built into the parent part at a given time.\nIf no validity period is given the relation is considered valid at any point in time."@en;
+   samm:characteristic :ValidityPeriodCharacteristic.
 
-:businessPartner a samm:Property ;
-   samm:preferredName "Business Partner"@en ;
-   samm:description "The supplier of the given child item."@en ;
-   samm:characteristic :BpnTrait ;
-   samm:exampleValue "BPNL50096894aNXY" .
+:businessPartner a samm:Property;
+   samm:preferredName "Business Partner"@en;
+   samm:description "The supplier of the given child item."@en;
+   samm:characteristic :BpnTrait;
+   samm:exampleValue "BPNL50096894aNXY".
 
-:QuantityCharacteristic a samm-c:Quantifiable ;
-   samm:preferredName "Quantity Characteristic"@en ;
-   samm:description "Describes the quantity in which the child part is assembled in the given parent object by providing a quantity value and the measurement unit in which the quantity is measured."@en ;
-   samm:dataType :Quantity .
+:QuantityCharacteristic a samm-c:Quantifiable;
+   samm:preferredName "Quantity Characteristic"@en;
+   samm:description "Describes the quantity in which the child part is assembled in the given parent object by providing a quantity value and the measurement unit in which the quantity is measured."@en;
+   samm:dataType :Quantity.
 
-:BpnTrait a samm-c:Trait ;
-   samm:preferredName "BPN Business Partner Number Trait"@en ;
-   samm-c:baseCharacteristic :BpnCharacteristic ;
-   samm-c:constraint :BpnConstraint .
+:BpnTrait a samm-c:Trait;
+   samm:preferredName "BPN Business Partner Number Trait"@en;
+   samm-c:baseCharacteristic :BpnCharacteristic;
+   samm-c:constraint :BpnConstraint.
 
-:BpnCharacteristic a samm:Characteristic ;
-   samm:preferredName "BPN Characteristic"@en ;
-   samm:dataType xsd:string .
+:BpnCharacteristic a samm:Characteristic;
+   samm:preferredName "BPN Characteristic"@en;
+   samm:dataType xsd:string.
 
-:BpnConstraint a samm-c:RegularExpressionConstraint ;
-   samm:preferredName "BPN Constraint"@en ;
-   samm:description "Business Partner Number Regular Expression allowing only BPNL which stands for a legal entity."@en ;
-   samm:value "^(BPNL)([0-9]{8})([a-zA-Z0-9]{4})$" .
+:BpnConstraint a samm-c:RegularExpressionConstraint;
+   samm:preferredName "BPN Constraint"@en;
+   samm:description "Business Partner Number Regular Expression allowing only BPNL which stands for a legal entity."@en;
+   samm:value "^(BPNL)([0-9]{8})([a-zA-Z0-9]{4})$".
 
-:ValidityPeriodCharacteristic a samm:Characteristic ;
-   samm:preferredName "Validity Period Characteristic"@en ;
-   samm:description "Characteristic for a validity period defined by an (optional) start and an (optional) end timestamp."@en ;
-   samm:dataType :ValidityPeriodEntity .
+:ValidityPeriodCharacteristic a samm:Characteristic;
+   samm:preferredName "Validity Period Characteristic"@en;
+   samm:description "Characteristic for a validity period defined by an (optional) start and an (optional) end timestamp."@en;
+   samm:dataType :ValidityPeriodEntity.
 
-:Quantity a samm:Entity ;
-   samm:preferredName "Quantity"@en ;
-   samm:description "Comprises the number of objects and the unit of measurement for the respective child objects"@en ;
-   samm:properties ( :quantityNumber :measurementUnit ) .
+:Quantity a samm:Entity;
+   samm:preferredName "Quantity"@en;
+   samm:description "Comprises the number of objects and the unit of measurement for the respective child objects"@en;
+   samm:properties (:quantityNumber :measurementUnit).
 
-:ValidityPeriodEntity a samm:Entity ;
-   samm:preferredName "Validity Period Entity"@en ;
-   samm:description "If a validity period only has a start that means that the period is valid from the start date without a (yet) defined enddate and vice versa."@en ;
-   samm:properties ( [ samm:property :validFrom; samm:optional true ] [ samm:property :validTo; samm:optional true ] ) .
+:ValidityPeriodEntity a samm:Entity;
+   samm:preferredName "Validity Period Entity"@en;
+   samm:description "If a validity period only has a start that means that the period is valid from the start date without a (yet) defined enddate and vice versa."@en;
+   samm:properties ([samm:property :validFrom; samm:optional true][samm:property :validTo; samm:optional true]).
 
-:quantityNumber a samm:Property ;
-   samm:preferredName "Quantity Number"@en ;
-   samm:description "The number of objects related to the measurement unit"@en ;
-   samm:characteristic :NumberofObjects ;
-   samm:exampleValue "2.5"^^xsd:double .
+:quantityNumber a samm:Property;
+   samm:preferredName "Quantity Number"@en;
+   samm:description "The number of objects related to the measurement unit"@en;
+   samm:characteristic :NumberofObjects;
+   samm:exampleValue "2.5"^^xsd:double.
 
-:measurementUnit a samm:Property ;
-   samm:preferredName "Measurement Unit"@en ;
-   samm:description "Unit of measurement for the quantity of objects.\nIf possible, use units from the aspect meta model unit catalog, which is based on the UNECE Recommendation No. 20 \"Codes for Units of Measure used in International Trade\"."@en ;
-   samm:see <https://eclipse-esmf.github.io/samm-specification/2.0.0/appendix/unitcatalog.html> ;
-   samm:characteristic samm-c:UnitReference ;
-   samm:exampleValue "unit:litre"^^samm:curie .
+:measurementUnit a samm:Property;
+   samm:preferredName "Measurement Unit"@en;
+   samm:description "Unit of measurement for the quantity of objects.\nIf possible, use units from the aspect meta model unit catalog, which is based on the UNECE Recommendation No. 20 \"Codes for Units of Measure used in International Trade\"."@en;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.0.0/appendix/unitcatalog.html>;
+   samm:characteristic samm-c:UnitReference;
+   samm:exampleValue "unit:litre"^^samm:curie.
 
-:validFrom a samm:Property ;
-   samm:preferredName "Valid from"@en ;
-   samm:description "Start date of validity period"@en ;
-   samm:characteristic samm-c:Timestamp ;
-   samm:exampleValue "2023-03-21T08:17:29.187+01:00"^^xsd:dateTime .
+:validFrom a samm:Property;
+   samm:preferredName "Valid from"@en;
+   samm:description "Start date of validity period"@en;
+   samm:characteristic samm-c:Timestamp;
+   samm:exampleValue "2023-03-21T08:17:29.187+01:00"^^xsd:dateTime.
 
-:validTo a samm:Property ;
-   samm:preferredName "Valid to"@en ;
-   samm:description "End date of validity period"@en ;
-   samm:characteristic samm-c:Timestamp ;
-   samm:exampleValue "2024-07-01T16:10:00.000+01:00"^^xsd:dateTime .
+:validTo a samm:Property;
+   samm:preferredName "Valid to"@en;
+   samm:description "End date of validity period"@en;
+   samm:characteristic samm-c:Timestamp;
+   samm:exampleValue "2024-07-01T16:10:00.000+01:00"^^xsd:dateTime.
 
-:NumberofObjects a samm:Characteristic ;
-   samm:preferredName "Number of Objects"@en ;
-   samm:description "Quantifiable number of objects in reference to the measurementUnit"@en ;
-   samm:dataType xsd:double .
+:NumberofObjects a samm:Characteristic;
+   samm:preferredName "Number of Objects"@en;
+   samm:description "Quantifiable number of objects in reference to the measurementUnit"@en;
+   samm:dataType xsd:double.

--- a/io.catenax.single_level_bom_as_planned/2.0.0/SingleLevelBomAsPlanned.ttl
+++ b/io.catenax.single_level_bom_as_planned/2.0.0/SingleLevelBomAsPlanned.ttl
@@ -23,10 +23,10 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
-@prefix samm: <urn:samm:io.openmanufacturing:meta-model:2.0.0#>.
-@prefix samm-c: <urn:samm:io.openmanufacturing:characteristic:2.0.0#>.
-@prefix samm-e: <urn:samm:io.openmanufacturing:entity:2.0.0#>.
-@prefix unit: <urn:samm:io.openmanufacturing:unit:2.0.0#>.
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

--- a/io.catenax.single_level_bom_as_planned/2.0.0/SingleLevelBomAsPlanned.ttl
+++ b/io.catenax.single_level_bom_as_planned/2.0.0/SingleLevelBomAsPlanned.ttl
@@ -1,0 +1,171 @@
+######################################################################
+# Copyright (c) 2022, 2023 BASF SE
+# Copyright (c) 2022, 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022, 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright (c) 2022, 2023 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2022, 2023 Henkel AG & Co. KGaA
+# Copyright (c) 2022, 2023 Mercedes Benz AG
+# Copyright (c) 2022, 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2022, 2023 SAP SE
+# Copyright (c) 2022, 2023 Siemens AG
+# Copyright (c) 2022, 2023 T-Systems International GmbH
+# Copyright (c) 2022, 2023 ZF Friedrichshafen AG
+# Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#>.
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#>.
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#>.
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:bamm:io.catenax.single_level_bom_as_planned:2.0.0#> .
+
+:SingleLevelBomAsPlanned a bamm:Aspect ;
+   bamm:preferredName "Single Level Bill of Material as Planned"@en ;
+   bamm:description "The single-level bill of material (BoM) represents one sub-level of an assembly and does not include any lower-level subassemblies. In the As-Planned lifecycle state all variants are covered (\"120% BoM\").\nIf multiple versions of child parts exist that can be assembled into the same parent part, all versions of the child part are included in the BoM.\nIf there are multiple suppliers for the same child part, each supplier has an entry for their child part in the BoM."@en ;
+   bamm:properties ( :catenaXId :childItems ) ;
+   bamm:operations ( ) ;
+   bamm:events ( ) .
+
+:catenaXId a bamm:Property ;
+   bamm:preferredName "Catena-X Identifier"@en ;
+   bamm:description "The Catena-X ID of the given part (e.g. the component), valid for the Catena-X dataspace."@en ;
+   bamm:characteristic :CatenaXIdTraitCharacteristic ;
+   bamm:exampleValue "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d" .
+
+:childItems a bamm:Property ;
+   bamm:preferredName "Child Items"@en ;
+   bamm:description "Set of child items in As-Planned lifecycle phase, of which the given parent object is assembled by (one structural level down)."@en ;
+   bamm:characteristic :SetOfChildItemsCharacteristic .
+
+:CatenaXIdTraitCharacteristic a bamm-c:Trait ;
+   bamm:preferredName "Catena-X ID Trait"@en ;
+   bamm:description "Trait to ensure UUID v4 data format"@en ;
+   bamm-c:baseCharacteristic :Uuidv4Characteristic ;
+   bamm-c:constraint :Uuidv4RegularExpression .
+
+:SetOfChildItemsCharacteristic a bamm-c:Set ;
+   bamm:preferredName "Set of Child Items"@en ;
+   bamm:description "Set of child items the parent object is assembled by (one structural level down)."@en ;
+   bamm:dataType :ChildData .
+
+:Uuidv4Characteristic a bamm:Characteristic ;
+   bamm:preferredName "UUID v4"@en ;
+   bamm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en ;
+   bamm:see <https://tools.ietf.org/html/rfc4122> ;
+   bamm:dataType xsd:string .
+
+:Uuidv4RegularExpression a bamm-c:RegularExpressionConstraint ;
+   bamm:preferredName "Catena-X ID Regular Expression"@en ;
+   bamm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en ;
+   bamm:see <https://datatracker.ietf.org/doc/html/rfc4122> ;
+   bamm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)" .
+
+:ChildData a bamm:Entity ;
+   bamm:preferredName "Child Data"@en ;
+   bamm:description "Catena-X ID and meta data of the child part."@en ;
+   bamm:properties ( :createdOn :quantity [ bamm:property :lastModifiedOn; bamm:optional true ] [ bamm:property :validityPeriod; bamm:optional true ] :catenaXId [ bamm:property :businessPartner; bamm:optional true ] ) .
+
+:createdOn a bamm:Property ;
+   bamm:preferredName "Created on"@en ;
+   bamm:description "Timestamp when the relation between the parent part and the child part was created"@en ;
+   bamm:characteristic bamm-c:Timestamp ;
+   bamm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
+
+:quantity a bamm:Property ;
+   bamm:preferredName "Quantity"@en ;
+   bamm:description "Quantity of which the child part is assembled into the parent part."@en ;
+   bamm:characteristic :QuantityCharacteristic .
+
+:lastModifiedOn a bamm:Property ;
+   bamm:preferredName "Last Modified on"@en ;
+   bamm:description "Timestamp when the relationship between parent part and child part was last modified."@en ;
+   bamm:characteristic bamm-c:Timestamp ;
+   bamm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
+
+:validityPeriod a bamm:Property ;
+   bamm:preferredName "Validity Period"@en ;
+   bamm:description "The period of time during which the parent-child relation is valid. This relates to whether a child part can be built into the parent part at a given time.\nIf no validity period is given the relation is considered valid at any point in time."@en ;
+   bamm:characteristic :ValidityPeriodCharacteristic .
+
+:businessPartner a bamm:Property ;
+   bamm:preferredName "Business Partner"@en ;
+   bamm:description "The supplier of the given child item."@en ;
+   bamm:characteristic :BpnTrait ;
+   bamm:exampleValue "BPNL50096894aNXY" .
+
+:QuantityCharacteristic a bamm-c:Quantifiable ;
+   bamm:preferredName "Quantity Characteristic"@en ;
+   bamm:description "Describes the quantity in which the child part is assembled in the given parent object by providing a quantity value and the measurement unit in which the quantity is measured."@en ;
+   bamm:dataType :Quantity .
+
+:BpnTrait a bamm-c:Trait ;
+   bamm:preferredName "BPN Business Partner Number Trait"@en ;
+   bamm-c:baseCharacteristic :BpnCharacteristic ;
+   bamm-c:constraint :BpnConstraint .
+
+:BpnCharacteristic a bamm:Characteristic ;
+   bamm:preferredName "BPN Characteristic"@en ;
+   bamm:dataType xsd:string .
+
+:BpnConstraint a bamm-c:RegularExpressionConstraint ;
+   bamm:preferredName "BPN Constraint"@en ;
+   bamm:description "Business Partner Number Regular Expression allowing only BPNL which stands for a legal entity."@en ;
+   bamm:value "^(BPNL)([0-9]{8})([a-zA-Z0-9]{4})$" .
+
+:ValidityPeriodCharacteristic a bamm:Characteristic ;
+   bamm:preferredName "Validity Period Characteristic"@en ;
+   bamm:description "Characteristic for a validity period defined by an (optional) start and an (optional) end timestamp."@en ;
+   bamm:dataType :ValidityPeriodEntity .
+
+:Quantity a bamm:Entity ;
+   bamm:preferredName "Quantity"@en ;
+   bamm:description "Comprises the number of objects and the unit of measurement for the respective child objects"@en ;
+   bamm:properties ( :quantityNumber :measurementUnit ) .
+
+:ValidityPeriodEntity a bamm:Entity ;
+   bamm:preferredName "Validity Period Entity"@en ;
+   bamm:description "If a validity period only has a start that means that the period is valid from the start date without a (yet) defined enddate and vice versa."@en ;
+   bamm:properties ( [ bamm:property :validFrom; bamm:optional true ] [ bamm:property :validTo; bamm:optional true ] ) .
+
+:quantityNumber a bamm:Property ;
+   bamm:preferredName "Quantity Number"@en ;
+   bamm:description "The number of objects related to the measurement unit"@en ;
+   bamm:characteristic :NumberofObjects ;
+   bamm:exampleValue "2.5"^^xsd:double .
+
+:measurementUnit a bamm:Property ;
+   bamm:preferredName "Measurement Unit"@en ;
+   bamm:description "Unit of measurement for the quantity of objects.\nIf possible, use units from the aspect meta model unit catalog, which is based on the UNECE Recommendation No. 20 \"Codes for Units of Measure used in International Trade\"."@en ;
+   bamm:see <https://eclipse-esmf.github.io/samm-specification/2.0.0/appendix/unitcatalog.html> ;
+   bamm:characteristic bamm-c:UnitReference ;
+   bamm:exampleValue "unit:litre"^^bamm:curie .
+
+:validFrom a bamm:Property ;
+   bamm:preferredName "Valid from"@en ;
+   bamm:description "Start date of validity period"@en ;
+   bamm:characteristic bamm-c:Timestamp ;
+   bamm:exampleValue "2023-03-21T08:17:29.187+01:00"^^xsd:dateTime .
+
+:validTo a bamm:Property ;
+   bamm:preferredName "Valid to"@en ;
+   bamm:description "End date of validity period"@en ;
+   bamm:characteristic bamm-c:Timestamp ;
+   bamm:exampleValue "2024-07-01T16:10:00.000+01:00"^^xsd:dateTime .
+
+:NumberofObjects a bamm:Characteristic ;
+   bamm:preferredName "Number of Objects"@en ;
+   bamm:description "Quantifiable number of objects in reference to the measurementUnit"@en ;
+   bamm:dataType xsd:double .

--- a/io.catenax.single_level_bom_as_planned/2.0.0/metadata.json
+++ b/io.catenax.single_level_bom_as_planned/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.single_level_bom_as_planned/2.0.0/metadata.json
+++ b/io.catenax.single_level_bom_as_planned/2.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{"status" : "release"} 

--- a/io.catenax.single_level_bom_as_planned/RELEASE_NOTES.md
+++ b/io.catenax.single_level_bom_as_planned/RELEASE_NOTES.md
@@ -3,6 +3,19 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0]
+### Added
+- optional `businessPartner` to each child item
+
+### Changed
+- changed `childCatenaXId` to `catenaXId`
+- changed `childParts` to `childItems`
+- changed several descriptions to use `item` instead of `part` where applicable
+- updated reference for SAMM Unit Catalog to a more readable one
+
+### Removed
+n/a
+
 ## [1.1.0]
 ### Added
 - optional validity period for child-parent relation
@@ -24,4 +37,3 @@ All notable changes to this model will be documented in this file.
 n/a
 
 ### Removed
-

--- a/io.catenax.single_level_bom_as_planned/RELEASE_NOTES.md
+++ b/io.catenax.single_level_bom_as_planned/RELEASE_NOTES.md
@@ -5,7 +5,7 @@ All notable changes to this model will be documented in this file.
 
 ## [2.0.0]
 ### Added
-- optional `businessPartner` to each child item
+- mandatory `businessPartner` to each child item
 
 ### Changed
 - changed `childCatenaXId` to `catenaXId`

--- a/io.catenax.single_level_bom_as_planned/RELEASE_NOTES.md
+++ b/io.catenax.single_level_bom_as_planned/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
-## [2.0.0]
+## [2.0.0] - 2023-09-01
 ### Added
 - mandatory `businessPartner` to each child item
 


### PR DESCRIPTION
## Description
Since the colleague [jacewski-bosch](https://github.com/jacewski-bosch) is on parental leave, we aren't able to update the exsting PR #204.

Therefore we created a new PR based 1:1 on the existing PR #204 with the original content of the branch _single_level_bom_as_planned_2.0.0_ from the fork _jacewski-bosch/sldt-semantic-models_ to be able to continue the MS approval check.

Closes #204 and #203.

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] The release date in the Release Note is set to the date of the MS3 approval
