### PR TITLE
Material Flow Scenario Request v1.0.0

### DIFF
--- a/io.catenax.material_flow_scenario_request/1.0.0/MaterialFlowScenarioRequestAspect.ttl
+++ b/io.catenax.material_flow_scenario_request/1.0.0/MaterialFlowScenarioRequestAspect.ttl
@@ -1,0 +1,214 @@
+##########################################################################################
+# Copyright (c) 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e. V.
+# Copyright (c) 2023 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2023 Siemens AG
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+##########################################################################################
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.material_flow_scenario_request:1.0.0#> .
+@prefix ext-result: <urn:samm:io.catenax.material_flow_simulation_result:2.0.0#> .
+
+:MaterialFlowScenarioRequestAspect a samm:Aspect ;
+   samm:preferredName "Material Flow Scenario Request Aspect"@en ;
+   samm:description "Aspect model describing the Material Flow Scenario Request"@en ;
+   samm:properties ( :materialFlowScenarioRequest ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:materialFlowScenarioRequest a samm:Property ;
+   samm:preferredName "materialFlowScenarioRequest"@en ;
+   samm:description "Contains standardized attributes for the content of the Material Flow Scenario Request"@en ;
+   samm:characteristic :MaterialFlowScenarioRequestCharacteristic .
+
+:MaterialFlowScenarioRequestCharacteristic a samm:Characteristic ;
+   samm:preferredName "Material Flow Scenario Request Characteristic"@en ;
+   samm:description "Characteristic describing the aspect Material Flow Scenario Request"@en ;
+   samm:dataType :MaterialFlowScenarioRequest .
+
+:MaterialFlowScenarioRequest a samm:Entity ;
+   samm:preferredName "Material Flow Scenario Request"@en ;
+   samm:description "The Material Flow Scenario Request contains standardized attributes for exchanging scenario requests and the resulting simulation results between two OSIM Manager Instances"@en ;
+   samm:properties ( :scenarioHeader [ samm:property :scenarioParameter; samm:optional true ] :scenarioSimResults ) .
+
+:scenarioHeader a samm:Property ;
+   samm:preferredName "scenarioHeader"@en ;
+   samm:description "Required parameters for the scenario header"@en ;
+   samm:characteristic :ScenarioHeaderCharacteristic .
+
+:scenarioParameter a samm:Property ;
+   samm:preferredName "scenarioParameter"@en ;
+   samm:description "Required parameters for the material flow scenario request"@en ;
+   samm:characteristic :ScenarioParameterCharacteristic .
+
+:scenarioSimResults a samm:Property ;
+   samm:preferredName "scenarioSimResults"@en ;
+   samm:description "Simulation results of the scenario"@en ;
+   samm:characteristic :ScenarioSimResultsCharacteristic .
+
+:ScenarioHeaderCharacteristic a samm:Characteristic ;
+   samm:preferredName "Scenario Header Characteristic"@en ;
+   samm:description "Characteristic describing the parameter for a scenario header"@en ;
+   samm:dataType :ScenarioHeader .
+
+:ScenarioParameterCharacteristic a samm:Characteristic ;
+   samm:preferredName "Scenario Parameter Characteristic"@en ;
+   samm:description "Characteristic describing the scenario parameter"@en ;
+   samm:dataType :ScenarioParameter .
+
+:ScenarioSimResultsCharacteristic a samm:Characteristic ;
+   samm:preferredName "Scenario Simulation Results Characteristic"@en ;
+   samm:description "Characteristic for simulation results"@en ;
+   samm:dataType :ScenarioSimResults .
+
+:ScenarioHeader a samm:Entity ;
+   samm:preferredName "Scenario Header"@en ;
+   samm:description "Headers required for every exchange"@en ;
+   samm:properties ( :scenarioId :scenarioTitle :scenarioCreationTimestamp :scenarioExpirationTimestamp :scenarioOwner :scenarioOwnerRole [ samm:property :scenarioDescription; samm:optional true ] ) .
+
+:ScenarioParameter a samm:Entity ;
+   samm:preferredName "Scenario Parameter"@en ;
+   samm:description "Parameters which are used to describe a material flow scenario request"@en ;
+   samm:properties ( :parameterId :parameterDeliveryDateInitial :parameterDeliveryDateUpdated :parameterQuantityInitial :parameterQuantityUpdated :parameterOrderId :parameterScenario :parameterComment ext-result:materialNumber ext-result:materialName ext-result:unitOfMeasurement ) .
+
+:ScenarioSimResults a samm:Entity ;
+   samm:preferredName "Scenario Simulation Results"@en ;
+   samm:description "Attached to a scenario simulation results of the feedback requestor"@en ;
+   samm:properties ( :resultOwnId [ samm:property :resultOwnSimRunInitial; samm:optional true ] [ samm:property :resultOwnSimRunUpdated; samm:optional true ] ) .
+
+:scenarioId a samm:Property ;
+   samm:preferredName "scenarioId"@en ;
+   samm:description "ID of scenario header"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "8d464b8b-6977-4952-8a22-0489067ca081" .
+
+:scenarioTitle a samm:Property ;
+   samm:preferredName "scenarioTitle"@en ;
+   samm:description "Title of scenario"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Delivery Modification" .
+
+:scenarioCreationTimestamp a samm:Property ;
+   samm:preferredName "scenarioCreationTimestamp"@en ;
+   samm:description "Date and Time of scenario creation"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-10-04T09:10:00.000Z"^^xsd:dateTime .
+
+:scenarioExpirationTimestamp a samm:Property ;
+   samm:preferredName "scenarioExpirationTimestamp"@en ;
+   samm:description "Date and Time of validity expiration"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-10-07T09:10:00.000Z"^^xsd:dateTime .
+
+:scenarioOwner a samm:Property ;
+   samm:preferredName "scenarioOwner"@en ;
+   samm:description "Owner of the simulation scenario"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BPNL0000007OTZ3" .
+
+:scenarioOwnerRole a samm:Property ;
+   samm:preferredName "scenarioOwnerRole"@en ;
+   samm:description "Role of the scenario owner"@en ;
+   samm:characteristic :ScenarioOwnerRoleCharacteristic ;
+   samm:exampleValue "Customer" .
+
+:scenarioDescription a samm:Property ;
+   samm:preferredName "scenarioDescription"@en ;
+   samm:description "Description of the scenario"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Changes in Delivery Date" .
+
+:parameterId a samm:Property ;
+   samm:preferredName "parameterId"@en ;
+   samm:description "Identifier of scenario parameter"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "847c71e5-614a-468b-a3a0-674bf2af3004" .
+
+:parameterDeliveryDateInitial a samm:Property ;
+   samm:preferredName "parameterDeliveryDateInitial"@en ;
+   samm:description "Delivery date initial (without scenario changes), optional, NULL when initially not set"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-10-09T10:00:00.000Z"^^xsd:dateTime .
+
+:parameterDeliveryDateUpdated a samm:Property ;
+   samm:preferredName "parameterDeliveryDateUpdated"@en ;
+   samm:description "Delivery date updated (with scenario changes)"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-10-10T09:00:00.000Z"^^xsd:dateTime .
+
+:parameterQuantityInitial a samm:Property ;
+   samm:preferredName "parameterQuantityInitial"@en ;
+   samm:description "Amount initial (without scenario changes), optional, NULL, when initially not set"@en ;
+   samm:characteristic :QuantityCharacteristic ;
+   samm:exampleValue "1.00"^^xsd:float .
+
+:parameterQuantityUpdated a samm:Property ;
+   samm:preferredName "parameterQuantityUpdated"@en ;
+   samm:description "Amount updated (with scenario changes)"@en ;
+   samm:characteristic :QuantityCharacteristic ;
+   samm:exampleValue "1.00"^^xsd:float .
+
+:parameterOrderId a samm:Property ;
+   samm:preferredName "parameterOrderId"@en ;
+   samm:description "ID of the order"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "OID-011123456" .
+
+:parameterScenario a samm:Property ;
+   samm:preferredName "parameterScenario"@en ;
+   samm:description "Foreign key to scenario header"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "8d464b8b-6977-4952-8a22-0489067ca081" .
+
+:parameterComment a samm:Property ;
+   samm:preferredName "parameterComment"@en ;
+   samm:description "Optional description of parameters"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "updated Delivery Date" .
+
+:resultOwnId a samm:Property ;
+   samm:preferredName "resultOwnId"@en ;
+   samm:description "ID of scenario result own"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "916b5688-8bd8-4d7e-83b9-e0d40939274e" .
+
+:resultOwnSimRunInitial a samm:Property ;
+   samm:preferredName "resultOwnSimRunInitial"@en ;
+   samm:description "Foreign key to simulation result based on initial parameters"@en ;
+   samm:characteristic :SimResult .
+
+:resultOwnSimRunUpdated a samm:Property ;
+   samm:preferredName "resultOwnSimRunUpdated"@en ;
+   samm:description "Foreign key to simulation result based on updated parameter (scenario)"@en ;
+   samm:characteristic :SimResult .
+
+:ScenarioOwnerRoleCharacteristic a samm-c:Enumeration ;
+   samm:preferredName "Scenario Owner Role Characteristic"@en ;
+   samm:description "Characteristic describing possible values for the role of the scenario owner"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Customer" "Supplier" "LogisticianReceiving" "LogisticianSending" ) .
+
+:QuantityCharacteristic a samm:Characteristic ;
+   samm:preferredName "Quantity Characteristic"@en ;
+   samm:description "Describes a property which is a Float"@en ;
+   samm:dataType xsd:float .
+
+:SimResult a samm:Characteristic ;
+   samm:preferredName "Sim Result"@en ;
+   samm:description "Characteristic describing the property for a Material Flow Simulation Result"@en ;
+   samm:dataType ext-result:MaterialFlowSimulationResult .
+

--- a/io.catenax.material_flow_scenario_request/1.0.0/metadata.json
+++ b/io.catenax.material_flow_scenario_request/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release" }

--- a/io.catenax.material_flow_scenario_request/RELEASE_NOTES.md
+++ b/io.catenax.material_flow_scenario_request/RELEASE_NOTES.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this model will be documented in this file.
+
+## [1.0.0]
+
+- initial version of the aspect model for Scenario Simulation Request

--- a/io.catenax.material_flow_scenario_request/RELEASE_NOTES.md
+++ b/io.catenax.material_flow_scenario_request/RELEASE_NOTES.md
@@ -2,6 +2,6 @@
 
 All notable changes to this model will be documented in this file.
 
-## [1.0.0]
+## [1.0.0] 2023-10-23
 
 - initial version of the aspect model for Scenario Simulation Request


### PR DESCRIPTION
## Description

Implementation of the material flow scenario request.

The model requires the latest version of Material Flow Simulation Result v2.0.0 https://github.com/eclipse-tractusx/sldt-semantic-models/pull/329

Closes #316

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
