### PR TITLE
[Model Update]: PartAsPlanned 3.0.0

### DIFF
--- a/io.catenax.part_as_planned/3.0.0/PartAsPlanned.ttl
+++ b/io.catenax.part_as_planned/3.0.0/PartAsPlanned.ttl
@@ -1,16 +1,16 @@
 #######################################################################
-# Copyright(c) 2023 BASF SE
-# Copyright(c) 2023 Bayerische Motoren Werke Aktiengesellschaft(BMW AG)
-# Copyright(c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.(represented by Fraunhofer ISST & Fraunhofer IML)
-# Copyright(c) 2023 German Edge Cloud GmbH & Co. KG
-# Copyright(c) 2023 Henkel AG & Co. KGaA
-# Copyright(c) 2023 Mercedes Benz AG
-# Copyright(c) 2023 Robert Bosch Manufacturing Solutions GmbH
-# Copyright(c) 2023 SAP SE
-# Copyright(c) 2023 Siemens AG
-# Copyright(c) 2023 T-Systems International GmbH
-# Copyright(c) 2023 ZF Friedrichshafen AG
-# Copyright(c) 2023 Contributors to the Eclipse Foundation
+# Copyright(c) 2024 BASF SE
+# Copyright(c) 2024 Bayerische Motoren Werke Aktiengesellschaft(BMW AG)
+# Copyright(c) 2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.(represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright(c) 2024 German Edge Cloud GmbH & Co. KG
+# Copyright(c) 2024 Henkel AG & Co. KGaA
+# Copyright(c) 2024 Mercedes Benz AG
+# Copyright(c) 2024 Robert Bosch Manufacturing Solutions GmbH
+# Copyright(c) 2024 SAP SE
+# Copyright(c) 2024 Siemens AG
+# Copyright(c) 2024 T-Systems International GmbH
+# Copyright(c) 2024 ZF Friedrichshafen AG
+# Copyright(c) 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -106,12 +106,14 @@
 :functionValidFrom a samm:Property;
    samm:preferredName "Function valid from"@en;
    samm:description "Timestamp, from when the site has the specified function for the given part"@en;
-   samm:characteristic :DateTrait.
+   samm:characteristic :DateTrait;
+   samm:exampleValue "2024-01-29T12:00:00.123+02:00".
 
 :functionValidUntil a samm:Property;
    samm:preferredName "Function valid until"@en;
    samm:description "Timestamp, until when the site has the specified function for the given part"@en;
-   samm:characteristic :DateTrait.
+   samm:characteristic :DateTrait;
+   samm:exampleValue "2024-01-29T12:00:00.123+02:00".
 
 :PartIdCharacteristic a samm:Characteristic;
    samm:preferredName "Part ID characteristic"@en;
@@ -143,5 +145,5 @@
 :DateTimeRegularExpression a samm-c:RegularExpressionConstraint;
    samm:preferredName "Date Time Regular Expression"@en;
    samm:description "Regular Expression to enable UTC and Timezone formats and the possibility to exclude time information."@en;
-   samm:value "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?(Z|[+-]\\d{2}:\\d{2}))?$".
+   samm:value "^(?:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?Z|[0-9]{4}-[0-9]{2}-[0-9]{2}(?:T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2}))?)$".
 

--- a/io.catenax.part_as_planned/3.0.0/PartAsPlanned.ttl
+++ b/io.catenax.part_as_planned/3.0.0/PartAsPlanned.ttl
@@ -1,0 +1,147 @@
+#######################################################################
+# Copyright(c) 2023 BASF SE
+# Copyright(c) 2023 Bayerische Motoren Werke Aktiengesellschaft(BMW AG)
+# Copyright(c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.(represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright(c) 2023 German Edge Cloud GmbH & Co. KG
+# Copyright(c) 2023 Henkel AG & Co. KGaA
+# Copyright(c) 2023 Mercedes Benz AG
+# Copyright(c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright(c) 2023 SAP SE
+# Copyright(c) 2023 Siemens AG
+# Copyright(c) 2023 T-Systems International GmbH
+# Copyright(c) 2023 ZF Friedrichshafen AG
+# Copyright(c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International(CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#>.
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#>.
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#>.
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:samm:io.catenax.part_as_planned:3.0.0#>.
+@prefix ext-classification: <urn:samm:io.catenax.shared.part_classification:1.0.0#>.
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:1.0.0#>.
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:1.0.0#>.
+
+:PartAsPlanned a samm:Aspect;
+   samm:preferredName "Part as Planned"@en;
+   samm:description "A Part as Planned represents an item in the Catena-X Bill of Material(BOM)in As-Planned lifecycle status in a specific version. "@en;
+   samm:properties (:catenaXId :partTypeInformation [ samm:property :partSitesInformationAsPlanned; samm:optional true ]);
+   samm:operations ();
+   samm:events ().
+
+:catenaXId a samm:Property;
+   samm:preferredName "Catena-X ID"@en;
+   samm:description "The fully anonymous Catena-X ID of the serialized part, valid for the Catena-X dataspace."@en;
+   samm:characteristic ext-uuid:UuidV4Trait;
+   samm:exampleValue "580d3adf-1981-44a0-a214-13d6ceed9379".
+
+:partTypeInformation a samm:Property;
+   samm:preferredName "Part Type Information"@en;
+   samm:description "The part type from which the serialized part has been instantiated"@en;
+   samm:characteristic :PartTypeInformationCharacteristic.
+
+:partSitesInformationAsPlanned a samm:Property;
+   samm:preferredName "Part Sites Information as Planned"@en;
+   samm:description "A site is a delimited geographical area where a legal entity does business(geographical address with geo coordinates).A site always has a primary physical address. It is possible that further physical addresses are specified for the site. P.O. box details are only possible in addition to the physical address. A site has a 1:n relation to addresses, means at least 1 address is necessary and multiple addresses are possible."@en;
+   samm:see <https://confluence.catena-x.net/x/QkBHAw>;
+   samm:characteristic :partSitesInformationAsPlannedCharacteristic.
+
+:PartTypeInformationCharacteristic a samm:Characteristic;
+   samm:preferredName "Part Type Information Characteristic"@en;
+   samm:description "The characteristics of the part type"@en;
+   samm:dataType :PartTypeInformationEntity.
+
+:partSitesInformationAsPlannedCharacteristic a samm-c:Set;
+   samm:preferredName "Part Sites Information as Planned Characteristic"@en;
+   samm:description "The characteristic of the part site information that represents a set of possible site to a repective part. "@en;
+   samm:dataType :partSitesInformationAsPlannedEntity.
+
+:PartTypeInformationEntity a samm:Entity;
+   samm:preferredName "Part Type Information Entity"@en;
+   samm:description "Encapsulation for data related to the part type"@en;
+   samm:properties (:manufacturerPartId :nameAtManufacturer [ samm:property ext-classification:partClassification; samm:optional true ]).
+
+:partSitesInformationAsPlannedEntity a samm:Entity;
+   samm:preferredName "Part Sites Information as Planned Entity"@en;
+   samm:description "Describes the ID, function and validity date of a site for the associated part in the AsPlanned context."@en;
+   samm:properties (:catenaXsiteId :function [ samm:property :functionValidFrom; samm:optional true ] [ samm:property :functionValidUntil; samm:optional true ]).
+
+:manufacturerPartId a samm:Property;
+   samm:preferredName "Manufacturer Part ID"@en;
+   samm:description "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part in the manufacturer`s dataspace. The Part ID references a specific version of a part. The version number must be included in the Part ID if it is available.\n\nThe Part ID does not reference a specific instance of a part and must not be confused with the serial number."@en;
+   samm:characteristic :PartIdCharacteristic;
+   samm:exampleValue "123-0.740-3434-A".
+
+:nameAtManufacturer a samm:Property;
+   samm:preferredName "Name at manufacturer"@en;
+   samm:description "Name of the part as assigned by the manufacturer"@en;
+   samm:characteristic :PartNameCharacteristic;
+   samm:exampleValue "Mirror left".
+
+:catenaXsiteId a samm:Property;
+   samm:preferredName "Catena-X site identifier"@en;
+   samm:description "The identifier of the site according to Catena-X BPDM. The catenaXsiteId must be a valid Catena-X BPN. The BPN is a unique, unchangeable identifier for Business Partners / company locations from foundation to closure, regardless of the different business relationships / structures between or within the Business Partners or company locations."@en;
+   samm:characteristic ext-number:BpnsCharacteristic;
+   samm:exampleValue "BPNS1234567890ZZ".
+
+:function a samm:Property;
+   samm:preferredName "Function"@en;
+   samm:description "The function of the site in relation to the part(i.e. the activity within the value chain of the part that is performed at the site)"@en;
+   samm:characteristic :FunctionCharacteristic;
+   samm:exampleValue "production".
+
+:functionValidFrom a samm:Property;
+   samm:preferredName "Function valid from"@en;
+   samm:description "Timestamp, from when the site has the specified function for the given part"@en;
+   samm:characteristic :DateTrait.
+
+:functionValidUntil a samm:Property;
+   samm:preferredName "Function valid until"@en;
+   samm:description "Timestamp, until when the site has the specified function for the given part"@en;
+   samm:characteristic :DateTrait.
+
+:PartIdCharacteristic a samm:Characteristic;
+   samm:preferredName "Part ID characteristic"@en;
+   samm:description "The part ID is a multi-character string, usually assigned by an ERP system"@en;
+   samm:dataType xsd:string.
+
+:PartNameCharacteristic a samm:Characteristic;
+   samm:preferredName "Part Name characteristic"@en;
+   samm:description "Part Name in string format from the respective system in the value chain"@en;
+   samm:dataType xsd:string.
+
+:FunctionCharacteristic a samm-c:Enumeration;
+   samm:preferredName "Function characteristic"@en;
+   samm:description "Describes the characteristics of the function for a site related to the respective part"@en;
+   samm:dataType xsd:string;
+   samm-c:values ("production" "warehouse" "spare part warehouse").
+
+:DateTrait a samm-c:Trait;
+   samm:preferredName "Date Trait"@en;
+   samm:description "Trait to ensure regular expressions with different date formats."@en;
+   samm-c:baseCharacteristic :DateTimeCharacteristic;
+   samm-c:constraint :DateTimeRegularExpression.
+
+:DateTimeCharacteristic a samm:Characteristic;
+   samm:preferredName "Date Time Characteristic"@en;
+   samm:description "Describes a Property which contains the date and time with an optional timezone."@en;
+   samm:dataType xsd:string.
+
+:DateTimeRegularExpression a samm-c:RegularExpressionConstraint;
+   samm:preferredName "Date Time Regular Expression"@en;
+   samm:description "Regular Expression to enable UTC and Timezone formats and the possibility to exclude time information."@en;
+   samm:value "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?(Z|[+-]\\d{2}:\\d{2}))?$".
+

--- a/io.catenax.part_as_planned/3.0.0/metadata.json
+++ b/io.catenax.part_as_planned/3.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.part_as_planned/RELEASE_NOTES.md
+++ b/io.catenax.part_as_planned/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
+## [3.0.0] 2024-02-05
+### Added
+- Integration of the new shared PartClassifcation 1.0.0 aspect model as child-property of the PartTypeInformation
+- Added possibility to add date information excluding time
+
 ## [2.0.0] - 2023-12-04
 ### Added
 - added all relevant part site information of the PartSiteInforamtionAsPlanned aspect model, that will be deprecated


### PR DESCRIPTION
## Description
Based on the continous development of the Industry Core, there are a new data, that needs to be integrated in the **PartAsPlanned** aspect model. Therefore these extensions / adaptations were made:

- Integration of the new shared Classifcation model
- Permit to add date information excluding time

Closes #566  

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.3.2)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
