### PR TITLE
[Model deprecation]: week_based_capacity_group:1.0.0

### DIFF
--- a/io.catenax.week_based_capacity_group/1.0.0/metadata.json
+++ b/io.catenax.week_based_capacity_group/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release" }
+{ "status" : "deprecate" }


### PR DESCRIPTION
## Description
deprecating week_based_capacity_group:1.0.0
closes #384



 

