### PR TITLE
Update IotSensorDeviceDefinition v.2.0.0

### DIFF
--- a/io.catenax.iot_sensor_device_definition/2.0.0/IotSensorDeviceDefinition.ttl
+++ b/io.catenax.iot_sensor_device_definition/2.0.0/IotSensorDeviceDefinition.ttl
@@ -22,7 +22,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.iot_sensor_device_definition:1.0.0#> .
+@prefix : <urn:samm:io.catenax.iot_sensor_device_definition:2.0.0#> .
 
 :IotSensorDeviceDefinition a samm:Aspect ;
    samm:preferredName "IoT Sensor Device Definition"@en ;

--- a/io.catenax.iot_sensor_device_definition/2.0.0/IotSensorDeviceDefinition.ttl
+++ b/io.catenax.iot_sensor_device_definition/2.0.0/IotSensorDeviceDefinition.ttl
@@ -23,6 +23,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <urn:samm:io.catenax.iot_sensor_device_definition:2.0.0#> .
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:1.0.0#> .
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:1.0.0#> .
 
 :IotSensorDeviceDefinition a samm:Aspect ;
    samm:preferredName "IoT Sensor Device Definition"@en ;
@@ -34,7 +36,7 @@
 :catenaXId a samm:Property ;
    samm:preferredName "Catena-X Identifier"@en ;
    samm:description "The fully anonymous Catena-X ID of the serialized part, valid for the Catena-X dataspace."@en ;
-   samm:characteristic :CatenaXIdTrait ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
    samm:exampleValue "urn:uuid:7a6a8376-1783-4926-9be0-5d946622b2e2" .
 
 :manufacturer a samm:Property ;
@@ -59,14 +61,8 @@
 :ownerID a samm:Property ;
    samm:preferredName "IoT Sensor Device Owner"@en ;
    samm:description "The Catena-X BPNL of the device owner."@en ;
-   samm:characteristic :OwnerIDCharacteristic ;
+   samm:characteristic ext-number:BpnlTrait ;
    samm:exampleValue "BPNL00000003ABCD" .
-
-:CatenaXIdTrait a samm-c:Trait ;
-   samm:preferredName "Catena-X ID Trait"@en ;
-   samm:description "Trait to ensure data format for Catena-X ID"@en ;
-   samm-c:baseCharacteristic :UUIDv4 ;
-   samm-c:constraint :UUIDv4RegularExpression .
 
 :ManufacturerCharacteristic a samm:Characteristic ;
    samm:preferredName "IoT Device Manufacturer Name"@en ;
@@ -83,20 +79,3 @@
    samm:preferredName "IoT Device Serial Number"@en ;
    samm:description "Describes the characteristic of the property serial number."@en ;
    samm:dataType xsd:string .
-
-:OwnerIDCharacteristic a samm:Characteristic ;
-   samm:preferredName "IoT Device Owner Characteristic"@en ;
-   samm:description "Describes the Characteristic of the property ownerID."@en ;
-   samm:dataType xsd:string .
-
-:UUIDv4 a samm:Characteristic ;
-   samm:preferredName "UUIDv4"@en ;
-   samm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en ;
-   samm:dataType xsd:string .
-
-:UUIDv4RegularExpression a samm-c:RegularExpressionConstraint ;
-   samm:preferredName "Catena-X Id Regular Expression"@en ;
-   samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en ;
-   samm:see <https://datatracker.ietf.org/doc/html/rfc4122> ;
-   samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)" .
-

--- a/io.catenax.iot_sensor_device_definition/2.0.0/IotSensorDeviceDefinition.ttl
+++ b/io.catenax.iot_sensor_device_definition/2.0.0/IotSensorDeviceDefinition.ttl
@@ -1,0 +1,102 @@
+#######################################################################
+# Copyright (c) 2023 BASF SE
+# Copyright (c) 2023 Henkel AG & Co. KGaA
+# Copyright (c) 2023 ZF Friedrichshafen AG
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.iot_sensor_device_definition:1.0.0#> .
+
+:IotSensorDeviceDefinition a samm:Aspect ;
+   samm:preferredName "IoT Sensor Device Definition"@en ;
+   samm:description "Permanent characteristics of the individual IoT sensor device."@en ;
+   samm:properties ( :catenaXId :manufacturer :type :serialNumber :ownerID ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:catenaXId a samm:Property ;
+   samm:preferredName "Catena-X Identifier"@en ;
+   samm:description "The fully anonymous Catena-X ID of the serialized part, valid for the Catena-X dataspace."@en ;
+   samm:characteristic :CatenaXIdTrait ;
+   samm:exampleValue "urn:uuid:7a6a8376-1783-4926-9be0-5d946622b2e2" .
+
+:manufacturer a samm:Property ;
+   samm:preferredName "Manufacturer"@en ;
+   samm:description "Manufacturer of the IoT sensor device."@en ;
+   samm:see <https://www.wikidata.org/wiki/Q13235160> ;
+   samm:characteristic :ManufacturerCharacteristic ;
+   samm:exampleValue "Company X" .
+
+:type a samm:Property ;
+   samm:preferredName "IoT Sensor  Device Type"@en ;
+   samm:description "The type of the IoT sensor device."@en ;
+   samm:characteristic :TypeCharacteristic ;
+   samm:exampleValue "TRACK02839" .
+
+:serialNumber a samm:Property ;
+   samm:preferredName "IoT Sensor Device Serial Number"@en ;
+   samm:description "The serial number of the IoT sensor device, as assigned by the manufacturer of the device."@en ;
+   samm:characteristic :SerialNumberCharacteristic ;
+   samm:exampleValue "123-0740-3434-A" .
+
+:ownerID a samm:Property ;
+   samm:preferredName "IoT Sensor Device Owner"@en ;
+   samm:description "The Catena-X BPNL of the device owner."@en ;
+   samm:characteristic :OwnerIDCharacteristic ;
+   samm:exampleValue "BPNL00000003ABCD" .
+
+:CatenaXIdTrait a samm-c:Trait ;
+   samm:preferredName "Catena-X ID Trait"@en ;
+   samm:description "Trait to ensure data format for Catena-X ID"@en ;
+   samm-c:baseCharacteristic :UUIDv4 ;
+   samm-c:constraint :UUIDv4RegularExpression .
+
+:ManufacturerCharacteristic a samm:Characteristic ;
+   samm:preferredName "IoT Device Manufacturer Name"@en ;
+   samm:description "Characteristic describing the property manufacturer."@en ;
+   samm:see <https://www.wikidata.org/wiki/Q184754> ;
+   samm:dataType xsd:string .
+
+:TypeCharacteristic a samm:Characteristic ;
+   samm:preferredName "IoT Device Type"@en ;
+   samm:description "Describes the characteristics of the given type of device."@en ;
+   samm:dataType xsd:string .
+
+:SerialNumberCharacteristic a samm:Characteristic ;
+   samm:preferredName "IoT Device Serial Number"@en ;
+   samm:description "Describes the characteristic of the property serial number."@en ;
+   samm:dataType xsd:string .
+
+:OwnerIDCharacteristic a samm:Characteristic ;
+   samm:preferredName "IoT Device Owner Characteristic"@en ;
+   samm:description "Describes the Characteristic of the property ownerID."@en ;
+   samm:dataType xsd:string .
+
+:UUIDv4 a samm:Characteristic ;
+   samm:preferredName "UUIDv4"@en ;
+   samm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en ;
+   samm:dataType xsd:string .
+
+:UUIDv4RegularExpression a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Catena-X Id Regular Expression"@en ;
+   samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en ;
+   samm:see <https://datatracker.ietf.org/doc/html/rfc4122> ;
+   samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)" .
+

--- a/io.catenax.iot_sensor_device_definition/2.0.0/metadata.json
+++ b/io.catenax.iot_sensor_device_definition/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.iot_sensor_device_definition/RELEASE_NOTES.md
+++ b/io.catenax.iot_sensor_device_definition/RELEASE_NOTES.md
@@ -2,13 +2,18 @@
 All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
+## [2.0.0] - 2023-11-13
+### Added
+N/A
+### Changed
+* Converted BAMM to SAMM
+### Removed
+N/A
 
+## [Unreleased]
 ## [1.0.0] - 2023-02-22
 ### Added
 - initial model
-
 ### Changed
-n/a
-
 ### Removed
 

--- a/io.catenax.iot_sensor_device_definition/RELEASE_NOTES.md
+++ b/io.catenax.iot_sensor_device_definition/RELEASE_NOTES.md
@@ -2,11 +2,12 @@
 All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
-## [2.0.0] - 2023-11-13
+## [2.0.0] - 2023-11-20
 ### Added
 N/A
 ### Changed
 * Converted BAMM to SAMM
+* Changed to use shared aspects for the UUID and BPNL.
 ### Removed
 N/A
 


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->
* Converted from BAMM to SAMM.

Closes #428

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
