### PR TITLE
Correct the Release Status of the PartAsPlanned Aspect Models in TractusX

### DIFF
--- a/io.catenax.part_as_planned/1.0.0/metadata.json
+++ b/io.catenax.part_as_planned/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"}
+{ "status" : "deprecate"}

--- a/io.catenax.part_as_planned/1.0.1/metadata.json
+++ b/io.catenax.part_as_planned/1.0.1/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "deprecate"}
+{ "status" : "release"}


### PR DESCRIPTION
## Description
This PR corrects the release note for the model PartAsPlanned.
Meaning: 1.0.1 receives the label: "release" and 1.0.0 the label "deprecate. 
Discussed with @bs-jokri. 


 -->

Closes #234 

