### PR TITLE
[Model deprecation]: io.catenax.battery.battery_pass:2.0.0

### DIFF
--- a/io.catenax.battery.battery_pass/2.0.0/metadata.json
+++ b/io.catenax.battery.battery_pass/2.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{ "status" : "deprecate"} 


### PR DESCRIPTION
io.catenax.battery.battery_pass:2.0.0
closes #333
