### PR TITLE
Provide Production Forecast

### DIFF
--- a/io.catenax.shopfloor_information.provide_production_forecast/2.0.0/ProvideProductionForecast.ttl
+++ b/io.catenax.shopfloor_information.provide_production_forecast/2.0.0/ProvideProductionForecast.ttl
@@ -21,14 +21,15 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.shopfloor_information.production_forecast:1.0.0#> .
-@prefix ext-header: <urn:samm:io.catenax.shared.message_header:1.0.0#> .
-@prefix ext-types: <urn:samm:io.catenax.shared.shopfloor_information_types:1.0.0#> .
+@prefix : <urn:samm:io.catenax.shopfloor_information.production_forecast_response:2.0.0#> .
+@prefix ext-header2: <urn:samm:io.catenax.shared.message_header:2.0.0#> .
+@prefix ext-types2: <urn:samm:io.catenax.shared.shopfloor_information_types:2.0.0#> .
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:1.0.0#> .
 
 :ProvideProductionForecast a samm:Aspect ;
    samm:preferredName "Provide Production Forecast"@en ;
    samm:description "Answer to a customer with all information about the requested items"@en ;
-   samm:properties ( :productionForecastResponse ext-header:header ) ;
+   samm:properties ( :productionForecastResponse ext-header2:header ) ;
    samm:operations ( ) ;
    samm:events ( ) .
 
@@ -45,7 +46,7 @@
 :ProductionForecastItem a samm:Entity ;
    samm:preferredName "Production Forecast Item"@en ;
    samm:description "Datamodel of the concrete production forecast for one forecast item"@en ;
-   samm:properties ( :listOfForecastItems [ samm:property :iterationNumber; samm:optional true ] ext-types:communicationMode ext-types:versionDataModel ) .
+   samm:properties ( :listOfForecastItems [ samm:property :iterationNumber; samm:optional true ] ext-types2:communicationMode ext-header2:version ) .
 
 :listOfForecastItems a samm:Property ;
    samm:preferredName "List Of Forecast Items"@en ;
@@ -55,7 +56,7 @@
 :iterationNumber a samm:Property ;
    samm:preferredName "Iteration Number"@en ;
    samm:description "Only set in CommunicationMode == \"notification/cyclic\" to be able to check the order of the notifications. \n\nNot required for communication mode = \"synchronous\""@en ;
-   samm:characteristic ext-types:IntegerValueCharacteristic ;
+   samm:characteristic ext-types2:IntegerValueCharacteristic ;
    samm:exampleValue 6 .
 
 :ForecastItemList a samm-c:List ;
@@ -71,7 +72,7 @@
 :positionId a samm:Property ;
    samm:preferredName "Position Id"@en ;
    samm:description "Identifier of a position of an order"@en ;
-   samm:characteristic ext-header:UuidCharacteristic ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
    samm:exampleValue "00000000-0000-0000-C000-000000000046" .
 
 :productionForecast a samm:Property ;
@@ -83,7 +84,7 @@
 :precisionOfForecast a samm:Property ;
    samm:preferredName "Precision Of Forecast"@en ;
    samm:description "Accuracy of the prediction"@en ;
-   samm:characteristic ext-types:TimeValueCharacteristic .
+   samm:characteristic ext-types2:TimeValueCharacteristic .
 
 :productionStatus a samm:Property ;
    samm:preferredName "Production Status"@en ;

--- a/io.catenax.shopfloor_information.provide_production_forecast/2.0.0/metadata.json
+++ b/io.catenax.shopfloor_information.provide_production_forecast/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release" }

--- a/io.catenax.shopfloor_information.provide_production_forecast/RELEASE_NOTES.md
+++ b/io.catenax.shopfloor_information.provide_production_forecast/RELEASE_NOTES.md
@@ -5,3 +5,7 @@ All notable changes to this model will be documented in this file.
 ## [1.0.0]
 
 - initial version of the aspect model for ProvideProductionForecast
+
+## [2.0.0] 29.01.2024
+
+- Message Header, shopfloor_information_types updated to latest version 2.0.0


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

update message header and shopfloor_information_types to latest version 2.0.0

 -->

Closes #534 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.2)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
