### PR TITLE
Material Flow Simulation Result v2.0.0

### DIFF
--- a/io.catenax.material_flow_simulation_result/2.0.0/MaterialFlowSimulationResultAspect.ttl
+++ b/io.catenax.material_flow_simulation_result/2.0.0/MaterialFlowSimulationResultAspect.ttl
@@ -77,7 +77,7 @@
    samm:preferredName "Data Quality"@en ;
    samm:description "Information on quality of simulation results"@en ;
    samm:characteristic :DataQualityOptions ;
-   samm:exampleValue "0"^^xsd:positiveInteger .
+   samm:exampleValue "0"^^xsd:nonNegativeInteger .
 
 :shipments a samm:Property ;
    samm:preferredName "Shipments"@en ;
@@ -103,8 +103,8 @@
 :DataQualityOptions a samm-c:Enumeration ;
    samm:preferredName "Data Quality Options"@en ;
    samm:description "Possible values determining data quality"@en ;
-   samm:dataType xsd:positiveInteger ;
-   samm-c:values ( "0"^^xsd:positiveInteger "1"^^xsd:positiveInteger "2"^^xsd:positiveInteger "3"^^xsd:positiveInteger "4"^^xsd:positiveInteger "5"^^xsd:positiveInteger ) .
+   samm:dataType xsd:nonNegativeInteger ;
+   samm-c:values ( "0"^^xsd:nonNegativeInteger "1"^^xsd:nonNegativeInteger "2"^^xsd:nonNegativeInteger "3"^^xsd:nonNegativeInteger "4"^^xsd:nonNegativeInteger "5"^^xsd:nonNegativeInteger ) .
 
 :ShipmentList a samm-c:List ;
    samm:preferredName "Shipment List"@en ;

--- a/io.catenax.material_flow_simulation_result/2.0.0/MaterialFlowSimulationResultAspect.ttl
+++ b/io.catenax.material_flow_simulation_result/2.0.0/MaterialFlowSimulationResultAspect.ttl
@@ -261,7 +261,7 @@
 :MaterialBatch a samm:Entity ;
    samm:preferredName "Material Batch"@en ;
    samm:description "Material Batches are part of a handling unit"@en ;
-   samm:properties ( :batchId :materialNumber :materialName :hazardousGoods :batchExpirationTimestamp :quantity :unitOfMeasurement :batchNumber :batchOrderId ) .
+   samm:properties ( :batchId :materialNumber :materialName :materialHazardousGoods :batchExpirationTimestamp :quantity :unitOfMeasurement :batchNumber :batchOrderId ) .
 
 :batchId a samm:Property ;
    samm:preferredName "Batch Id"@en ;
@@ -281,8 +281,8 @@
    samm:characteristic :Text ;
    samm:exampleValue "KK1000GR-Gehäuse-Rot" .
 
-:hazardousGoods a samm:Property ;
-   samm:preferredName "Hazardous Goods"@en ;
+:materialHazardousGoods a samm:Property ;
+   samm:preferredName "Material Hazardous Goods"@en ;
    samm:description "Flags hazardous goods"@en ;
    samm:characteristic samm-c:Boolean ;
    samm:exampleValue false .
@@ -326,3 +326,4 @@
    samm:description "Possible options for units of measurement"@en ;
    samm:dataType xsd:string ;
    samm-c:values ( "KG" "Liter" "Piece" ) .
+

--- a/io.catenax.material_flow_simulation_result/2.0.0/MaterialFlowSimulationResultAspect.ttl
+++ b/io.catenax.material_flow_simulation_result/2.0.0/MaterialFlowSimulationResultAspect.ttl
@@ -1,0 +1,328 @@
+##########################################################################################
+# Copyright (c) 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e. V.
+# Copyright (c) 2023 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2023 Siemens AG
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+##########################################################################################
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.material_flow_simulation_result:2.0.0#> .
+
+:MaterialFlowSimulationResultAspect a samm:Aspect ;
+   samm:preferredName "Material Flow Simulation Result Aspect"@en ;
+   samm:description "Aspect Model for the result of a Material Flow Simulation"@en ;
+   samm:properties ( :materialFlowSimulationResult ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:materialFlowSimulationResult a samm:Property ;
+   samm:preferredName "Material Flow Simulation Result"@en ;
+   samm:description "Contains standardized attributes for the result of a material flow simulation"@en ;
+   samm:characteristic :MaterialFlowSimulationResultCharacteristic .
+
+:MaterialFlowSimulationResultCharacteristic a samm:Characteristic ;
+   samm:preferredName "Material Flow Simulation Result Characteristic"@en ;
+   samm:description "Characteristic describing the aspect material flow simulation result"@en ;
+   samm:dataType :MaterialFlowSimulationResult .
+
+:MaterialFlowSimulationResult a samm:Entity ;
+   samm:preferredName "Material Flow Simulation Result"@en ;
+   samm:description "Result of a Material Flow Simulation"@en ;
+   samm:properties ( :description :runId :comment :expirationTimestamp :owner :dataQuality :shipments :timestamp ) .
+
+:description a samm:Property ;
+   samm:preferredName "Description"@en ;
+   samm:description "Verbal description"@en ;
+   samm:characteristic :Text ;
+   samm:exampleValue "Please simulate asap" .
+
+:runId a samm:Property ;
+   samm:preferredName "RunId"@en ;
+   samm:description "Id of the simulation run"@en ;
+   samm:characteristic :Text ;
+   samm:exampleValue "0fece48b-c8d1-4180-1a9caca6d67e" .
+
+:comment a samm:Property ;
+   samm:preferredName "Comment"@en ;
+   samm:description "Additional comments"@en ;
+   samm:characteristic :Text ;
+   samm:exampleValue "successful simulation " .
+
+:expirationTimestamp a samm:Property ;
+   samm:preferredName "ExpirationTimestamp"@en ;
+   samm:description "Date and time when the simulation is expired"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-03-24T09:15:24.000Z"^^xsd:dateTime .
+
+:owner a samm:Property ;
+   samm:preferredName "Owner"@en ;
+   samm:description "Site identifier of the simulation originator"@en ;
+   samm:characteristic :OwnerCharacteristic .
+
+:dataQuality a samm:Property ;
+   samm:preferredName "Data Quality"@en ;
+   samm:description "Information on quality of simulation results"@en ;
+   samm:characteristic :DataQualityOptions ;
+   samm:exampleValue "0"^^xsd:positiveInteger .
+
+:shipments a samm:Property ;
+   samm:preferredName "Shipments"@en ;
+   samm:description "List of shipments"@en ;
+   samm:characteristic :ShipmentList .
+
+:timestamp a samm:Property ;
+   samm:preferredName "Timestamp"@en ;
+   samm:description "Timestamp of simulation run"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-03-09T14:13:42.806Z"^^xsd:dateTime .
+
+:Text a samm:Characteristic ;
+   samm:preferredName "Text"@en ;
+   samm:description "Describes a Property which contains plain text. This is intended exclusively for human readable strings, not for identifiers, measurement values, etc."@en ;
+   samm:dataType xsd:string .
+
+:OwnerCharacteristic a samm-c:SingleEntity ;
+   samm:preferredName "Owner Characteristic"@en ;
+   samm:description "Site identifier of the simulation originator"@en ;
+   samm:dataType :BusinessPartnerSite .
+
+:DataQualityOptions a samm-c:Enumeration ;
+   samm:preferredName "Data Quality Options"@en ;
+   samm:description "Possible values determining data quality"@en ;
+   samm:dataType xsd:positiveInteger ;
+   samm-c:values ( "0"^^xsd:positiveInteger "1"^^xsd:positiveInteger "2"^^xsd:positiveInteger "3"^^xsd:positiveInteger "4"^^xsd:positiveInteger "5"^^xsd:positiveInteger ) .
+
+:ShipmentList a samm-c:List ;
+   samm:preferredName "Shipment List"@en ;
+   samm:description "List of shipments contained in the simulation"@en ;
+   samm:dataType :Shipment .
+
+:BusinessPartnerSite a samm:Entity ;
+   samm:preferredName "Business Partner Site"@en ;
+   samm:description "Identifier for the physical location of a business partner plant or site, (e.g. BPNS in Catena-X context)"@en ;
+   samm:properties ( ) .
+
+:Shipment a samm:Entity ;
+   samm:preferredName "Shipment"@en ;
+   samm:description "Delivery item from a sender to a recipient containing goods"@en ;
+   samm:properties ( :shipmentId :destination :destinationTimestamp :recipient :recipientTimestampPlanned :splittingAllowed :logistics :preceding :handlingUnits ) .
+
+:shipmentId a samm:Property ;
+   samm:preferredName "Shipment Id"@en ;
+   samm:description "ID to identify the shipment"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "DE51515151" .
+
+:destination a samm:Property ;
+   samm:preferredName "Destination"@en ;
+   samm:description "Address where the shipment is immediately delivered to (by logistician) or provided for pickup (by producer)"@en ;
+   samm:characteristic :DestinationCharacteristic .
+
+:destinationTimestamp a samm:Property ;
+   samm:preferredName "Destination Timestamp"@en ;
+   samm:description "Time when delivery arrives or is ready at goods issue"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-03-19T09:00:00.000Z"^^xsd:dateTime .
+
+:recipient a samm:Property ;
+   samm:preferredName "Recipient"@en ;
+   samm:description "Address of final recipient of shipment"@en ;
+   samm:characteristic :RecipientCharacteristic .
+
+:recipientTimestampPlanned a samm:Property ;
+   samm:preferredName "Recipient Timestamp Planned"@en ;
+   samm:description "Planned delivery time"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-04-19T09:00:00.000Z"^^xsd:dateTime .
+
+:splittingAllowed a samm:Property ;
+   samm:preferredName "Splitting Allowed"@en ;
+   samm:description "Permission to split the shipment into individual deliveries"@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:logistics a samm:Property ;
+   samm:preferredName "Logistics"@en ;
+   samm:description "Address of logistician executing the shipment"@en ;
+   samm:characteristic :LogisticsCharacteristic .
+
+:preceding a samm:Property ;
+   samm:preferredName "Preceding"@en ;
+   samm:description "Reference ID of a preceding shipment"@en ;
+   samm:characteristic :PrecedingCharacteristic .
+
+:handlingUnits a samm:Property ;
+   samm:preferredName "Handling Units"@en ;
+   samm:description "List of Handling Units"@en ;
+   samm:characteristic :HandlingUnitList .
+
+:DestinationCharacteristic a samm-c:SingleEntity ;
+   samm:preferredName "Destination Characteristic"@en ;
+   samm:description "Address where the shipment is immediately delivered to (by logistician) or provided for pickup (by producer)"@en ;
+   samm:dataType :BusinessPartnerSite .
+
+:RecipientCharacteristic a samm-c:SingleEntity ;
+   samm:preferredName "Recipient Characteristic"@en ;
+   samm:description "Location identifier of the final recipient of the shipment"@en ;
+   samm:dataType :BusinessPartnerSite .
+
+:LogisticsCharacteristic a samm-c:SingleEntity ;
+   samm:preferredName "Logistics Characteristic"@en ;
+   samm:description "Site identifier of the logistician executing the shipment"@en ;
+   samm:dataType :BusinessPartnerSite .
+
+:PrecedingCharacteristic a samm-c:SingleEntity ;
+   samm:preferredName "Preceding Characteristic"@en ;
+   samm:description "Reference of preceding shipments"@en ;
+   samm:dataType :BusinessPartnerSite .
+
+:HandlingUnitList a samm-c:List ;
+   samm:preferredName "Handling Unit List"@en ;
+   samm:description "List of handling units included in the shipment"@en ;
+   samm:dataType :HandlingUnit .
+
+:HandlingUnit a samm:Entity ;
+   samm:preferredName "Handling Unit"@en ;
+   samm:description "Handling Unit is the smallest shipment unit and cannot be divided into several shipments"@en ;
+   samm:properties ( :handlingUnitId :name :volume :weight :amount :batches ) .
+
+:handlingUnitId a samm:Property ;
+   samm:preferredName "Handling Unit Id"@en ;
+   samm:description "ID of the handling unit"@en ;
+   samm:characteristic :Text ;
+   samm:exampleValue "HUT_1" .
+
+:name a samm:Property ;
+   samm:preferredName "Name"@en ;
+   samm:description "Name of the type of handling unit"@en ;
+   samm:characteristic :Text ;
+   samm:exampleValue "Palette" .
+
+:volume a samm:Property ;
+   samm:preferredName "Volume"@en ;
+   samm:description "Volume of the handling unit"@en ;
+   samm:characteristic :VolumeCharacteristic ;
+   samm:exampleValue "1.00"^^xsd:float .
+
+:weight a samm:Property ;
+   samm:preferredName "Weight"@en ;
+   samm:description "Weight of the handling unit"@en ;
+   samm:characteristic :WeightCharacteristic ;
+   samm:exampleValue "189"^^xsd:float .
+
+:amount a samm:Property ;
+   samm:preferredName "Amount"@en ;
+   samm:description "Number of handling units with identical content"@en ;
+   samm:characteristic :AmountCharacteristic ;
+   samm:exampleValue "1"^^xsd:positiveInteger .
+
+:batches a samm:Property ;
+   samm:preferredName "Batches"@en ;
+   samm:description "List of material batches contained within a handling unit"@en ;
+   samm:characteristic :BatchList .
+
+:VolumeCharacteristic a samm-c:Measurement ;
+   samm:preferredName "Volume Characteristic"@en ;
+   samm:description "Volumetric value determining the volume of the handling unit"@en ;
+   samm:dataType xsd:float ;
+   samm-c:unit unit:litre .
+
+:WeightCharacteristic a samm-c:Measurement ;
+   samm:preferredName "Weight Characteristic"@en ;
+   samm:description "Amount of weight of the handling unit"@en ;
+   samm:dataType xsd:float ;
+   samm-c:unit unit:kilogram .
+
+:AmountCharacteristic a samm-c:Quantifiable ;
+   samm:preferredName "Amount Characteristic"@en ;
+   samm:description "Number describing handling units with identical pieces"@en ;
+   samm:dataType xsd:positiveInteger ;
+   samm-c:unit unit:piece .
+
+:BatchList a samm-c:List ;
+   samm:preferredName "Batch List"@en ;
+   samm:description "List of material batches"@en ;
+   samm:dataType :MaterialBatch .
+
+:MaterialBatch a samm:Entity ;
+   samm:preferredName "Material Batch"@en ;
+   samm:description "Material Batches are part of a handling unit"@en ;
+   samm:properties ( :batchId :materialNumber :materialName :hazardousGoods :batchExpirationTimestamp :quantity :unitOfMeasurement :batchNumber :batchOrderId ) .
+
+:batchId a samm:Property ;
+   samm:preferredName "Batch Id"@en ;
+   samm:description "ID for the material batch"@en ;
+   samm:characteristic :Text ;
+   samm:exampleValue "Batch_1" .
+
+:materialNumber a samm:Property ;
+   samm:preferredName "Material Number"@en ;
+   samm:description "ID of the material contained in the batch"@en ;
+   samm:characteristic :Text ;
+   samm:exampleValue "KK1000GR" .
+
+:materialName a samm:Property ;
+   samm:preferredName "Material Name"@en ;
+   samm:description "Name of the material"@en ;
+   samm:characteristic :Text ;
+   samm:exampleValue "KK1000GR-Gehäuse-Rot" .
+
+:hazardousGoods a samm:Property ;
+   samm:preferredName "Hazardous Goods"@en ;
+   samm:description "Flags hazardous goods"@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue false .
+
+:batchExpirationTimestamp a samm:Property ;
+   samm:preferredName "Batch Expiration Timestamp"@en ;
+   samm:description "Expiration date of batch"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-08-22T16:00:00.000Z"^^xsd:dateTime .
+
+:quantity a samm:Property ;
+   samm:preferredName "Quantity"@en ;
+   samm:description "Amount of materials"@en ;
+   samm:characteristic :QuantityCharacteristic ;
+   samm:exampleValue "50"^^xsd:float .
+
+:unitOfMeasurement a samm:Property ;
+   samm:preferredName "UnitOfMeasurement"@en ;
+   samm:description "Unit used for measuring the quantity"@en ;
+   samm:characteristic :UnitOfMeasurementCharacteristic .
+
+:batchNumber a samm:Property ;
+   samm:preferredName "Batch Number"@en ;
+   samm:description "Number of the batch, generated by originator (e.g. from ERP system, no uuid)"@en ;
+   samm:characteristic :Text ;
+   samm:exampleValue "45" .
+
+:batchOrderId a samm:Property ;
+   samm:preferredName "Batch Order Id"@en ;
+   samm:description "Order ID to which the batch belongs"@en ;
+   samm:characteristic :Text ;
+   samm:exampleValue "Order-0001" .
+
+:QuantityCharacteristic a samm:Characteristic ;
+   samm:preferredName "Quantity Characteristic"@en ;
+   samm:description "Number of materials contained within a handling unit"@en ;
+   samm:dataType xsd:float .
+
+:UnitOfMeasurementCharacteristic a samm-c:Enumeration ;
+   samm:preferredName "Unit Of Measurement Characteristic"@en ;
+   samm:description "Possible options for units of measurement"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "KG" "Liter" "Piece" ) .

--- a/io.catenax.material_flow_simulation_result/2.0.0/metadata.json
+++ b/io.catenax.material_flow_simulation_result/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release" }

--- a/io.catenax.material_flow_simulation_result/RELEASE_NOTES.md
+++ b/io.catenax.material_flow_simulation_result/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 All notable changes to this model will be documented in this file.
 
-## [2.0.0]
+## [2.0.0] 2023-10-16
 
 ### Added
 

--- a/io.catenax.material_flow_simulation_result/RELEASE_NOTES.md
+++ b/io.catenax.material_flow_simulation_result/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 All notable changes to this model will be documented in this file.
 
+## [2.0.0]
+
+### Added
+
+- Entity containing the properties of a Material Flow Simulation Result
+
 ## [1.0.0]
 
 - initial version of the aspect model for Material Flow Simulation Result


### PR DESCRIPTION
## Description

Add an additional layer for the SimulationResult for reusability. The current model lacks a reusable entity for MaterialFlowSimulationResult, which can be reused in other models.

Closes #315

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
