### PR TITLE
[Model Deprecation]: urn:bamm:io.catenax.esr_certificates.esr_certifi…

### DIFF
--- a/io.catenax.esr_certificates.esr_certificate_state_statistic/1.0.1/metadata.json
+++ b/io.catenax.esr_certificates.esr_certificate_state_statistic/1.0.1/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{ "status" : "deprecate"} 


### PR DESCRIPTION
## Description
Deprecating model 
urn:bamm:io.catenax.esr_certificates.esr_certificate_state_statistic:1.0.1 
closes #339

