### PR TITLE
[New Model]: Shared Aspect for UUID v4

### DIFF
--- a/io.catenax.shared.uuid/1.0.0/Uuid.ttl
+++ b/io.catenax.shared.uuid/1.0.0/Uuid.ttl
@@ -1,0 +1,49 @@
+#######################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#>.
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#>.
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#>.
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:samm:io.catenax.shared.uuid:1.0.0#>.
+
+:Uuid a samm:Aspect;
+    samm:preferredName "Shared Aspect for UUIDs v4"@en;
+    samm:description "This is a shared aspect for UUIDs with a regex."@en;
+    samm:properties (:uuidV4Property);
+    samm:operations ();
+    samm:events ().
+:uuidV4Property a samm:Property;
+    samm:preferredName "UUID v4 Property"@en;
+    samm:description "Property based on a UUID v4."@en;
+    samm:characteristic :UuidV4Trait;
+    samm:exampleValue "urn:uuid:48878d48-6f1d-47f5-8ded-a441d0d879df".
+:UuidV4Trait a samm-c:Trait;
+    samm:preferredName "Trait for UUIDs v4"@en;
+    samm:description "Trait to ensure UUID v4 data format."@en;
+    samm-c:baseCharacteristic :Uuidv4Characteristic;
+    samm-c:constraint :Uuidv4RegularExpression.
+:Uuidv4Characteristic a samm:Characteristic;
+    samm:preferredName "UUID v4"@en;
+    samm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en;
+    samm:dataType xsd:string;
+    samm:see <https://tools.ietf.org/html/rfc4122>.
+:Uuidv4RegularExpression a samm-c:RegularExpressionConstraint;
+    samm:preferredName "UUID v4 Regular Expression"@en;
+    samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en;
+    samm:see <https://datatracker.ietf.org/doc/html/rfc4122>;
+    samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)".

--- a/io.catenax.shared.uuid/1.0.0/metadata.json
+++ b/io.catenax.shared.uuid/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{"status": "release"}

--- a/io.catenax.shared.uuid/RELEASE_NOTES.md
+++ b/io.catenax.shared.uuid/RELEASE_NOTES.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [1.0.0] - 2023-09-11
+### Added
+- initial model
+
+### Changed
+n/a
+
+### Removed
+n/a


### PR DESCRIPTION
## Description
As proposed in the review of PR #295, I created the MS2 first. MS1 will be added afterwards, so that we can directly do the MS3 next week.

 -->

Closes #301 

## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the BAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar bamm-cli.jar -i \<path-to-aspect-model\> -v ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the BAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] The release date in the Release Note is set to the date of the MS3 approval
