### PR TITLE
[Model Deprecation]: AssetTrackerLinks v.1.0.0

### DIFF
--- a/io.catenax.asset_tracker_links/1.0.0/metadata.json
+++ b/io.catenax.asset_tracker_links/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"}
+{ "status" : "deprecate"}


### PR DESCRIPTION
deprecate AssetTrackerLinks v.1.0.0

Closes #496 