### PR TITLE
Update IotSensorData

### DIFF
--- a/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
+++ b/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
@@ -151,7 +151,7 @@
 :sensorUnit a samm:Property ;
    samm:preferredName "Sensor Unit"@en ;
    samm:characteristic samm-c:UnitReference ;
-   samm:exampleValue "Celsius"^^samm:curie .
+   samm:exampleValue "unit: Celsius"^^samm:curie .
 
 :LatitudeCharacteristic a samm:Characteristic ;
    samm:preferredName "Latitude Characteristic"@en ;

--- a/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
+++ b/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
@@ -169,6 +169,7 @@
    samm:dataType xsd:decimal .
 
 :SensorValueCharacteristics a samm:Characteristic ;
+   samm:preferredName "Sensor Value Characteristic"@en ;
    samm:description "Describes the property which contains a sensor value of data type decimal."@en ;
    samm:dataType xsd:decimal .
 

--- a/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
+++ b/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
@@ -1,3 +1,20 @@
+#######################################################################
+# Copyright (c) 2023 BASF SE
+# Copyright (c) 2023 Henkel AG & Co. KGaA
+# Copyright (c) 2023 ZF Friedrichshafen AG
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
@@ -5,7 +22,8 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:org.eclipse.examples:2.0.0#> .
+@prefix : <urn:samm:io.catenax.iot_sensor_data:2.0.0#> .
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:1.0.0#> .
 
 :IotSensorData a samm:Aspect ;
    samm:preferredName "Iot Sensor Data"@en ;
@@ -17,7 +35,7 @@
 :catenaXId a samm:Property ;
    samm:preferredName "Catena-X Identifier"@en ;
    samm:description "The fully anonymous Catena-X ID of the asset, valid for the Catena-X dataspace."@en ;
-   samm:characteristic :CatenaXIdTrait ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
    samm:exampleValue "urn:uuid:ed85f17e-29dd-473c-9cb8-d7ad1dc44d2f" .
 
 :sensorRuntimeData a samm:Property ;
@@ -25,26 +43,10 @@
    samm:description "The information collected by a Sensor device at an instance in time."@en ;
    samm:characteristic :SensorRuntimeDataCharacteristics .
 
-:CatenaXIdTrait a samm-c:Trait ;
-   samm:preferredName "Catena-X Id Trait"@en ;
-   samm:description "Trait to ensure UUID v4 data format."@en ;
-   samm-c:baseCharacteristic :UUIDv4 ;
-   samm-c:constraint :CatenaXIdRegularExpression .
-
 :SensorRuntimeDataCharacteristics a samm-c:List ;
    samm:preferredName "Sensor Runtime Data Characteristics"@en ;
    samm:description "Characteristic describing the list of the Sensor Runtime Data property."@en ;
    samm:dataType :SensorRuntimeDataEntity .
-
-:UUIDv4 a samm:Characteristic ;
-   samm:preferredName "UUIDv4"@en ;
-   samm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en ;
-   samm:dataType xsd:string .
-
-:CatenaXIdRegularExpression a samm-c:RegularExpressionConstraint ;
-   samm:preferredName "Catena-X Id Regular Expression"@en ;
-   samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en ;
-   samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)" .
 
 :SensorRuntimeDataEntity a samm:Entity ;
    samm:preferredName "Sensor Runtime Data Entity"@en ;

--- a/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
+++ b/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
@@ -151,7 +151,7 @@
 :sensorUnit a samm:Property ;
    samm:preferredName "Sensor Unit"@en ;
    samm:characteristic samm-c:UnitReference ;
-   samm:exampleValue "unit: Celsius"^^samm:curie .
+   samm:exampleValue "unit:Celsius"^^samm:curie .
 
 :LatitudeCharacteristic a samm:Characteristic ;
    samm:preferredName "Latitude Characteristic"@en ;

--- a/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
+++ b/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
@@ -1,0 +1,172 @@
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:org.eclipse.examples:1.0.0#> .
+
+:IotSensorData a samm:Aspect ;
+   samm:preferredName "Iot Sensor Data"@en ;
+   samm:description "The data collected by an IoT Sensor Device."@en ;
+   samm:properties ( :catenaXId :sensorRuntimeData ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:catenaXId a samm:Property ;
+   samm:preferredName "Catena-X Identifier"@en ;
+   samm:description "The fully anonymous Catena-X ID of the asset, valid for the Catena-X dataspace."@en ;
+   samm:characteristic :CatenaXIdTrait ;
+   samm:exampleValue "urn:uuid:ed85f17e-29dd-473c-9cb8-d7ad1dc44d2f" .
+
+:sensorRuntimeData a samm:Property ;
+   samm:preferredName "Sensor Runtime Data"@en ;
+   samm:description "The information collected by a Sensor device at an instance in time."@en ;
+   samm:characteristic :SensorRuntimeDataCharacteristics .
+
+:CatenaXIdTrait a samm-c:Trait ;
+   samm:preferredName "Catena-X Id Trait"@en ;
+   samm:description "Trait to ensure UUID v4 data format."@en ;
+   samm-c:baseCharacteristic :UUIDv4 ;
+   samm-c:constraint :CatenaXIdRegularExpression .
+
+:SensorRuntimeDataCharacteristics a samm-c:List ;
+   samm:preferredName "Sensor Runtime Data Characteristics"@en ;
+   samm:description "Characteristic describing the list of the Sensor Runtime Data property."@en ;
+   samm:dataType :SensorRuntimeDataEntity .
+
+:UUIDv4 a samm:Characteristic ;
+   samm:preferredName "UUIDv4"@en ;
+   samm:description "A version 4 UUID is a universally unique identifier that is generated using random 32 hexadecimal characters."@en ;
+   samm:dataType xsd:string .
+
+:CatenaXIdRegularExpression a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Catena-X Id Regular Expression"@en ;
+   samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI."@en ;
+   samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)" .
+
+:SensorRuntimeDataEntity a samm:Entity ;
+   samm:preferredName "Sensor Runtime Data Entity"@en ;
+   samm:description "Encapsulates the Sensor Data relevant attributes."@en ;
+   samm:properties ( :sensorGeoLocation :batteryLevel :timestamp :sensorData :transmissionMethod ) .
+
+:sensorGeoLocation a samm:Property ;
+   samm:preferredName "Sensor Geo Location"@en ;
+   samm:description "Geodata, geographic data or geospatial data, refers to data and information that has explicit or implicit association with a location relative to Earth."@en ;
+   samm:characteristic :SensorGeoLocationCharacteristics .
+
+:batteryLevel a samm:Property ;
+   samm:preferredName "Battery Level"@en ;
+   samm:description "The battery level displays how much charge of the battery has been left."@en ;
+   samm:characteristic :BatteryLevelCharacteristic ;
+   samm:exampleValue "50.00"^^xsd:decimal .
+
+:timestamp a samm:Property ;
+   samm:preferredName "Timestamp"@en ;
+   samm:description "The timestamp of the latest sensor reading."@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-02-04T14:48:54"^^xsd:dateTime .
+
+:sensorData a samm:Property ;
+   samm:preferredName "Sensor Data"@en ;
+   samm:description "The data collected by an IoT Sensor Device."@en ;
+   samm:characteristic :SensorDataCharacteristics .
+
+:transmissionMethod a samm:Property ;
+   samm:preferredName "Transmission Method"@en ;
+   samm:description "The method under which the sensing data is transmitted from the source to the remote node."@en ;
+   samm:characteristic :TransmissionMethodCharacteristic ;
+   samm:exampleValue "LoRaWAN" .
+
+:SensorGeoLocationCharacteristics a samm:Characteristic ;
+   samm:preferredName "Sensor Geo Location Characteristics"@en ;
+   samm:description "Characteristic to describe the related Geo data."@en ;
+   samm:dataType :SensorGeoLocationEntity .
+
+:BatteryLevelCharacteristic a samm-c:Measurement ;
+   samm:preferredName "Battery Level Characteristic"@en ;
+   samm:description "Characteristic to describe the property battery level."@en ;
+   samm:dataType xsd:decimal ;
+   samm-c:unit unit:percent .
+
+:SensorDataCharacteristics a samm-c:List ;
+   samm:preferredName "Sensor Data Characteristics"@en ;
+   samm:description "Characteristic to describe the related Sensor data."@en ;
+   samm:dataType :SensorDataEntity .
+
+:TransmissionMethodCharacteristic a samm:Characteristic ;
+   samm:preferredName "Transmission Method Characteristic"@en ;
+   samm:description "Characteristic that describes the property transmission method."@en ;
+   samm:dataType xsd:string .
+
+:SensorGeoLocationEntity a samm:Entity ;
+   samm:preferredName "Sensor Geo Location Entity"@en ;
+   samm:description "Encapsulates the Geo Data relevant attributes."@en ;
+   samm:properties ( :latitude :longitude :altitude :geoDataTimestamp ) .
+
+:SensorDataEntity a samm:Entity ;
+   samm:preferredName "Sensor Data Entity"@en ;
+   samm:description "Encapsulates the Sensor Data relevant attributes."@en ;
+   samm:properties ( :sensorType :sensorValue :sensorUnit ) .
+
+:latitude a samm:Property ;
+   samm:preferredName "Latitude"@en ;
+   samm:description "The angle between zenith and a plane parallel to the equator."@en ;
+   samm:characteristic :LatitudeCharacteristic ;
+   samm:exampleValue "40.20361"^^xsd:decimal .
+
+:longitude a samm:Property ;
+   samm:preferredName "Longitude"@en ;
+   samm:description "Geographic coordinate that specifies the east-west position of a point on the Earth's surface."@en ;
+   samm:characteristic :LongitudeCharacteristic ;
+   samm:exampleValue "11.3102"^^xsd:decimal .
+
+:altitude a samm:Property ;
+   samm:preferredName "Altitude"@en ;
+   samm:description "Antenna Altitude above/below mean-sea-level (geoid)."@en ;
+   samm:characteristic :AltitudeCharacteristic ;
+   samm:exampleValue "280.20"^^xsd:decimal .
+
+:geoDataTimestamp a samm:Property ;
+   samm:preferredName "Geo Data Timestamp"@en ;
+   samm:description "The timestamp of the latest sensor reading of the geo data."@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-02-04T14:48:54"^^xsd:dateTime .
+
+:sensorType a samm:Property ;
+   samm:preferredName "Sensor Type"@en ;
+   samm:description "Different types of sensors that are commonly used in various applications, measuring one of the physical properties like Temperature, Pressure,  Resistance, Shock, Conduction, Heat Transfer etc."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Temperature" .
+
+:sensorValue a samm:Property ;
+   samm:preferredName "Sensor Value"@en ;
+   samm:description "The measured value of the sensor type."@en ;
+   samm:characteristic :SensorValueCharacteristics ;
+   samm:exampleValue "32.00"^^xsd:decimal .
+
+:sensorUnit a samm:Property ;
+   samm:preferredName "Sensor Unit"@en ;
+   samm:characteristic samm-c:UnitReference ;
+   samm:exampleValue "Celsius"^^samm:curie .
+
+:LatitudeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Latitude Characteristic"@en ;
+   samm:description "Characteristic describing the property latitude."@en ;
+   samm:dataType xsd:decimal .
+
+:LongitudeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Longitude Characteristic"@en ;
+   samm:description "Characteristic describing the property longitude."@en ;
+   samm:dataType xsd:decimal .
+
+:AltitudeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Altitude Characteristic"@en ;
+   samm:description "Characteristic describing the property altitude."@en ;
+   samm:dataType xsd:decimal .
+
+:SensorValueCharacteristics a samm:Characteristic ;
+   samm:description "Describes the property which contains a sensor value of data type decimal."@en ;
+   samm:dataType xsd:decimal .
+

--- a/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
+++ b/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
@@ -5,7 +5,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:org.eclipse.examples:1.0.0#> .
+@prefix : <urn:samm:org.eclipse.examples:2.0.0#> .
 
 :IotSensorData a samm:Aspect ;
    samm:preferredName "Iot Sensor Data"@en ;

--- a/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
+++ b/io.catenax.iot_sensor_data/2.0.0/IotSensorData.ttl
@@ -156,16 +156,19 @@
 :LatitudeCharacteristic a samm:Characteristic ;
    samm:preferredName "Latitude Characteristic"@en ;
    samm:description "Characteristic describing the property latitude."@en ;
+   samm:see <https://www.iso.org/standard/75147.html> ;
    samm:dataType xsd:decimal .
 
 :LongitudeCharacteristic a samm:Characteristic ;
    samm:preferredName "Longitude Characteristic"@en ;
    samm:description "Characteristic describing the property longitude."@en ;
+   samm:see <https://www.iso.org/standard/75147.html> ;
    samm:dataType xsd:decimal .
 
 :AltitudeCharacteristic a samm:Characteristic ;
    samm:preferredName "Altitude Characteristic"@en ;
    samm:description "Characteristic describing the property altitude."@en ;
+   samm:see <https://www.iso.org/standard/75147.html> ;
    samm:dataType xsd:decimal .
 
 :SensorValueCharacteristics a samm:Characteristic ;

--- a/io.catenax.iot_sensor_data/2.0.0/metadata.json
+++ b/io.catenax.iot_sensor_data/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.iot_sensor_data/RELEASE_NOTES.md
+++ b/io.catenax.iot_sensor_data/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
-## [2.0.0] - 2023-11-13
+## [2.0.0] - 2023-11-20
 ### Added
 
 ### Changed

--- a/io.catenax.iot_sensor_data/RELEASE_NOTES.md
+++ b/io.catenax.iot_sensor_data/RELEASE_NOTES.md
@@ -3,6 +3,15 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.0] - 2023-11-13
+### Added
+
+### Changed
+* From static to dynamic data attributes.
+* Converted from BAMM to SAMM.
+
+### Removed
+
 ## [1.0.0] - 2023-02-22
 ### Added
 - initial model

--- a/io.catenax.iot_sensor_data/RELEASE_NOTES.md
+++ b/io.catenax.iot_sensor_data/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
-## [1.0.0] - 2023-11-13
+## [2.0.0] - 2023-11-13
 ### Added
 
 ### Changed


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->
* Converted from BAMM to SAMM
* Changed from static to dynamic data attributes.

Ex. json:

``` json
{
  "sensorRuntimeData": [
    {
      "sensorData": [
        {
          "sensorValue": 32,
          "sensorUnit": "unit:Celsius",
          "sensorType": "Temperature"
        }
      ],
      "sensorGeoLocation": {
        "altitude": 280.2,
        "geoDataTimestamp": "2023-02-04T14:48:54",
        "latitude": 40.20361,
        "longitude": 11.3102
      },
      "batteryLevel": 50,
      "timestamp": "2023-02-04T14:48:54",
      "transmissionMethod": "LoRaWAN"
    }
  ],
  "catenaXId": "urn:uuid:ed85f17e-29dd-473c-9cb8-d7ad1dc44d2f"
}
```
Closes #427 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
