### PR TITLE
[Model Update] Get production forecast 2.0.0

### DIFF
--- a/io.catenax.shopfloor_information.get_production_forecast/1.0.0/GetProductionForecast.ttl
+++ b/io.catenax.shopfloor_information.get_production_forecast/1.0.0/GetProductionForecast.ttl
@@ -20,7 +20,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.shopfloor_information.production_forecast_request:1.0.0#> .
+@prefix : <urn:samm:io.catenax.shopfloor_information.get_production_forecast:1.0.0#> .
 @prefix ext-header: <urn:samm:io.catenax.shared.message_header:1.0.0#> .
 @prefix ext-types: <urn:samm:io.catenax.shared.shopfloor_information_types:1.0.0#> .
 

--- a/io.catenax.shopfloor_information.get_production_forecast/1.0.0/GetProductionForecast.ttl
+++ b/io.catenax.shopfloor_information.get_production_forecast/1.0.0/GetProductionForecast.ttl
@@ -1,7 +1,7 @@
 ##########################################################################################
-# Copyright (c) 2023 Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
-# Copyright (c) 2023 Siemens AG
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IOSB & Fraunhofer IWU & Fraunhofer IPA)
+# Copyright (c) 2023-2024 Siemens AG
+# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.shopfloor_information.get_production_forecast/1.0.0/metadata.json
+++ b/io.catenax.shopfloor_information.get_production_forecast/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release" }
+{ "status" : "deprecated" }

--- a/io.catenax.shopfloor_information.get_production_forecast/1.0.0/metadata.json
+++ b/io.catenax.shopfloor_information.get_production_forecast/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "deprecated" }
+{ "status" : "release" }

--- a/io.catenax.shopfloor_information.get_production_forecast/2.0.0/GetProductionForecast.ttl
+++ b/io.catenax.shopfloor_information.get_production_forecast/2.0.0/GetProductionForecast.ttl
@@ -54,8 +54,8 @@
     samm:characteristic ext-types2:TimeValueCharacteristic.
 
 :customerId a samm:Property;
-    samm:preferredName "customerId"@en;
-    samm:description "Internal customerId"@en;
+    samm:preferredName "customer identification number"@en;
+    samm:description "Internal customer Id"@en;
     samm:characteristic ext-number:BpnlTrait;
     samm:exampleValue "BPNL7588787849VQ".
 
@@ -71,7 +71,7 @@
     samm:exampleValue "false"^^xsd:boolean.
 
 :orderId a samm:Property;
-    samm:preferredName "orderId"@en;
+    samm:preferredName "order identification number"@en;
     samm:description "The Id identifying subject of the request"@en;
     samm:characteristic ext-uuid:UuidV4Trait;
     samm:exampleValue "00000000-0000-0000-C000-000000000046".

--- a/io.catenax.shopfloor_information.get_production_forecast/2.0.0/GetProductionForecast.ttl
+++ b/io.catenax.shopfloor_information.get_production_forecast/2.0.0/GetProductionForecast.ttl
@@ -1,0 +1,91 @@
+##########################################################################################
+# Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IOSB & Fraunhofer IWU & Fraunhofer IPA)
+# Copyright (c) 2023-2024 Siemens AG
+# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+##########################################################################################
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.shopfloor_information.production_forecast_request:1.0.0#> .
+@prefix ext-header: <urn:samm:io.catenax.shared.message_header:1.0.0#> .
+@prefix ext-types: <urn:samm:io.catenax.shared.shopfloor_information_types:1.0.0#> .
+
+:GetProductionForecast a samm:Aspect ;
+   samm:preferredName "Get Production Forecast"@en ;
+   samm:description "Aspect Model to request a production forecast"@en ;
+   samm:properties ( [ samm:property :request; samm:optional true ] ext-header:header ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:request a samm:Property ;
+   samm:preferredName "Request"@en ;
+   samm:description "Data model for a request"@en ;
+   samm:characteristic :RequestCharacteristic .
+
+:RequestCharacteristic a samm:Characteristic ;
+   samm:preferredName "Request Characteristic"@en ;
+   samm:description "Data type for a request"@en ;
+   samm:dataType :RequestEntity .
+
+:RequestEntity a samm:Entity ;
+   samm:preferredName "Request Entity"@en ;
+   samm:description "Entity for a request of a production forecast"@en ;
+   samm:properties ( :offset :customerId [ samm:property :precisionOfForecast; samm:optional true ] :productionForecastForAll :orderId [ samm:property :deviationOfSchedule; samm:optional true ] [ samm:property :notificationInterval; samm:optional true ] ext-types:communicationMode ext-types:versionDataModel ) .
+
+:offset a samm:Property ;
+   samm:preferredName "offset"@en ;
+   samm:description "Send/start time of the first message/notification\n- \"0\" ==> immediate response"@en ;
+   samm:characteristic :TimeValueCharacteristic .
+
+:customerId a samm:Property ;
+   samm:preferredName "customerId"@en ;
+   samm:description "Internal customerId"@en ;
+   samm:characteristic ext-header:BpnCharacteristic ;
+   samm:exampleValue "BPNL7588787849VQ" .
+
+:precisionOfForecast a samm:Property ;
+   samm:preferredName "Precision of forecast"@en ;
+   samm:description "Accuracy of the time specification of the completion date.\n- default: implicitly defined by production\n- only as a REQUEST of the requester since it cannot be guaranteed that the store floor can provide the data in this accuracy."@en ;
+   samm:characteristic :TimeValueCharacteristic .
+
+:productionForecastForAll a samm:Property ;
+   samm:preferredName "Production forecast for all"@en ;
+   samm:description "Boolean variable that detemines whether the customer request information about each position of an order, or information about the complete order"@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue false .
+
+:orderId a samm:Property ;
+   samm:preferredName "orderId"@en ;
+   samm:description "The Id identifying subject of the request"@en ;
+   samm:characteristic ext-header:UuidCharacteristic ;
+   samm:exampleValue "00000000-0000-0000-C000-000000000046" .
+
+:deviationOfSchedule a samm:Property ;
+   samm:preferredName "Deviation of Schedule"@en ;
+   samm:description "Mandatory property for the notification mode. The property specifies the deviation from targeted delivery date that must be met to send a notification to a subscriber\n\nmandatory for CommunicationMode = \"notification\""@en ;
+   samm:characteristic :TimeValueCharacteristic .
+
+:notificationInterval a samm:Property ;
+   samm:preferredName "Notification Interval"@en ;
+   samm:description "Interval time that either specifies the cyclic send time or limits the notification time\nmandatory for CommunicationMode = \"cyclic\""@en ;
+   samm:characteristic :TimeValueCharacteristic .
+
+:TimeValueCharacteristic a samm:Characteristic ;
+   samm:preferredName "TimeValueCharacteristic"@en ;
+   samm:description "Link to the  TimeUnit Data Type"@en ;
+   samm:dataType ext-types:TimeValue .
+

--- a/io.catenax.shopfloor_information.get_production_forecast/2.0.0/GetProductionForecast.ttl
+++ b/io.catenax.shopfloor_information.get_production_forecast/2.0.0/GetProductionForecast.ttl
@@ -13,79 +13,79 @@
 #
 # SPDX-License-Identifier: CC-BY-4.0
 ##########################################################################################
-@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#> .
-@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#> .
-@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#> .
-@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.shopfloor_information.production_forecast_request:1.0.0#> .
-@prefix ext-header: <urn:samm:io.catenax.shared.message_header:1.0.0#> .
-@prefix ext-types: <urn:samm:io.catenax.shared.shopfloor_information_types:1.0.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#>.
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#>.
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#>.
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:samm:io.catenax.shopfloor_information.production_forecast_request:2.0.0#>.
+@prefix ext-types2: <urn:samm:io.catenax.shared.shopfloor_information_types:2.0.0#>.
+@prefix ext-header2: <urn:samm:io.catenax.shared.message_header:2.0.0#>.
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:1.0.0#>.
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:1.0.0#>.
 
-:GetProductionForecast a samm:Aspect ;
-   samm:preferredName "Get Production Forecast"@en ;
-   samm:description "Aspect Model to request a production forecast"@en ;
-   samm:properties ( [ samm:property :request; samm:optional true ] ext-header:header ) ;
-   samm:operations ( ) ;
-   samm:events ( ) .
+:GetProductionForecast a samm:Aspect;
+    samm:preferredName "Get Production Forecast"@en;
+    samm:description "Aspect Model to request a production forecast"@en;
+    samm:properties ([
+  samm:property :request;
+  samm:optional "true"^^xsd:boolean
+] ext-header2:header);
+    samm:operations ();
+    samm:events ().
+:request a samm:Property;
+    samm:preferredName "Request"@en;
+    samm:description "Data model for a request"@en;
+    samm:characteristic :RequestCharacteristic.
+:RequestCharacteristic a samm:Characteristic;
+    samm:preferredName "Request Characteristic"@en;
+    samm:description "Data type for a request"@en;
+    samm:dataType :RequestEntity.
+:RequestEntity a samm:Entity;
+    samm:preferredName "Request Entity"@en;
+    samm:description "Entity for a request of a production forecast"@en;
+    samm:properties (:offset :customerId [
+  samm:property :precisionOfForecast;
+  samm:optional "true"^^xsd:boolean
+] :productionForecastForAll :orderId [
+  samm:property :deviationOfSchedule;
+  samm:optional "true"^^xsd:boolean
+] [
+  samm:property :notificationInterval;
+  samm:optional "true"^^xsd:boolean
+] ext-types2:communicationMode ext-header2:version).
+:offset a samm:Property;
+    samm:preferredName "offset"@en;
+    samm:description "Send/start time of the first message/notification\n- \"0\" ==> immediate response"@en;
+    samm:characteristic ext-types2:TimeValueCharacteristic.
+:customerId a samm:Property;
+    samm:preferredName "customerId"@en;
+    samm:description "Internal customerId"@en;
+    samm:characteristic ext-number:BpnlTrait;
+    samm:exampleValue "BPNL7588787849VQ".
+:precisionOfForecast a samm:Property;
+    samm:preferredName "Precision of forecast"@en;
+    samm:description "Accuracy of the time specification of the completion date.\n- default: implicitly defined by production\n- only as a REQUEST of the requester since it cannot be guaranteed that the store floor can provide the data in this accuracy."@en;
+    samm:characteristic ext-types2:TimeValueCharacteristic.
+:productionForecastForAll a samm:Property;
+    samm:preferredName "Production forecast for all"@en;
+    samm:description "Boolean variable that detemines whether the customer request information about each position of an order, or information about the complete order"@en;
+    samm:characteristic samm-c:Boolean;
+    samm:exampleValue "false"^^xsd:boolean.
+:orderId a samm:Property;
+    samm:preferredName "orderId"@en;
+    samm:description "The Id identifying subject of the request"@en;
+    samm:characteristic ext-uuid:UuidV4Trait;
+    samm:exampleValue "00000000-0000-0000-C000-000000000046".
+:deviationOfSchedule a samm:Property;
+    samm:preferredName "Deviation of Schedule"@en;
+    samm:description "Mandatory property for the notification mode. The property specifies the deviation from targeted delivery date that must be met to send a notification to a subscriber\n\nmandatory for CommunicationMode = \"notification\""@en;
+    samm:characteristic ext-types2:TimeValueCharacteristic.
+:notificationInterval a samm:Property;
+    samm:preferredName "Notification Interval"@en;
+    samm:description "Interval time that either specifies the cyclic send time or limits the notification time\nmandatory for CommunicationMode = \"cyclic\""@en;
+    samm:characteristic ext-types2:TimeValueCharacteristic.
 
-:request a samm:Property ;
-   samm:preferredName "Request"@en ;
-   samm:description "Data model for a request"@en ;
-   samm:characteristic :RequestCharacteristic .
-
-:RequestCharacteristic a samm:Characteristic ;
-   samm:preferredName "Request Characteristic"@en ;
-   samm:description "Data type for a request"@en ;
-   samm:dataType :RequestEntity .
-
-:RequestEntity a samm:Entity ;
-   samm:preferredName "Request Entity"@en ;
-   samm:description "Entity for a request of a production forecast"@en ;
-   samm:properties ( :offset :customerId [ samm:property :precisionOfForecast; samm:optional true ] :productionForecastForAll :orderId [ samm:property :deviationOfSchedule; samm:optional true ] [ samm:property :notificationInterval; samm:optional true ] ext-types:communicationMode ext-types:versionDataModel ) .
-
-:offset a samm:Property ;
-   samm:preferredName "offset"@en ;
-   samm:description "Send/start time of the first message/notification\n- \"0\" ==> immediate response"@en ;
-   samm:characteristic :TimeValueCharacteristic .
-
-:customerId a samm:Property ;
-   samm:preferredName "customerId"@en ;
-   samm:description "Internal customerId"@en ;
-   samm:characteristic ext-header:BpnCharacteristic ;
-   samm:exampleValue "BPNL7588787849VQ" .
-
-:precisionOfForecast a samm:Property ;
-   samm:preferredName "Precision of forecast"@en ;
-   samm:description "Accuracy of the time specification of the completion date.\n- default: implicitly defined by production\n- only as a REQUEST of the requester since it cannot be guaranteed that the store floor can provide the data in this accuracy."@en ;
-   samm:characteristic :TimeValueCharacteristic .
-
-:productionForecastForAll a samm:Property ;
-   samm:preferredName "Production forecast for all"@en ;
-   samm:description "Boolean variable that detemines whether the customer request information about each position of an order, or information about the complete order"@en ;
-   samm:characteristic samm-c:Boolean ;
-   samm:exampleValue false .
-
-:orderId a samm:Property ;
-   samm:preferredName "orderId"@en ;
-   samm:description "The Id identifying subject of the request"@en ;
-   samm:characteristic ext-header:UuidCharacteristic ;
-   samm:exampleValue "00000000-0000-0000-C000-000000000046" .
-
-:deviationOfSchedule a samm:Property ;
-   samm:preferredName "Deviation of Schedule"@en ;
-   samm:description "Mandatory property for the notification mode. The property specifies the deviation from targeted delivery date that must be met to send a notification to a subscriber\n\nmandatory for CommunicationMode = \"notification\""@en ;
-   samm:characteristic :TimeValueCharacteristic .
-
-:notificationInterval a samm:Property ;
-   samm:preferredName "Notification Interval"@en ;
-   samm:description "Interval time that either specifies the cyclic send time or limits the notification time\nmandatory for CommunicationMode = \"cyclic\""@en ;
-   samm:characteristic :TimeValueCharacteristic .
-
-:TimeValueCharacteristic a samm:Characteristic ;
-   samm:preferredName "TimeValueCharacteristic"@en ;
-   samm:description "Link to the  TimeUnit Data Type"@en ;
-   samm:dataType ext-types:TimeValue .
 

--- a/io.catenax.shopfloor_information.get_production_forecast/2.0.0/GetProductionForecast.ttl
+++ b/io.catenax.shopfloor_information.get_production_forecast/2.0.0/GetProductionForecast.ttl
@@ -14,9 +14,9 @@
 # SPDX-License-Identifier: CC-BY-4.0
 ##########################################################################################
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#>.
-@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#>.
-@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#>.
-@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#>.
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#>.
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#>.
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.

--- a/io.catenax.shopfloor_information.get_production_forecast/2.0.0/GetProductionForecast.ttl
+++ b/io.catenax.shopfloor_information.get_production_forecast/2.0.0/GetProductionForecast.ttl
@@ -13,14 +13,14 @@
 #
 # SPDX-License-Identifier: CC-BY-4.0
 ##########################################################################################
-@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#>.
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#>.
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#>.
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#>.
 @prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix : <urn:samm:io.catenax.shopfloor_information.production_forecast_request:2.0.0#>.
+@prefix : <urn:samm:io.catenax.shopfloor_information.get_production_forecast:2.0.0#>.
 @prefix ext-types2: <urn:samm:io.catenax.shared.shopfloor_information_types:2.0.0#>.
 @prefix ext-header2: <urn:samm:io.catenax.shared.message_header:2.0.0#>.
 @prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:1.0.0#>.
@@ -29,60 +29,58 @@
 :GetProductionForecast a samm:Aspect;
     samm:preferredName "Get Production Forecast"@en;
     samm:description "Aspect Model to request a production forecast"@en;
-    samm:properties ([
-  samm:property :request;
-  samm:optional "true"^^xsd:boolean
-] ext-header2:header);
+    samm:properties ([ samm:property :request; samm:optional "true"^^xsd:boolean ] ext-header2:header);
     samm:operations ();
     samm:events ().
+
 :request a samm:Property;
     samm:preferredName "Request"@en;
     samm:description "Data model for a request"@en;
     samm:characteristic :RequestCharacteristic.
+
 :RequestCharacteristic a samm:Characteristic;
     samm:preferredName "Request Characteristic"@en;
     samm:description "Data type for a request"@en;
     samm:dataType :RequestEntity.
+
 :RequestEntity a samm:Entity;
     samm:preferredName "Request Entity"@en;
     samm:description "Entity for a request of a production forecast"@en;
-    samm:properties (:offset :customerId [
-  samm:property :precisionOfForecast;
-  samm:optional "true"^^xsd:boolean
-] :productionForecastForAll :orderId [
-  samm:property :deviationOfSchedule;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :notificationInterval;
-  samm:optional "true"^^xsd:boolean
-] ext-types2:communicationMode ext-header2:version).
+    samm:properties (:offset :customerId [ samm:property :precisionOfForecast; samm:optional "true"^^xsd:boolean ] :productionForecastForAll :orderId [ samm:property :deviationOfSchedule; samm:optional "true"^^xsd:boolean ] [ samm:property :notificationInterval; samm:optional "true"^^xsd:boolean ] ext-types2:communicationMode ext-header2:version).
+
 :offset a samm:Property;
     samm:preferredName "offset"@en;
     samm:description "Send/start time of the first message/notification\n- \"0\" ==> immediate response"@en;
     samm:characteristic ext-types2:TimeValueCharacteristic.
+
 :customerId a samm:Property;
     samm:preferredName "customerId"@en;
     samm:description "Internal customerId"@en;
     samm:characteristic ext-number:BpnlTrait;
     samm:exampleValue "BPNL7588787849VQ".
+
 :precisionOfForecast a samm:Property;
     samm:preferredName "Precision of forecast"@en;
     samm:description "Accuracy of the time specification of the completion date.\n- default: implicitly defined by production\n- only as a REQUEST of the requester since it cannot be guaranteed that the store floor can provide the data in this accuracy."@en;
     samm:characteristic ext-types2:TimeValueCharacteristic.
+
 :productionForecastForAll a samm:Property;
     samm:preferredName "Production forecast for all"@en;
     samm:description "Boolean variable that detemines whether the customer request information about each position of an order, or information about the complete order"@en;
     samm:characteristic samm-c:Boolean;
     samm:exampleValue "false"^^xsd:boolean.
+
 :orderId a samm:Property;
     samm:preferredName "orderId"@en;
     samm:description "The Id identifying subject of the request"@en;
     samm:characteristic ext-uuid:UuidV4Trait;
     samm:exampleValue "00000000-0000-0000-C000-000000000046".
+
 :deviationOfSchedule a samm:Property;
     samm:preferredName "Deviation of Schedule"@en;
     samm:description "Mandatory property for the notification mode. The property specifies the deviation from targeted delivery date that must be met to send a notification to a subscriber\n\nmandatory for CommunicationMode = \"notification\""@en;
     samm:characteristic ext-types2:TimeValueCharacteristic.
+
 :notificationInterval a samm:Property;
     samm:preferredName "Notification Interval"@en;
     samm:description "Interval time that either specifies the cyclic send time or limits the notification time\nmandatory for CommunicationMode = \"cyclic\""@en;

--- a/io.catenax.shopfloor_information.get_production_forecast/2.0.0/metadata.json
+++ b/io.catenax.shopfloor_information.get_production_forecast/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release" }

--- a/io.catenax.shopfloor_information.get_production_forecast/RELEASE_NOTES.md
+++ b/io.catenax.shopfloor_information.get_production_forecast/RELEASE_NOTES.md
@@ -4,4 +4,8 @@ All notable changes to this model will be documented in this file.
 
 ## [1.0.0]
 
-- initial version of the aspect model for get production forecast
+- initial version of the aspect model for GetProductionForecast
+
+## [2.0.0] 29.01.2024
+
+- Message Header, shopfloor_information_types updated to latest version 2.0.0


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

Message Header and shopfloor_information_types are updated to version 2.0.0updated

 -->

Closes #533 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.2)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
