### PR TITLE
[Model deprecation]:io.catenax.esr_certificates.esr_certificate:1.0.1

### DIFF
--- a/io.catenax.esr_certificates.esr_certificate/1.0.1/metadata.json
+++ b/io.catenax.esr_certificates.esr_certificate/1.0.1/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{ "status" : "deprecate"} 


### PR DESCRIPTION
deprecate io.catenax.esr_certificates.esr_certificate:1.0.1
close #338 

