### PR TITLE
ManufacturingCapability v.2.0.0: Migration to SAMM

### DIFF
--- a/io.catenax.manufacturing_capability/2.0.0/ManufacturingCapability.ttl
+++ b/io.catenax.manufacturing_capability/2.0.0/ManufacturingCapability.ttl
@@ -1,0 +1,176 @@
+#######################################################################
+# Copyright (c) 2023 Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.manufacturing_capability:2.0.0#> .
+
+:ManufacturingCapability a samm:Aspect ;
+   samm:preferredName "Manufacturing Capability Aspect Model"@en ;
+   samm:description "An aspect model representing manufacturing capabilities, based on the concepts for products, processes, resources and capabilities, as well as their relations to each other."@en ;
+   samm:properties ( :processSet :resourceSet :productSet :capabilitySet :capabilityConstraintSet ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:processSet a samm:Property ;
+   samm:preferredName "Process Set"@en ;
+   samm:description "Set of production-relevant activities at any level of granularity that might affect materials and is performed by resources."@en ;
+   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1> ;
+   samm:characteristic :ProcessSetCharacteristic .
+
+:resourceSet a samm:Property ;
+   samm:preferredName "Resource Set"@en ;
+   samm:description "Set of entities capable of performing functions specified as capabilities."@en ;
+   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1> ;
+   samm:characteristic :ResourceSetCharacteristic .
+
+:productSet a samm:Property ;
+   samm:preferredName "Product Set"@en ;
+   samm:description "Set of physical objects being used as an input or created as an output of a production process."@en ;
+   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1> ;
+   samm:characteristic :ProductSetCharacteristic .
+
+:capabilitySet a samm:Property ;
+   samm:preferredName "Capability Set"@en ;
+   samm:description "Set of implementation-independent specifications of functions in industrial production to achieve an effect in the physical or virtual world."@en ;
+   samm:see <https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/CapabilitiesSkillsServices.pdf?__blob=publicationFile&v=1> ;
+   samm:characteristic :CapabilitySetCharacteristic .
+
+:capabilityConstraintSet a samm:Property ;
+   samm:preferredName "Capability Constraint Set"@en ;
+   samm:description "Set of conditions imposed on capabilities which further detail their applicability."@en ;
+   samm:characteristic :CapabilityConstraintSetCharacteristic .
+
+:ProcessSetCharacteristic a samm-c:Set ;
+   samm:preferredName "Process Set Characteristic"@en ;
+   samm:description "Characteristic for a set of process representations."@en ;
+   samm:dataType :ProcessEntity .
+
+:ResourceSetCharacteristic a samm-c:Set ;
+   samm:preferredName "Resource Set Characteristic"@en ;
+   samm:description "Characteristic for a set of resource representations."@en ;
+   samm:dataType :ResourceEntity .
+
+:ProductSetCharacteristic a samm-c:Set ;
+   samm:preferredName "Product Set Characteristic"@en ;
+   samm:description "Characteristic for a set of productrepresentations."@en ;
+   samm:dataType :ProductEntity .
+
+:CapabilitySetCharacteristic a samm-c:Set ;
+   samm:preferredName "Capability Set Characteristic"@en ;
+   samm:description "Characteristic for a set of capability representations."@en ;
+   samm:dataType :CapabilityEntity .
+
+:CapabilityConstraintSetCharacteristic a samm-c:Set ;
+   samm:preferredName "Capability Constraint Set Characteristic"@en ;
+   samm:description "Characteristic for a set of capability constraint representations."@en ;
+   samm:dataType :CapabilityConstraintEntity .
+
+:ProcessEntity a samm:Entity ;
+   samm:extends :ElementAbstractEntity ;
+   samm:preferredName "Process Entity"@en ;
+   samm:description "Element containing the bamm properties of a process."@en ;
+   samm:properties ( :hasInput :hasOutput :requires ) .
+
+:ResourceEntity a samm:Entity ;
+   samm:extends :ElementAbstractEntity ;
+   samm:preferredName "Resource Entity"@en ;
+   samm:description "Element containing the bamm properties of a resource."@en ;
+   samm:properties ( :provides ) .
+
+:ProductEntity a samm:Entity ;
+   samm:extends :ElementAbstractEntity ;
+   samm:preferredName "Product Entity"@en ;
+   samm:description "Element containing the bamm properties of a product."@en ;
+   samm:properties ( :productLabel ) .
+
+:CapabilityEntity a samm:Entity ;
+   samm:extends :ElementAbstractEntity ;
+   samm:preferredName "Capability Entity"@en ;
+   samm:description "Element containing the bamm properties of a capability."@en ;
+   samm:properties ( :capabilityLabel ) .
+
+:CapabilityConstraintEntity a samm:Entity ;
+   samm:preferredName "Capability Constraint Entity"@en ;
+   samm:description "Element containing the bamm properties of a capability constraint."@en ;
+   samm:properties ( :references ) .
+
+:ElementAbstractEntity a samm:AbstractEntity ;
+   samm:preferredName "Element Abstract Entity"@en ;
+   samm:description "Abstract Entity containing the bamm properties every process, resource, product and capability entity shall contain."@en ;
+   samm:properties ( :propertySet ) .
+
+:hasInput a samm:Property ;
+   samm:preferredName "Has Input"@en ;
+   samm:description "Relation between a process and its input products."@en ;
+   samm:characteristic :ProductSetCharacteristic .
+
+:hasOutput a samm:Property ;
+   samm:preferredName "Has Output"@en ;
+   samm:description "Relation between a process and its output products."@en ;
+   samm:characteristic :ProductSetCharacteristic .
+
+:requires a samm:Property ;
+   samm:preferredName "Requires"@en ;
+   samm:description "Relation between a process and capabilities it requires."@en ;
+   samm:characteristic :CapabilitySetCharacteristic .
+
+:provides a samm:Property ;
+   samm:preferredName "Provides"@en ;
+   samm:description "Relation between a resource and capabilities it provides."@en ;
+   samm:characteristic :CapabilitySetCharacteristic .
+
+:productLabel a samm:Property ;
+   samm:preferredName "Product Label"@en ;
+   samm:description "Human readable label of a product, e.g. the name."@en ;
+   samm:characteristic samm-c:MultiLanguageText ;
+   samm:exampleValue "wheel suspension"@en .
+
+:capabilityLabel a samm:Property ;
+   samm:preferredName "Capability Label"@en ;
+   samm:description "Human readable label of a capability"@en ;
+   samm:characteristic samm-c:MultiLanguageText ;
+   samm:exampleValue "drilling"@en .
+
+:references a samm:Property ;
+   samm:preferredName "References"@en ;
+   samm:description "Relation between a capability constraint and its properties."@en ;
+   samm:characteristic :PropertySetCharacteristic .
+
+:propertySet a samm:Property ;
+   samm:preferredName "Property Set"@en ;
+   samm:description "Set of qualities or characteristics inherent in or ascribed to process, resource, product or capability entities."@en ;
+   samm:characteristic :PropertySetCharacteristic .
+
+:PropertySetCharacteristic a samm-c:Set ;
+   samm:preferredName "Property Set Characteristic"@en ;
+   samm:description "Characteristic for a set of property representations."@en ;
+   samm:dataType :PropertyEntity .
+
+:PropertyEntity a samm:Entity ;
+   samm:preferredName "Property Entity"@en ;
+   samm:description "Element containing the bamm properties of a property."@en ;
+   samm:properties ( :propertyLabel ) .
+
+:propertyLabel a samm:Property ;
+   samm:preferredName "Property Label"@en ;
+   samm:description "Human readable label of a property."@en ;
+   samm:characteristic samm-c:MultiLanguageText ;
+   samm:exampleValue "diameter"@en .

--- a/io.catenax.manufacturing_capability/2.0.0/ManufacturingCapability.ttl
+++ b/io.catenax.manufacturing_capability/2.0.0/ManufacturingCapability.ttl
@@ -70,7 +70,7 @@
 
 :ProductSetCharacteristic a samm-c:Set ;
    samm:preferredName "Product Set Characteristic"@en ;
-   samm:description "Characteristic for a set of productrepresentations."@en ;
+   samm:description "Characteristic for a set of product representations."@en ;
    samm:dataType :ProductEntity .
 
 :CapabilitySetCharacteristic a samm-c:Set ;
@@ -86,35 +86,35 @@
 :ProcessEntity a samm:Entity ;
    samm:extends :ElementAbstractEntity ;
    samm:preferredName "Process Entity"@en ;
-   samm:description "Element containing the bamm properties of a process."@en ;
+   samm:description "Element containing the samm properties of a process."@en ;
    samm:properties ( :hasInput :hasOutput :requires ) .
 
 :ResourceEntity a samm:Entity ;
    samm:extends :ElementAbstractEntity ;
    samm:preferredName "Resource Entity"@en ;
-   samm:description "Element containing the bamm properties of a resource."@en ;
+   samm:description "Element containing the samm properties of a resource."@en ;
    samm:properties ( :provides ) .
 
 :ProductEntity a samm:Entity ;
    samm:extends :ElementAbstractEntity ;
    samm:preferredName "Product Entity"@en ;
-   samm:description "Element containing the bamm properties of a product."@en ;
+   samm:description "Element containing the samm properties of a product."@en ;
    samm:properties ( :productLabel ) .
 
 :CapabilityEntity a samm:Entity ;
    samm:extends :ElementAbstractEntity ;
    samm:preferredName "Capability Entity"@en ;
-   samm:description "Element containing the bamm properties of a capability."@en ;
+   samm:description "Element containing the samm properties of a capability."@en ;
    samm:properties ( :capabilityLabel ) .
 
 :CapabilityConstraintEntity a samm:Entity ;
    samm:preferredName "Capability Constraint Entity"@en ;
-   samm:description "Element containing the bamm properties of a capability constraint."@en ;
+   samm:description "Element containing the samm properties of a capability constraint."@en ;
    samm:properties ( :references ) .
 
 :ElementAbstractEntity a samm:AbstractEntity ;
    samm:preferredName "Element Abstract Entity"@en ;
-   samm:description "Abstract Entity containing the bamm properties every process, resource, product and capability entity shall contain."@en ;
+   samm:description "Abstract Entity containing the samm properties every process, resource, product and capability entity shall contain."@en ;
    samm:properties ( :propertySet ) .
 
 :hasInput a samm:Property ;
@@ -166,7 +166,7 @@
 
 :PropertyEntity a samm:Entity ;
    samm:preferredName "Property Entity"@en ;
-   samm:description "Element containing the bamm properties of a property."@en ;
+   samm:description "Element containing the samm properties of a property."@en ;
    samm:properties ( :propertyLabel ) .
 
 :propertyLabel a samm:Property ;

--- a/io.catenax.manufacturing_capability/2.0.0/metadata.json
+++ b/io.catenax.manufacturing_capability/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.manufacturing_capability/RELEASE_NOTES.md
+++ b/io.catenax.manufacturing_capability/RELEASE_NOTES.md
@@ -1,14 +1,23 @@
 # Changelog
+
 All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0] - 2023-10-09
+
+### Changed
+
+- Moved from BAMM to SAMM
+
 ## [1.0.0] - 2023-07-03
+
 ### Added
+
 - initial model
 
 ### Changed
+
 n/a
 
 ### Removed
-

--- a/io.catenax.manufacturing_capability/RELEASE_NOTES.md
+++ b/io.catenax.manufacturing_capability/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
-## [2.0.0] - 2023-10-09
+## [2.0.0] - 2023-10-16
 
 ### Changed
 


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 The model has been converted using the Aspect Model Editor and validated using samm-cli-2.3.2

Closes https://github.com/eclipse-tractusx/sldt-semantic-models/issues/393

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
