### PR TITLE
[Model Update]: ReuseCertificate_v2.0.0

### DIFF
--- a/io.catenax.reuse_certificate/2.0.0/ReuseCertificate.ttl
+++ b/io.catenax.reuse_certificate/2.0.0/ReuseCertificate.ttl
@@ -33,5 +33,6 @@
 
 :certificate a samm:Property ;
    samm:preferredName "Certificate"@en ;
+   samm:description "A property of the model, named certificate."@en ;
    samm:characteristic ext-certificate:RecyclingStrategyCertificateCharacteristic .
 

--- a/io.catenax.reuse_certificate/2.0.0/ReuseCertificate.ttl
+++ b/io.catenax.reuse_certificate/2.0.0/ReuseCertificate.ttl
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft
 # Copyright (c) 2023 LRP Autorecycling Leipzig GmbH
 # Copyright (c) 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
-# Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.reuse_certificate/2.0.0/ReuseCertificate.ttl
+++ b/io.catenax.reuse_certificate/2.0.0/ReuseCertificate.ttl
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 SAP SE
+# Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft
+# Copyright (c) 2023 LRP Autorecycling Leipzig GmbH
+# Copyright (c) 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.reuse_certificate:2.0.0#> .
+@prefix ext-certificate: <urn:samm:io.catenax.shared.recycling_strategy_certificate:2.0.0#> .
+
+:ReuseCertificate a samm:Aspect ;
+   samm:preferredName "Reuse certificate"@en ;
+   samm:description "The certificate marks the point in time at which an asset irrevocably enters a new life. The eol (end of life) phase is completed and a new product life cycle is started."@en ;
+   samm:properties ( :certificate ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:certificate a samm:Property ;
+   samm:preferredName "Certificate"@en ;
+   samm:characteristic ext-certificate:RecyclingStrategyCertificateCharacteristic .
+

--- a/io.catenax.reuse_certificate/2.0.0/metadata.json
+++ b/io.catenax.reuse_certificate/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.reuse_certificate/RELEASE_NOTES.md
+++ b/io.catenax.reuse_certificate/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
-## [2.0.0] - 2023-11-20
+## [2.0.0] - 2023-12-04
 ### Added
 - Upgrade from BAMM model to SAMM model
 - Update based on shared aspect "recycling strategy certificate"

--- a/io.catenax.reuse_certificate/RELEASE_NOTES.md
+++ b/io.catenax.reuse_certificate/RELEASE_NOTES.md
@@ -3,6 +3,16 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0] - 2023-11-20
+### Added
+- Upgrade from BAMM model to SAMM model
+- Update based on shared aspect "recycling strategy certificate"
+
+### Changed
+
+
+### Removed
+
 ## [1.0.0] - 2023-02-08
 ### Added
 - initial model


### PR DESCRIPTION
## Description
As mentioned in issue https://github.com/eclipse-tractusx/sldt-semantic-models/issues/324 and in pull request https://github.com/eclipse-tractusx/sldt-semantic-models/pull/420. A new version of this model is generated.

 -->

Closes #324 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.2)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
