### PR TITLE
[Model Update] shopfloor_information_types

### DIFF
--- a/io.catenax.shared.shopfloor_information_types/1.0.0/ShopfloorInformationTypes.ttl
+++ b/io.catenax.shared.shopfloor_information_types/1.0.0/ShopfloorInformationTypes.ttl
@@ -1,7 +1,7 @@
 ##########################################################################################
-# Copyright (c) 2023 Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
-# Copyright (c) 2023 Siemens AG
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IOSB & Fraunhofer IWU & Fraunhofer IPA)
+# Copyright (c) 2023-2024 Siemens AG
+# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -13,6 +13,7 @@
 #
 # SPDX-License-Identifier: CC-BY-4.0
 ##########################################################################################
+
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .

--- a/io.catenax.shared.shopfloor_information_types/1.0.0/metadata.json
+++ b/io.catenax.shared.shopfloor_information_types/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release" }
+{ "status" : "deprecated" }

--- a/io.catenax.shared.shopfloor_information_types/1.0.0/metadata.json
+++ b/io.catenax.shared.shopfloor_information_types/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "deprecated" }
+{ "status" : "release" }

--- a/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
+++ b/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
@@ -1,5 +1,5 @@
 ##########################################################################################
-# Copyright (c) 2023-2024 Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
+# Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IOSB & Fraunhofer IWU & Fraunhofer IPA)
 # Copyright (c) 2023-2024 Siemens AG
 # Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
 #
@@ -20,13 +20,13 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.shared.shopfloor_information_types:1.0.0#> .
-@prefix ext-header: <urn:samm:io.catenax.shared.message_header:1.0.0#> .
+@prefix : <urn:samm:io.catenax.shared.shopfloor_information_types:2.0.0#> .
+@prefix ext-header: <urn:samm:io.catenax.shared.message_header:2.0.0#> .
 
 :ShopfloorInformationTypes a samm:Aspect ;
    samm:preferredName "Shopfloor Information Types"@en ;
    samm:description "Collection of types used in multiple data models of the Shopfloor Information Service"@en ;
-   samm:properties ( :communicationMode :versionDataModel :timeValue ) ;
+   samm:properties ( :communicationMode :timeValue ext-header:version ) ;
    samm:operations ( ) ;
    samm:events ( ) .
 
@@ -35,12 +35,6 @@
    samm:description "Specification of the communication mode"@en ;
    samm:characteristic :CommunicationModeEnum ;
    samm:exampleValue "synchronous" .
-
-:versionDataModel a samm:Property ;
-   samm:preferredName "Version Data Model"@en ;
-   samm:description "Specifies the used version of the data model"@en ;
-   samm:characteristic ext-header:BpnCharacteristic ;
-   samm:exampleValue "urn:samm:io.catenax.shared.shopfloor_information_types:1.0.0" .
 
 :timeValue a samm:Property ;
    samm:preferredName "Time Value"@en ;
@@ -77,11 +71,13 @@
 :TimeUnitEnum a samm-c:Enumeration ;
    samm:preferredName "Time Unit Enum"@en ;
    samm:description "Enumerates all time units"@en ;
-   samm:dataType samm:curie ;
-   samm-c:values ( "unit:secondUnitOfTime"^^samm:curie "unit:minuteUnitOfTime"^^samm:curie "unit:hour"^^samm:curie "unit:day"^^samm:curie "unit:week"^^samm:curie "unit:month"^^samm:curie "unit:year"^^samm:curie ) .
+   samm:dataType xsd:string ;
+   samm-c:values ( "unit:secondUnitOfTime" "unit:minuteUnitOfTime" "unit:hour" "unit:day" "unit:week" "unit:month" "unit:year" ) .
 
 :IntegerValueCharacteristic a samm:Characteristic ;
    samm:preferredName "Integer Value Characteristic"@en ;
    samm:description "The value of the specified timeUnit as an integer value"@en ;
    samm:dataType xsd:integer .
+
+
 

--- a/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
+++ b/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
@@ -13,73 +13,69 @@
 #
 # SPDX-License-Identifier: CC-BY-4.0
 ##########################################################################################
-@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
-@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
-@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
-@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.shared.shopfloor_information_types:2.0.0#> .
-@prefix ext-header: <urn:samm:io.catenax.shared.message_header:2.0.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#>.
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#>.
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#>.
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:samm:io.catenax.shared.shopfloor_information_types:2.0.0#>.
+@prefix ext-header: <urn:samm:io.catenax.shared.message_header:2.0.0#>.
 
-:ShopfloorInformationTypes a samm:Aspect ;
-   samm:preferredName "Shopfloor Information Types"@en ;
-   samm:description "Collection of types used in multiple data models of the Shopfloor Information Service"@en ;
-   samm:properties ( :communicationMode :timeValue ) ;
-   samm:operations ( ) ;
-   samm:events ( ) .
+:ShopfloorInformationTypes a samm:Aspect;
+   samm:preferredName "Shopfloor Information Types"@en;
+   samm:description "Collection of types used in multiple data models of the Shopfloor Information Service"@en;
+   samm:properties ( :communicationMode :timeValue );
+   samm:operations ( );
+   samm:events ( ).
 
-:communicationMode a samm:Property ;
-   samm:preferredName "Communication Mode"@en ;
-   samm:description "Specification of the communication mode"@en ;
-   samm:characteristic :CommunicationModeEnum ;
-   samm:exampleValue "synchronous" .
+:communicationMode a samm:Property;
+   samm:preferredName "Communication Mode"@en;
+   samm:description "Specification of the communication mode"@en;
+   samm:characteristic :CommunicationModeEnum;
+   samm:exampleValue "synchronous".
 
-:timeValue a samm:Property ;
-   samm:preferredName "Time Value"@en ;
-   samm:description "A time Value property"@en ;
-   samm:characteristic :TimeValueCharacteristic .
+:timeValue a samm:Property;
+   samm:preferredName "Time Value"@en;
+   samm:description "A time Value property"@en;
+   samm:characteristic :TimeValueCharacteristic.
 
-:CommunicationModeEnum a samm-c:Enumeration ;
-   samm:preferredName "Communication Mode Enumeration"@en ;
-   samm:description "Enumerates all possible communication modes"@en ;
-   samm:dataType xsd:string ;
-   samm-c:values ( "synchronous" "cyclic" "notification" ) .
+:CommunicationModeEnum a samm-c:Enumeration;
+   samm:preferredName "Communication Mode Enumeration"@en;
+   samm:description "Enumerates all possible communication modes"@en;
+   samm:dataType xsd:string;
+   samm-c:values ( "synchronous" "cyclic" "notification" ).
 
-:TimeValueCharacteristic a samm:Characteristic ;
-   samm:preferredName "Time Value Characteristic"@en ;
-   samm:description "Link to the  TimeUnit Data Type"@en ;
-   samm:dataType :TimeValue .
+:TimeValueCharacteristic a samm:Characteristic;
+   samm:preferredName "Time Value Characteristic"@en;
+   samm:description "Link to the  TimeUnit Data Type"@en;
+   samm:dataType :TimeValue.
 
-:TimeValue a samm:Entity ;
-   samm:preferredName "Time Value"@en ;
-   samm:description "Datatype to express a time value"@en ;
-   samm:properties ( :timeUnit :value ) .
+:TimeValue a samm:Entity;
+   samm:preferredName "Time Value"@en;
+   samm:description "Datatype to express a time value"@en;
+   samm:properties ( :timeUnit :value ).
 
-:timeUnit a samm:Property ;
-   samm:preferredName "Time Unit"@en ;
-   samm:description "Specifies the unit in which the time is represented"@en ;
-   samm:characteristic :TimeUnitEnum .
+:timeUnit a samm:Property;
+   samm:preferredName "Time Unit"@en;
+   samm:description "Specifies the unit in which the time is represented"@en;
+   samm:characteristic :TimeUnitEnum.
 
-:value a samm:Property ;
-   samm:preferredName "Value"@en ;
-   samm:description "The amount of timeUnits considered"@en ;
-   samm:characteristic :IntegerValueCharacteristic ;
-   samm:exampleValue 12 .
+:value a samm:Property;
+   samm:preferredName "Value"@en;
+   samm:description "The amount of timeUnits considered"@en;
+   samm:characteristic :IntegerValueCharacteristic;
+   samm:exampleValue 12.
 
-:TimeUnitEnum a samm-c:Enumeration ;
-   samm:preferredName "Time Unit Enum"@en ;
-   samm:description "Enumerates all time units"@en ;
-   samm:dataType samm:curie ;
-   samm-c:values ( "unit:secondUnitOfTime"^^samm:curie "unit:minuteUnitOfTime"^^samm:curie "unit:hour"^^samm:curie "unit:day"^^samm:curie "unit:week"^^samm:curie "unit:month"^^samm:curie "unit:year"^^samm:curie ) .
+:TimeUnitEnum a samm-c:Enumeration;
+   samm:preferredName "Time Unit Enum"@en;
+   samm:description "Enumerates all time units"@en;
+   samm:dataType samm:curie;
+   samm-c:values ( "unit:secondUnitOfTime"^^samm:curie "unit:minuteUnitOfTime"^^samm:curie "unit:hour"^^samm:curie "unit:day"^^samm:curie "unit:week"^^samm:curie "unit:month"^^samm:curie "unit:year"^^samm:curie ).
 
-:IntegerValueCharacteristic a samm:Characteristic ;
-   samm:preferredName "Integer Value Characteristic"@en ;
-   samm:description "The value of the specified timeUnit as an integer value"@en ;
-   samm:dataType xsd:integer .
-
-
-
-
+:IntegerValueCharacteristic a samm:Characteristic;
+   samm:preferredName "Integer Value Characteristic"@en;
+   samm:description "The value of the specified timeUnit as an integer value"@en;
+   samm:dataType xsd:integer.
 

--- a/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
+++ b/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
@@ -14,9 +14,9 @@
 # SPDX-License-Identifier: CC-BY-4.0
 ##########################################################################################
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#>.
-@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#>.
-@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#>.
-@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#>.
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#>.
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#>.
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.

--- a/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
+++ b/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
@@ -1,7 +1,7 @@
 ##########################################################################################
-# Copyright (c) 2023 Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
-# Copyright (c) 2023 Siemens AG
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2023-2024 Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
+# Copyright (c) 2023-2024 Siemens AG
+# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
+++ b/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
@@ -1,0 +1,87 @@
+##########################################################################################
+# Copyright (c) 2023 Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
+# Copyright (c) 2023 Siemens AG
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+##########################################################################################
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.shared.shopfloor_information_types:1.0.0#> .
+@prefix ext-header: <urn:samm:io.catenax.shared.message_header:1.0.0#> .
+
+:ShopfloorInformationTypes a samm:Aspect ;
+   samm:preferredName "Shopfloor Information Types"@en ;
+   samm:description "Collection of types used in multiple data models of the Shopfloor Information Service"@en ;
+   samm:properties ( :communicationMode :versionDataModel :timeValue ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:communicationMode a samm:Property ;
+   samm:preferredName "Communication Mode"@en ;
+   samm:description "Specification of the communication mode"@en ;
+   samm:characteristic :CommunicationModeEnum ;
+   samm:exampleValue "synchronous" .
+
+:versionDataModel a samm:Property ;
+   samm:preferredName "Version Data Model"@en ;
+   samm:description "Specifies the used version of the data model"@en ;
+   samm:characteristic ext-header:BpnCharacteristic ;
+   samm:exampleValue "urn:samm:io.catenax.shared.shopfloor_information_types:1.0.0" .
+
+:timeValue a samm:Property ;
+   samm:preferredName "Time Value"@en ;
+   samm:description "A time Value property"@en ;
+   samm:characteristic :TimeValueCharacteristic .
+
+:CommunicationModeEnum a samm-c:Enumeration ;
+   samm:preferredName "Communication Mode Enumeration"@en ;
+   samm:description "Enumerates all possible communication modes"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "synchronous" "cyclic" "notification" ) .
+
+:TimeValueCharacteristic a samm:Characteristic ;
+   samm:preferredName "Time Value Characteristic"@en ;
+   samm:description "Link to the  TimeUnit Data Type"@en ;
+   samm:dataType :TimeValue .
+
+:TimeValue a samm:Entity ;
+   samm:preferredName "Time Value"@en ;
+   samm:description "Datatype to express a time value"@en ;
+   samm:properties ( :timeUnit :value ) .
+
+:timeUnit a samm:Property ;
+   samm:preferredName "Time Unit"@en ;
+   samm:description "Specifies the unit in which the time is represented"@en ;
+   samm:characteristic :TimeUnitEnum .
+
+:value a samm:Property ;
+   samm:preferredName "Value"@en ;
+   samm:description "The amount of timeUnits considered"@en ;
+   samm:characteristic :IntegerValueCharacteristic ;
+   samm:exampleValue 12 .
+
+:TimeUnitEnum a samm-c:Enumeration ;
+   samm:preferredName "Time Unit Enum"@en ;
+   samm:description "Enumerates all time units"@en ;
+   samm:dataType samm:curie ;
+   samm-c:values ( "unit:secondUnitOfTime"^^samm:curie "unit:minuteUnitOfTime"^^samm:curie "unit:hour"^^samm:curie "unit:day"^^samm:curie "unit:week"^^samm:curie "unit:month"^^samm:curie "unit:year"^^samm:curie ) .
+
+:IntegerValueCharacteristic a samm:Characteristic ;
+   samm:preferredName "Integer Value Characteristic"@en ;
+   samm:description "The value of the specified timeUnit as an integer value"@en ;
+   samm:dataType xsd:integer .
+

--- a/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
+++ b/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
@@ -26,7 +26,7 @@
 :ShopfloorInformationTypes a samm:Aspect ;
    samm:preferredName "Shopfloor Information Types"@en ;
    samm:description "Collection of types used in multiple data models of the Shopfloor Information Service"@en ;
-   samm:properties ( :communicationMode :timeValue ext-header:version ) ;
+   samm:properties ( :communicationMode :timeValue ) ;
    samm:operations ( ) ;
    samm:events ( ) .
 
@@ -78,6 +78,8 @@
    samm:preferredName "Integer Value Characteristic"@en ;
    samm:description "The value of the specified timeUnit as an integer value"@en ;
    samm:dataType xsd:integer .
+
+
 
 
 

--- a/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
+++ b/io.catenax.shared.shopfloor_information_types/2.0.0/ShopfloorInformationTypes.ttl
@@ -71,8 +71,8 @@
 :TimeUnitEnum a samm-c:Enumeration ;
    samm:preferredName "Time Unit Enum"@en ;
    samm:description "Enumerates all time units"@en ;
-   samm:dataType xsd:string ;
-   samm-c:values ( "unit:secondUnitOfTime" "unit:minuteUnitOfTime" "unit:hour" "unit:day" "unit:week" "unit:month" "unit:year" ) .
+   samm:dataType samm:curie ;
+   samm-c:values ( "unit:secondUnitOfTime"^^samm:curie "unit:minuteUnitOfTime"^^samm:curie "unit:hour"^^samm:curie "unit:day"^^samm:curie "unit:week"^^samm:curie "unit:month"^^samm:curie "unit:year"^^samm:curie ) .
 
 :IntegerValueCharacteristic a samm:Characteristic ;
    samm:preferredName "Integer Value Characteristic"@en ;

--- a/io.catenax.shared.shopfloor_information_types/2.0.0/metadata.json
+++ b/io.catenax.shared.shopfloor_information_types/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release" }

--- a/io.catenax.shared.shopfloor_information_types/RELEASE_NOTES.md
+++ b/io.catenax.shared.shopfloor_information_types/RELEASE_NOTES.md
@@ -5,3 +5,7 @@ All notable changes to this model will be documented in this file.
 ## [1.0.0]
 
 - initial version of the aspect model for ShopfloorInformationTypes
+
+## [2.0.0] 29.01.2024
+
+- Message header updated to latest version 2.0.0


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

Update of the Message_header to the latest version 

 -->

Closes #535 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.2)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
