### PR TITLE
[Model Update]: return request_v2.0.0

### DIFF
--- a/io.catenax.return_request/2.0.0/ReturnRequest.ttl
+++ b/io.catenax.return_request/2.0.0/ReturnRequest.ttl
@@ -97,7 +97,7 @@
 
 :isRecall a samm:Property ;
    samm:preferredName "is recall"@en ;
-   samm:description "Depicts if the manufacturer issued a recall (e.g. for security reasons). In concjunction with property needsReturn it can be expressed if the item has to be returned or can directly be destroyed."@en ;
+   samm:description "Depicts if the manufacturer issued a recall (e.g. for security reasons). In conjunction with property needsReturn it can be expressed if the item has to be returned or can directly be destroyed."@en ;
    samm:characteristic samm-c:Boolean ;
    samm:exampleValue false .
 
@@ -204,20 +204,20 @@
 :mileage a samm:Property ;
    samm:preferredName "mileage"@en ;
    samm:description "Current mileage of the component"@en ;
-   samm:characteristic :Mileage ;
+   samm:characteristic :NumericValueofMileage ;
    samm:exampleValue 89000 .
 
 :startDate a samm:Property ;
    samm:preferredName "start date"@en ;
    samm:description "The first day of the period"@en ;
-   samm:characteristic samm-c:Timestamp ;
-   samm:exampleValue "2019-01-01"^^xsd:dateTime .
+   samm:characteristic :DateTimestamp ;
+   samm:exampleValue "2019-01-01"^^xsd:date .
 
 :endDate a samm:Property ;
    samm:preferredName "end date"@en ;
    samm:description "The last day of the period."@en ;
-   samm:characteristic samm-c:Timestamp ;
-   samm:exampleValue "2030-09-30"^^xsd:dateTime .
+   samm:characteristic :DateTimestamp ;
+   samm:exampleValue "2030-09-30"^^xsd:date .
 
 :manufacturingPartID a samm:Property ;
    samm:preferredName "manufacturing part id"@en ;
@@ -237,8 +237,9 @@
    samm:characteristic samm-c:Text ;
    samm:exampleValue "PODBS39HZ7382HDG28" .
 
-:Mileage a samm-c:Measurement ;
-   samm:preferredName "mileage"@en ;
+:NumericValueofMileage a samm-c:Measurement ;
+   samm:preferredName "value of mileage"@en ;
+   samm:description "Represents the value of mileage."@en ;
    samm:dataType xsd:integer ;
    samm-c:unit unit:kilometre .
 

--- a/io.catenax.return_request/2.0.0/ReturnRequest.ttl
+++ b/io.catenax.return_request/2.0.0/ReturnRequest.ttl
@@ -1,0 +1,249 @@
+#######################################################################
+# Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft
+# Copyright (c) 2023 Robert Bosch GmbH
+# Copyright (c) 2023 Henkel AG & Co. KGaA
+# Copyright (c) 2023 LRP Autorecycling Leipzig GmbH
+# Copyright (c) 2023 SAP SE
+# Copyright (c) 2023 ZF Friedrichshafen AG
+# Copyright (c) 2023 Circular Economy Solutions GmbH (C-ECO)
+# Copyright (c) 2023 T-Systems International GmbH
+# Copyright (c) 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the 
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license, 
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.return_request:2.0.0#> .
+
+:ReturnRequest a samm:Aspect ;
+   samm:preferredName "return request"@en ;
+   samm:description "Aspect to indicate if there is a return request for a product."@en ;
+   samm:properties ( :needsReturn :returnConditions :requestDate :latestReturnDate :productConditions :title :marketplaceProduct :quantity :unitOfMeasure :validityPeriod :isRecall :identification :productionDate :deliveryAddress :areaOfUsage :productGroup :arrivalDateAtCustomer ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:needsReturn a samm:Property ;
+   samm:preferredName "needs return"@en ;
+   samm:description "Describes the fact whether a vehicle, assembly or part needs to be returned to requestor."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:returnConditions a samm:Property ;
+   samm:preferredName "return conditions"@en ;
+   samm:description "Describes WHY a vehicle, assembly or part needs to be returned to the requestor and under which conditions."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Wishes to buy" .
+
+:requestDate a samm:Property ;
+   samm:preferredName "request date"@en ;
+   samm:description "Describes date when the return request was placed."@en ;
+   samm:characteristic :DateTimestamp ;
+   samm:exampleValue "2022-01-01"^^xsd:date .
+
+:latestReturnDate a samm:Property ;
+   samm:preferredName "latest return date"@en ;
+   samm:description "Describes until when the return request is valid."@en ;
+   samm:characteristic :DateTimestamp ;
+   samm:exampleValue "2025-01-01"^^xsd:date .
+
+:productConditions a samm:Property ;
+   samm:preferredName "product conditions"@en ;
+   samm:description "textual description of the product conditions"@en ;
+   samm:characteristic :ProductConditionsCharacteristic .
+
+:title a samm:Property ;
+   samm:preferredName "title"@en ;
+   samm:description "The request name to be used by the buyer to navigate through the list of demand requests."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BMW 318i Brake caliper" .
+
+:marketplaceProduct a samm:Property ;
+   samm:preferredName "marketplace product"@en ;
+   samm:description "The description of the product within the marketplace that might differ from the digital twin."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BMW 318i E46 Coupe Bj.2000 Bremssattel hinten links" .
+
+:quantity a samm:Property ;
+   samm:preferredName "quantity"@en ;
+   samm:description "The desired quantity of the on the marketplace offered product in SKU."@en ;
+   samm:characteristic :QuantityCharacteristic ;
+   samm:exampleValue "50.00"^^xsd:float .
+
+:unitOfMeasure a samm:Property ;
+   samm:preferredName "unit of measure"@en ;
+   samm:description "The unit of measure (related to quantity)."@en ;
+   samm:see <https://resources.gs1us.org/GS1-US-Data-Hub-Help-Center/ArtMID/3451/ArticleID/116/Unit-of-Measure-Codes> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "kg" .
+
+:validityPeriod a samm:Property ;
+   samm:preferredName "validity period"@en ;
+   samm:description "Specifies the time period when the need exists"@en ;
+   samm:characteristic :TimePeriod .
+
+:isRecall a samm:Property ;
+   samm:preferredName "is recall"@en ;
+   samm:description "Depicts if the manufacturer issued a recall (e.g. for security reasons). In concjunction with property needsReturn it can be expressed if the item has to be returned or can directly be destroyed."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue false .
+
+:identification a samm:Property ;
+   samm:preferredName "identification"@en ;
+   samm:description "The unique identifier of the product (via manufacturingPartID, OeNumber and/or serialNumber)\n"@en ;
+   samm:characteristic :IdentificationCharacteristic .
+
+:productionDate a samm:Property ;
+   samm:preferredName "production date"@en ;
+   samm:description "Date, when the component was manufactured"@en ;
+   samm:characteristic :DateTimestamp ;
+   samm:exampleValue "2000-01-01"^^xsd:date .
+
+:deliveryAddress a samm:Property ;
+   samm:preferredName "delivery address"@en ;
+   samm:description "The address that the product should be delivered to"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Unten den Linden 1" .
+
+:areaOfUsage a samm:Property ;
+   samm:preferredName "area of usage"@en ;
+   samm:description "Information, in which countries/areas the component has been in use"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Sahara, extreme dry and high temperature" .
+
+:productGroup a samm:Property ;
+   samm:preferredName "product group"@en ;
+   samm:description "Classification of product group"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "power unit" .
+
+:arrivalDateAtCustomer a samm:Property ;
+   samm:preferredName "arrival date at customer"@en ;
+   samm:description "Until when should the product arrive (if known)"@en ;
+   samm:characteristic :DateTimestamp ;
+   samm:exampleValue "2023-12-01"^^xsd:date .
+
+:DateTimestamp a samm:Characteristic ;
+   samm:preferredName "date timestamp"@en ;
+   samm:description "Timestamp for dates"@en ;
+   samm:dataType xsd:date .
+
+:ProductConditionsCharacteristic a samm:Characteristic ;
+   samm:preferredName "product conditions characteristic"@en ;
+   samm:description "Criteria describing the state of a product on the marketplace."@en ;
+   samm:dataType :ProductConditionsEntity .
+
+:QuantityCharacteristic a samm:Characteristic ;
+   samm:preferredName "quantity characteristic"@en ;
+   samm:description "Characteristic describing the quantity"@en ;
+   samm:dataType xsd:float .
+
+:TimePeriod a samm-c:SortedSet ;
+   samm:preferredName "time period"@en ;
+   samm:description "Depicts a time period by specifying start and end date"@en ;
+   samm:dataType :TimePeriodEntity .
+
+:IdentificationCharacteristic a samm:Characteristic ;
+   samm:preferredName "identification characteristic"@en ;
+   samm:description "The unique identifier of the product (via manufacturingPartID, OeNumber and/or serialNumber)\n"@en ;
+   samm:dataType :IdentificationEntity .
+
+:ProductConditionsEntity a samm:Entity ;
+   samm:preferredName "product conditions entity"@en ;
+   samm:description "Entity encapsulating the conditions the product is in."@en ;
+   samm:properties ( [ samm:property :missingParts; samm:optional true ] [ samm:property :dismantled; samm:optional true ] [ samm:property :mechanicalDamage; samm:optional true ] [ samm:property :corroded; samm:optional true ] [ samm:property :discolored; samm:optional true ] :mileage ) .
+
+:TimePeriodEntity a samm:Entity ;
+   samm:preferredName "time period"@en ;
+   samm:description "Entity defining a range of dates to define a time period."@en ;
+   samm:properties ( :startDate :endDate ) .
+
+:IdentificationEntity a samm:Entity ;
+   samm:preferredName "identification entity"@en ;
+   samm:description "Entity encapsulating different unique identifier of the product (manufacturingPartID, OeNumber and/or serialNumber)"@en ;
+   samm:properties ( :manufacturingPartID :oeNumber :serialNumber ) .
+
+:missingParts a samm:Property ;
+   samm:preferredName "missing parts"@en ;
+   samm:description "Completeness of the product, e.g. missing parts are not acceptable."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:dismantled a samm:Property ;
+   samm:preferredName "dismantled"@en ;
+   samm:description "Information on whether the product has been dismantled."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:mechanicalDamage a samm:Property ;
+   samm:preferredName "mechanical damage"@en ;
+   samm:description "Information on mechanical damage to the part, e.g. two broken ribs or part deformation indicate mechanical damage."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:corroded a samm:Property ;
+   samm:preferredName "corroded"@en ;
+   samm:description "Information on whether the product has corrosion."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:discolored a samm:Property ;
+   samm:preferredName "discolored"@en ;
+   samm:description "Information on whether the product has been discoloured."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:mileage a samm:Property ;
+   samm:preferredName "mileage"@en ;
+   samm:description "Current mileage of the component"@en ;
+   samm:characteristic :Mileage ;
+   samm:exampleValue 89000 .
+
+:startDate a samm:Property ;
+   samm:preferredName "start date"@en ;
+   samm:description "The first day of the period"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2019-01-01"^^xsd:dateTime .
+
+:endDate a samm:Property ;
+   samm:preferredName "end date"@en ;
+   samm:description "The last day of the period."@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2030-09-30"^^xsd:dateTime .
+
+:manufacturingPartID a samm:Property ;
+   samm:preferredName "manufacturing part id"@en ;
+   samm:description "The unique identifier of the product from the manufacturer, characterizes the type of component"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "4S7R7002DB" .
+
+:oeNumber a samm:Property ;
+   samm:preferredName "oe number"@en ;
+   samm:description "The unique identifier of the product from the original manufacturer, characterizes the type of component"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "8O8RKJZ7ER" .
+
+:serialNumber a samm:Property ;
+   samm:preferredName "serial number"@en ;
+   samm:description "Serial number as unique identifier for a part"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "PODBS39HZ7382HDG28" .
+
+:Mileage a samm-c:Measurement ;
+   samm:preferredName "mileage"@en ;
+   samm:dataType xsd:integer ;
+   samm-c:unit unit:kilometre .
+

--- a/io.catenax.return_request/2.0.0/ReturnRequest.ttl
+++ b/io.catenax.return_request/2.0.0/ReturnRequest.ttl
@@ -28,6 +28,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <urn:samm:io.catenax.return_request:2.0.0#> .
+@prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:1.0.0#> .
 
 :ReturnRequest a samm:Aspect ;
    samm:preferredName "return request"@en ;
@@ -80,8 +81,7 @@
 :quantity a samm:Property ;
    samm:preferredName "quantity"@en ;
    samm:description "The desired quantity of the on the marketplace offered product in SKU."@en ;
-   samm:characteristic :QuantityCharacteristic ;
-   samm:exampleValue "50.00"^^xsd:float .
+   samm:characteristic ext-quantity:ItemQuantityCharacteristic .
 
 :unitOfMeasure a samm:Property ;
    samm:preferredName "unit of measure"@en ;
@@ -145,11 +145,6 @@
    samm:preferredName "product conditions characteristic"@en ;
    samm:description "Criteria describing the state of a product on the marketplace."@en ;
    samm:dataType :ProductConditionsEntity .
-
-:QuantityCharacteristic a samm:Characteristic ;
-   samm:preferredName "quantity characteristic"@en ;
-   samm:description "Characteristic describing the quantity"@en ;
-   samm:dataType xsd:float .
 
 :TimePeriod a samm-c:SortedSet ;
    samm:preferredName "time period"@en ;

--- a/io.catenax.return_request/2.0.0/ReturnRequest.ttl
+++ b/io.catenax.return_request/2.0.0/ReturnRequest.ttl
@@ -28,11 +28,11 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.return_request:2.0.0#> .
+@prefix : <urn:samm:io.catenax.return_request:3.0.0#> .
 @prefix ext-characteristic: <urn:samm:io.catenax.shared.address_characteristic:3.0.0#> .
 @prefix ext-classification: <urn:samm:io.catenax.shared.part_classification:1.0.0#> .
 @prefix ext-part: <urn:samm:io.catenax.serial_part:2.0.0#> .
-@prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:1.0.0#> .
+@prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:2.0.0#> .
 
 :ReturnRequest a samm:Aspect ;
    samm:preferredName "return request"@en ;

--- a/io.catenax.return_request/2.0.0/ReturnRequest.ttl
+++ b/io.catenax.return_request/2.0.0/ReturnRequest.ttl
@@ -28,10 +28,10 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.return_request:3.0.0#> .
+@prefix : <urn:samm:io.catenax.return_request:2.0.0#> .
 @prefix ext-characteristic: <urn:samm:io.catenax.shared.address_characteristic:3.0.0#> .
 @prefix ext-classification: <urn:samm:io.catenax.shared.part_classification:1.0.0#> .
-@prefix ext-part: <urn:samm:io.catenax.serial_part:2.0.0#> .
+@prefix ext-part: <urn:samm:io.catenax.serial_part:3.0.0#> .
 @prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:2.0.0#> .
 
 :ReturnRequest a samm:Aspect ;

--- a/io.catenax.return_request/2.0.0/ReturnRequest.ttl
+++ b/io.catenax.return_request/2.0.0/ReturnRequest.ttl
@@ -1,13 +1,14 @@
 #######################################################################
-# Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft
-# Copyright (c) 2023 Robert Bosch GmbH
-# Copyright (c) 2023 Henkel AG & Co. KGaA
-# Copyright (c) 2023 LRP Autorecycling Leipzig GmbH
-# Copyright (c) 2023 SAP SE
-# Copyright (c) 2023 ZF Friedrichshafen AG
-# Copyright (c) 2023 Circular Economy Solutions GmbH (C-ECO)
-# Copyright (c) 2023 T-Systems International GmbH
-# Copyright (c) 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# Copyright (c) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft
+# Copyright (c) 2023-2024 Robert Bosch GmbH
+# Copyright (c) 2023-2024 Henkel AG & Co. KGaA
+# Copyright (c) 2023-2024 LRP Autorecycling Leipzig GmbH
+# Copyright (c) 2023-2024 SAP SE
+# Copyright (c) 2023-2024 ZF Friedrichshafen AG
+# Copyright (c) 2023-2024 Circular Economy Solutions GmbH (C-ECO)
+# Copyright (c) 2023-2024 T-Systems International GmbH
+# Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -20,20 +21,23 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
-@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
-@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
-@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
-@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <urn:samm:io.catenax.return_request:2.0.0#> .
+@prefix ext-characteristic: <urn:samm:io.catenax.shared.address_characteristic:3.0.0#> .
+@prefix ext-classification: <urn:samm:io.catenax.shared.part_classification:1.0.0#> .
+@prefix ext-part: <urn:samm:io.catenax.serial_part:2.0.0#> .
 @prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:1.0.0#> .
 
 :ReturnRequest a samm:Aspect ;
    samm:preferredName "return request"@en ;
    samm:description "Aspect to indicate if there is a return request for a product."@en ;
-   samm:properties ( :needsReturn :returnConditions :requestDate :latestReturnDate :productConditions :title :marketplaceProduct :quantity :unitOfMeasure :validityPeriod :isRecall :identification :productionDate :deliveryAddress :areaOfUsage :productGroup :arrivalDateAtCustomer ) ;
+   samm:properties ( :needsReturn :returnConditions :requestDate :latestReturnDate :productConditions :title :marketplaceProduct :quantity :validityPeriod :isRecall :identification :productionDate :deliveryAddress :areaOfUsage :productGroup :arrivalDateAtCustomer ) ;
    samm:operations ( ) ;
    samm:events ( ) .
 
@@ -83,13 +87,6 @@
    samm:description "The desired quantity of the on the marketplace offered product in SKU."@en ;
    samm:characteristic ext-quantity:ItemQuantityCharacteristic .
 
-:unitOfMeasure a samm:Property ;
-   samm:preferredName "unit of measure"@en ;
-   samm:description "The unit of measure (related to quantity)."@en ;
-   samm:see <https://resources.gs1us.org/GS1-US-Data-Hub-Help-Center/ArtMID/3451/ArticleID/116/Unit-of-Measure-Codes> ;
-   samm:characteristic samm-c:Text ;
-   samm:exampleValue "kg" .
-
 :validityPeriod a samm:Property ;
    samm:preferredName "validity period"@en ;
    samm:description "Specifies the time period when the need exists"@en ;
@@ -115,8 +112,7 @@
 :deliveryAddress a samm:Property ;
    samm:preferredName "delivery address"@en ;
    samm:description "The address that the product should be delivered to"@en ;
-   samm:characteristic samm-c:Text ;
-   samm:exampleValue "Unten den Linden 1" .
+   samm:characteristic ext-characteristic:PostalAddress .
 
 :areaOfUsage a samm:Property ;
    samm:preferredName "area of usage"@en ;
@@ -127,8 +123,7 @@
 :productGroup a samm:Property ;
    samm:preferredName "product group"@en ;
    samm:description "Classification of product group"@en ;
-   samm:characteristic samm-c:Text ;
-   samm:exampleValue "power unit" .
+   samm:characteristic ext-classification:ClassificationCharacteristic .
 
 :arrivalDateAtCustomer a samm:Property ;
    samm:preferredName "arrival date at customer"@en ;
@@ -169,7 +164,7 @@
 :IdentificationEntity a samm:Entity ;
    samm:preferredName "identification entity"@en ;
    samm:description "Entity encapsulating different unique identifier of the product (manufacturingPartID, OeNumber and/or serialNumber)"@en ;
-   samm:properties ( :manufacturingPartID :oeNumber :serialNumber ) .
+   samm:properties ( :oeNumber ext-part:localIdentifiers ext-part:manufacturerPartId ) .
 
 :missingParts a samm:Property ;
    samm:preferredName "missing parts"@en ;
@@ -219,23 +214,11 @@
    samm:characteristic :DateTimestamp ;
    samm:exampleValue "2030-09-30"^^xsd:date .
 
-:manufacturingPartID a samm:Property ;
-   samm:preferredName "manufacturing part id"@en ;
-   samm:description "The unique identifier of the product from the manufacturer, characterizes the type of component"@en ;
-   samm:characteristic samm-c:Text ;
-   samm:exampleValue "4S7R7002DB" .
-
 :oeNumber a samm:Property ;
    samm:preferredName "oe number"@en ;
    samm:description "The unique identifier of the product from the original manufacturer, characterizes the type of component"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "8O8RKJZ7ER" .
-
-:serialNumber a samm:Property ;
-   samm:preferredName "serial number"@en ;
-   samm:description "Serial number as unique identifier for a part"@en ;
-   samm:characteristic samm-c:Text ;
-   samm:exampleValue "PODBS39HZ7382HDG28" .
 
 :NumericValueofMileage a samm-c:Measurement ;
    samm:preferredName "value of mileage"@en ;

--- a/io.catenax.return_request/2.0.0/ReturnRequest.ttl
+++ b/io.catenax.return_request/2.0.0/ReturnRequest.ttl
@@ -37,7 +37,7 @@
 :ReturnRequest a samm:Aspect ;
    samm:preferredName "return request"@en ;
    samm:description "Aspect to indicate if there is a return request for a product."@en ;
-   samm:properties ( :needsReturn :returnConditions :requestDate :latestReturnDate :productConditions :title :marketplaceProduct :quantity :validityPeriod :isRecall :identification :productionDate :deliveryAddress :areaOfUsage :productGroup :arrivalDateAtCustomer ) ;
+   samm:properties ( :needsReturn :returnConditions :requestDate :latestReturnDate :productConditions :marketplaceProduct :quantity :validityPeriod :isRecall :identification :deliveryAddress :areaOfUsage :arrivalDateAtCustomer ext-part:date ext-part:nameAtCustomer ext-classification:partClassification ) ;
    samm:operations ( ) ;
    samm:events ( ) .
 
@@ -70,12 +70,6 @@
    samm:description "textual description of the product conditions"@en ;
    samm:characteristic :ProductConditionsCharacteristic .
 
-:title a samm:Property ;
-   samm:preferredName "title"@en ;
-   samm:description "The request name to be used by the buyer to navigate through the list of demand requests."@en ;
-   samm:characteristic samm-c:Text ;
-   samm:exampleValue "BMW 318i Brake caliper" .
-
 :marketplaceProduct a samm:Property ;
    samm:preferredName "marketplace product"@en ;
    samm:description "The description of the product within the marketplace that might differ from the digital twin."@en ;
@@ -103,12 +97,6 @@
    samm:description "The unique identifier of the product (via manufacturingPartID, OeNumber and/or serialNumber)\n"@en ;
    samm:characteristic :IdentificationCharacteristic .
 
-:productionDate a samm:Property ;
-   samm:preferredName "production date"@en ;
-   samm:description "Date, when the component was manufactured"@en ;
-   samm:characteristic :DateTimestamp ;
-   samm:exampleValue "2000-01-01"^^xsd:date .
-
 :deliveryAddress a samm:Property ;
    samm:preferredName "delivery address"@en ;
    samm:description "The address that the product should be delivered to"@en ;
@@ -119,11 +107,6 @@
    samm:description "Information, in which countries/areas the component has been in use"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Sahara, extreme dry and high temperature" .
-
-:productGroup a samm:Property ;
-   samm:preferredName "product group"@en ;
-   samm:description "Classification of product group"@en ;
-   samm:characteristic ext-classification:ClassificationCharacteristic .
 
 :arrivalDateAtCustomer a samm:Property ;
    samm:preferredName "arrival date at customer"@en ;
@@ -164,7 +147,7 @@
 :IdentificationEntity a samm:Entity ;
    samm:preferredName "identification entity"@en ;
    samm:description "Entity encapsulating different unique identifier of the product (manufacturingPartID, OeNumber and/or serialNumber)"@en ;
-   samm:properties ( :oeNumber ext-part:localIdentifiers ext-part:manufacturerPartId ) .
+   samm:properties ( ext-part:localIdentifiers ext-part:manufacturerPartId ext-part:customerPartId ) .
 
 :missingParts a samm:Property ;
    samm:preferredName "missing parts"@en ;
@@ -213,12 +196,6 @@
    samm:description "The last day of the period."@en ;
    samm:characteristic :DateTimestamp ;
    samm:exampleValue "2030-09-30"^^xsd:date .
-
-:oeNumber a samm:Property ;
-   samm:preferredName "oe number"@en ;
-   samm:description "The unique identifier of the product from the original manufacturer, characterizes the type of component"@en ;
-   samm:characteristic samm-c:Text ;
-   samm:exampleValue "8O8RKJZ7ER" .
 
 :NumericValueofMileage a samm-c:Measurement ;
    samm:preferredName "value of mileage"@en ;

--- a/io.catenax.return_request/2.0.0/metadata.json
+++ b/io.catenax.return_request/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.return_request/RELEASE_NOTES.md
+++ b/io.catenax.return_request/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
-## [2.0.0] - 2023-12-04
+## [2.0.0] - 2023-12-11
 ### Added
 - Upgrade from BAMM model to SAMM model
 - Update attributes

--- a/io.catenax.return_request/RELEASE_NOTES.md
+++ b/io.catenax.return_request/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
-## [2.0.0] - 2023-12-11
+## [2.0.0] - 2024-01-29
 ### Added
 - Upgrade from BAMM model to SAMM model
 - Update attributes

--- a/io.catenax.return_request/RELEASE_NOTES.md
+++ b/io.catenax.return_request/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
+## [2.0.0] - 2023-11-27
+### Added
+- Upgrade from BAMM model to SAMM model
+- Update attributes
+
+### Changed
+
+
+### Removed
+
 ## [1.1.2] - 2023-01-30
 ### Added
 - 

--- a/io.catenax.return_request/RELEASE_NOTES.md
+++ b/io.catenax.return_request/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
-## [2.0.0] - 2023-11-27
+## [2.0.0] - 2023-12-04
 ### Added
 - Upgrade from BAMM model to SAMM model
 - Update attributes

--- a/io.catenax.return_request/RELEASE_NOTES.md
+++ b/io.catenax.return_request/RELEASE_NOTES.md
@@ -1,15 +1,17 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
-## [2.0.0] - 2024-01-29
+## [2.0.0] - 2024-02-05
 ### Added
 - Upgrade from BAMM model to SAMM model
 - Update attributes
+- link several models
 
 ### Changed
-
+- eclipse from 2.0.0 to 2.1.0
 
 ### Removed
+- property "unitOfMeasure" 
 
 ## [1.1.2] - 2023-01-30
 ### Added


### PR DESCRIPTION
## Description
As mentioned in issue: https://github.com/eclipse-tractusx/sldt-semantic-models/issues/313.

 -->

Closes #313 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.2)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
