### PR TITLE
Get Production Tracking Aspect Model

### DIFF
--- a/io.catenax.shopfloor_information.get_production_tracking/1.0.0/GetProductionTrackingData.ttl
+++ b/io.catenax.shopfloor_information.get_production_tracking/1.0.0/GetProductionTrackingData.ttl
@@ -1,0 +1,148 @@
+##########################################################################################
+# Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IOSB & Fraunhofer IWU & Fraunhofer IPA)
+# Copyright (c) 2023-2024 Siemens AG
+# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+##########################################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#>.
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#>.
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#>.
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:samm:io.catenax.shopfloor_information.productionTrackingRequest:1.0.0#>.
+@prefix ext-header2: <urn:samm:io.catenax.shared.message_header:2.0.0#>.
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:1.0.0#>.
+@prefix ext-part: <urn:samm:io.catenax.serial_part:2.0.0#>.
+
+:GetProductionTrackingData a samm:Aspect;
+    samm:preferredName "GetProductionTrackingData"@en;
+    samm:properties (:customerId [
+  samm:property :billOfProcessId;
+  samm:optional "true"^^xsd:boolean
+] :processReferenceType :processStepIdentifierList ext-header2:header [
+  samm:property ext-part:catenaXId;
+  samm:optional "true"^^xsd:boolean
+] ext-part:localIdentifiers ext-header2:version);
+    samm:operations ();
+    samm:events ();
+    samm:description "Aspect to request product specific data from modular production"@en.
+:customerId a samm:Property;
+    samm:preferredName "customerId"@en;
+    samm:description "internal customer Id"@en;
+    samm:characteristic ext-number:BpnlTrait.
+:billOfProcessId a samm:Property;
+    samm:preferredName "billOfProcessId"@en;
+    samm:description "Id to identify an instance of the bill of process data model "@en;
+    samm:characteristic :URICharacteristic;
+    samm:exampleValue "12345TestBoP.org"^^xsd:anyURI.
+:processReferenceType a samm:Property;
+    samm:preferredName "processReferenceType"@en;
+    samm:description "Value of an enumeration that determines whether the request is based on concrete process steps or capabilities"@en;
+    samm:characteristic :ProcessReferenceTypeCharacteristic;
+    samm:exampleValue "processStep".
+:processStepIdentifierList a samm:Property;
+    samm:preferredName "processStepIdentifierList"@en;
+    samm:description "List of Process Steps for which a set of parameter is requested"@en;
+    samm:characteristic :ProcessStepIdentifierCharacteristic.
+:URICharacteristic a samm:Characteristic;
+    samm:preferredName "UriCharacteristic"@en;
+    samm:description "Characteristic to specify unique resource identifiers"@en;
+    samm:dataType xsd:anyURI.
+:ProcessReferenceTypeCharacteristic a samm-c:Enumeration;
+    samm:preferredName "ProcessReferenceTypeCharacteristic"@en;
+    samm:description "Enumeration to distinguish between a request based on process steps or a request based on capabilities"@en;
+    samm:dataType xsd:string;
+    samm-c:values ("processStep" "capability").
+:ProcessStepIdentifierCharacteristic a samm-c:List;
+    samm:preferredName "ProcessStepIdentifierCharacteristic"@en;
+    samm:dataType :ProcessStepId.
+:ProcessStepId a samm:Entity;
+    samm:preferredName "ProcessStepId"@en;
+    samm:properties ([
+  samm:property :capabilityId;
+  samm:optional "true"^^xsd:boolean
+] [
+  samm:property :partInstanceLevel;
+  samm:optional "true"^^xsd:boolean
+] [
+  samm:property :billOfMaterialId;
+  samm:optional "true"^^xsd:boolean
+] [
+  samm:property :billOfMaterialElementId;
+  samm:optional "true"^^xsd:boolean
+] [
+  samm:property :processStepIdentifier;
+  samm:optional "true"^^xsd:boolean
+] :processParameterList [
+  samm:property ext-part:localIdentifiers;
+  samm:optional "true"^^xsd:boolean
+]);
+    samm:description "Id of a process Step"@en.
+:StringCharacteristic a samm:Characteristic;
+    samm:preferredName "StringCharacteristic"@en;
+    samm:description "Characteristic to express string values"@en;
+    samm:dataType xsd:string.
+:capabilityId a samm:Property;
+    samm:preferredName "capabilityId"@en;
+    samm:description "Id of a capability that is required in case of a capability based request"@en;
+    samm:characteristic :URICharacteristic;
+    samm:exampleValue "Fuegen.Anpressen_Einpressen.Schrauben.Deckelverschrauben"^^xsd:anyURI.
+:partInstanceLevel a samm:Property;
+    samm:preferredName "partInstanceLevel"@en;
+    samm:description "Value of an enumeration that determins whether a part is identified based on its serial number of a Bom + BomElementId"@en;
+    samm:characteristic :PartInstanceLevelCharacteristic;
+    samm:exampleValue "bom".
+:billOfMaterialId a samm:Property;
+    samm:preferredName "billOfMaterialId"@en;
+    samm:description "Identifier for a bill of material, available for both partners"@en;
+    samm:characteristic :StringCharacteristic;
+    samm:exampleValue "321-BomIdentifier".
+:billOfMaterialElementId a samm:Property;
+    samm:preferredName "billOfMaterialElementId"@en;
+    samm:description "Id of an element of within an instance of a bill of material, available for both partners "@en;
+    samm:characteristic :StringCharacteristic;
+    samm:exampleValue "456-BomElementId.coverId".
+:processStepIdentifier a samm:Property;
+    samm:preferredName "processStepId"@en;
+    samm:description "Id of a process Step, specified within an instance of a Bill of process data model"@en;
+    samm:characteristic :StringCharacteristic;
+    samm:exampleValue "Fuegen.Anpressen_Einpressen.Schrauben.Deckelverschrauben_01".
+:processParameterList a samm:Property;
+    samm:preferredName "processParameterList"@en;
+    samm:description "List of requested Process parameter"@en;
+    samm:characteristic :ProcessPartameterListCharacteristic.
+:PartInstanceLevelCharacteristic a samm-c:Enumeration;
+    samm:preferredName "PartInstanceLevelCharacteristic"@en;
+    samm:description "Distinguishes whether the a Part is identifid by a bill of material Id, or a part instance Id, available for both partners"@en;
+    samm:dataType xsd:string;
+    samm-c:values ("bom" "serial").
+:ProcessPartameterListCharacteristic a samm-c:List;
+    samm:preferredName "ProcessPartameterListCharacteristic"@en;
+    samm:description "List os process parameters, whose values the requester wants to receive from the provider "@en;
+    samm:dataType :ProcessParameterRequestType.
+:ProcessParameterRequestType a samm:Entity;
+    samm:preferredName "ProcessParameterRequestType"@en;
+    samm:properties (:processParameterName :processParameterSemanticId);
+    samm:description "Entity to define process parameters"@en.
+:processParameterName a samm:Property;
+    samm:preferredName "processParameterName"@en;
+    samm:description "name of a process parameter"@en;
+    samm:characteristic :StringCharacteristic;
+    samm:exampleValue "Drehmoment_max".
+:processParameterSemanticId a samm:Property;
+    samm:preferredName "processParameterSemanticId"@en;
+    samm:description "Reference to a semantic that defines the unit and the data type of the parameter"@en;
+    samm:characteristic :StringCharacteristic;
+    samm:exampleValue "Semantic_Drehmoment_max".

--- a/io.catenax.shopfloor_information.get_production_tracking/1.0.0/metadata.json
+++ b/io.catenax.shopfloor_information.get_production_tracking/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release" }

--- a/io.catenax.shopfloor_information.get_production_tracking/RELEASE_NOTES.md
+++ b/io.catenax.shopfloor_information.get_production_tracking/RELEASE_NOTES.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this model will be documented in this file.
+
+## [1.0.0]
+
+- initial version of the aspect model for GetProductionTrackingData


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

New aspect model for the production tracking request within the SopfloorInformationService
 -->

Closes #546 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.2)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
