### PR TITLE
[Model Update]: Harmonize DeliveryInformation to industry core

### DIFF
--- a/io.catenax.delivery_information/2.0.0/DeliveryInformation.ttl
+++ b/io.catenax.delivery_information/2.0.0/DeliveryInformation.ttl
@@ -195,7 +195,7 @@
     samm:exampleValue "2023-04-01T14:23:00+01:00"^^xsd:dateTime.
 :eventType a samm:Property;
     samm:preferredName "Event Type"@en;
-    samm:description "Event type describes wether the mentioned timeOfEvent refers to a departure or arrival and provides the status of the delivery (estimated or actual)."@en;
+    samm:description "Event type describes whether the mentioned timeOfEvent refers to a departure or arrival and provides the status of the delivery (estimated or actual)."@en;
     samm:characteristic :EventTypeEnumeration;
     samm:exampleValue "estimated-departure".
 :LocationCharacteristic a samm:Characteristic;

--- a/io.catenax.delivery_information/2.0.0/DeliveryInformation.ttl
+++ b/io.catenax.delivery_information/2.0.0/DeliveryInformation.ttl
@@ -70,11 +70,6 @@
     samm:preferredName "Order Position Reference Characteristic"@en;
     samm:description "The order position reference includes reference numbers for the order and the position. As these information are meant for the customer, the customer reference numbers are mandatory."@en;
     samm:dataType :OrderPositionReference.
-:DateTimeStamp a samm:Characteristic;
-    samm:preferredName "Date Time Stamp Characteristic"@en;
-    samm:description "The Date with the timezone."@en;
-    samm:dataType xsd:dateTime;
-    samm:see <https://www.iso.org/iso-8601-date-and-time-format.html>.
 :DeliverySet a samm-c:Set;
     samm:preferredName "Estimated and Allocated Delivery Set"@en;
     samm:description "Set of deliveries that may relate to different origin or destination, different quantities and different time of departure or time of arrival. It MAY include different tracking numbers and different incoterms."@en;
@@ -191,8 +186,8 @@
 :dateTimeOfEvent a samm:Property;
     samm:preferredName "Time of Event"@en;
     samm:description "Time of Event signifies the time and date when the products leave (or will leave) the origin location of a delivery (i.e. supplier's production site) or when the products arrive (or will arrive) at the destination location of the delivery (i.e. customer's production site)."@en;
-    samm:characteristic :DateTimeStamp;
-    samm:exampleValue "2023-04-01T14:23:00+01:00"^^xsd:dateTime.
+    samm:characteristic samm-c:Timestamp;
+    samm:exampleValue "2023-04-29T14:23:00.123456+14:00"^^xsd:dateTime.
 :eventType a samm:Property;
     samm:preferredName "Event Type"@en;
     samm:description "Event type describes whether the mentioned timeOfEvent refers to a departure or arrival and provides the status of the delivery (estimated or actual)."@en;

--- a/io.catenax.delivery_information/2.0.0/DeliveryInformation.ttl
+++ b/io.catenax.delivery_information/2.0.0/DeliveryInformation.ttl
@@ -38,8 +38,8 @@
     samm:description "The positions refer to positions within an order of the given item (see material number supplier, material number customer and material global asset ID) for which the delivery information is exchanged. The positions can be differentiated by the order position reference. If no order position reference is given, then there is only one position containing all estimated deliveries of the item."@en;
     samm:characteristic :PositionsSet.
 :materialGlobalAssetId a samm:Property;
-    samm:preferredName "Material Number UUID of the Customer's Twin"@en;
-    samm:description "Material identifier used uniquely to identify the Material (e.g. PartAsPlanned)."@en;
+    samm:preferredName "UUID of the Part Type Twin"@en;
+    samm:description "Identifier used uniquely to identify part type twin."@en;
     samm:characteristic ext-uuid:UuidV4Trait;
     samm:exampleValue "urn:uuid:48878d48-6f1d-47f5-8ded-a441d0d879df".
 :PositionsSet a samm-c:Set;

--- a/io.catenax.delivery_information/2.0.0/DeliveryInformation.ttl
+++ b/io.catenax.delivery_information/2.0.0/DeliveryInformation.ttl
@@ -1,0 +1,216 @@
+#######################################################################
+# Copyright (c) 2023-2024 ISTOS GmbH (a member of the DMG Mori Group)
+# Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+# Copyright (c) 2023-2024 TRUMPF Werkzeugmaschinen SE + Co. KG
+# Copyright (c) 2023-2024 Volkswagen AG
+# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#>.
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#>.
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#>.
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:samm:io.catenax.delivery_information:2.0.0#>.
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:2.0.0#>.
+@prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:2.0.0#>.
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#>.
+
+:DeliveryInformation a samm:Aspect;
+    samm:preferredName "Delivery information"@en;
+    samm:description "This aspect represents the estimated and actual delivery information of one specific item, which is being shipped from the supplier to the customer."@en;
+    samm:properties (:positions :materialGlobalAssetId);
+    samm:operations ();
+    samm:events ().
+:positions a samm:Property;
+    samm:preferredName "Positions"@en;
+    samm:description "The positions refer to positions within an order of the given item (see material number supplier, material number customer and material global asset ID) for which the delivery information is exchanged. The positions can be differentiated by the order position reference. If no order position reference is given, then there is only one position containing all estimated deliveries of the item."@en;
+    samm:characteristic :PositionsSet.
+:materialGlobalAssetId a samm:Property;
+    samm:preferredName "Material Number UUID of the Customer's Twin"@en;
+    samm:description "Material identifier used uniquely to identify the Material (e.g. PartAsPlanned)."@en;
+    samm:characteristic ext-uuid:UuidV4Trait;
+    samm:exampleValue "urn:uuid:48878d48-6f1d-47f5-8ded-a441d0d879df".
+:PositionsSet a samm-c:Set;
+    samm:preferredName "Positions Set"@en;
+    samm:description "If any delivery for the customer is estimated, then there is at least one position. If each order position is assigned to one (or more) delivery (an OrderPositionReference is set), then multiple positions can be given."@en;
+    samm:dataType :Position.
+:Position a samm:Entity;
+    samm:preferredName "Position"@en;
+    samm:description "The Position can contain one or more deliveries involving one or more supplier's and one or more customer's sites. A position may be anonymous (no orderPositionReference is set) or may reference a position within an order."@en;
+    samm:properties ([
+  samm:property :orderPositionReference;
+  samm:optional "true"^^xsd:boolean
+] :deliveries).
+:orderPositionReference a samm:Property;
+    samm:preferredName "Order Position Reference"@en;
+    samm:description "The order position reference contains information to identify a position within an order."@en;
+    samm:characteristic :OrderPositionReferenceCharacteristic.
+:lastUpdatedOnDateTime a samm:Property;
+    samm:preferredName "Lasted Updated on Date"@en;
+    samm:description "Date and time at which the delivery has been updated by the data provider. Date and time are set according to the timezone."@en;
+    samm:characteristic samm-c:Timestamp;
+    samm:exampleValue "2023-04-28T14:23:00.123456+14:00"^^xsd:dateTime.
+:deliveries a samm:Property;
+    samm:preferredName "Estimated or actual delivery from supplier to a customer"@en;
+    samm:description "Deliveries are referred to the deliveries of an order position. One order position can be split into multiple deliveries. One delivery can have a different origin and destination than another delivery."@en;
+    samm:characteristic :DeliverySet.
+:OrderPositionReferenceCharacteristic a samm:Characteristic;
+    samm:preferredName "Order Position Reference Characteristic"@en;
+    samm:description "The order position reference includes reference numbers for the order and the position. As these information are meant for the customer, the customer reference numbers are mandatory."@en;
+    samm:dataType :OrderPositionReference.
+:DateTimeStamp a samm:Characteristic;
+    samm:preferredName "Date Time Stamp Characteristic"@en;
+    samm:description "The Date with the timezone."@en;
+    samm:dataType xsd:dateTime;
+    samm:see <https://www.iso.org/iso-8601-date-and-time-format.html>.
+:DeliverySet a samm-c:Set;
+    samm:preferredName "Estimated and Allocated Delivery Set"@en;
+    samm:description "Set of deliveries that may relate to different origin or destination, different quantities and different time of departure or time of arrival. It MAY include different tracking numbers and different incoterms."@en;
+    samm:dataType :Delivery.
+:OrderPositionReference a samm:Entity;
+    samm:preferredName "Reference to Order Position"@en;
+    samm:description "Encapsulates the references to identify a position within an order."@en;
+    samm:properties ([
+  samm:property :supplierOrderId;
+  samm:optional "true"^^xsd:boolean
+] :customerOrderId :customerOrderPositionId).
+:Delivery a samm:Entity;
+    samm:preferredName "Estimated and Allocated Delivery"@en;
+    samm:description "Quantity, origin and destination, time of departure and arrival, tracking number and incoterms for a certain delivery."@en;
+    samm:properties (:deliveryQuantity :lastUpdatedOnDateTime :transitEvents :transitLocations [
+  samm:property :trackingNumber;
+  samm:optional "true"^^xsd:boolean
+] [
+  samm:property :incoterm;
+  samm:optional "true"^^xsd:boolean
+]).
+:supplierOrderId a samm:Property;
+    samm:preferredName "Supplier Order ID"@en;
+    samm:description "This is the order number on the supplier side that is given by e.g., the supplier's enterprise resource planning system."@en;
+    samm:characteristic :OrderIdCharacteristic;
+    samm:exampleValue "M-Nbr-4711".
+:customerOrderId a samm:Property;
+    samm:preferredName "Customer Order ID"@en;
+    samm:description "This is the order number on the customer side that can be given by e.g., the customer's enterprise resource planning system."@en;
+    samm:characteristic :OrderIdCharacteristic;
+    samm:exampleValue "C-Nbr-4711".
+:customerOrderPositionId a samm:Property;
+    samm:preferredName "Customer Order Position ID"@en;
+    samm:description "This is an identifier for the position of an order defined by the customer. It's not a technical identifier, such as an UUID. This identifier is used within the business context when talking about the position."@en;
+    samm:characteristic :OrderPositionIdCharacteristic;
+    samm:exampleValue "PositionId-01".
+:deliveryQuantity a samm:Property;
+    samm:preferredName "Delivery Quantity"@en;
+    samm:description "Amount of items of a delivery between a supplier and a customer."@en;
+    samm:characteristic :QuantityCharacteristic.
+:transitEvents a samm:Property;
+    samm:preferredName "Date of departure or arrival"@en;
+    samm:description "Transit dates provide date and time of departure and date and time of arrival for a specific delivery. Date and time are set according to the timezone."@en;
+    samm:characteristic :TransitEventsTrait.
+:transitLocations a samm:Property;
+    samm:preferredName "Transit Locations"@en;
+    samm:description "Physical locations of the origin and destination."@en;
+    samm:characteristic :TransitLocationsCharacteristic.
+:trackingNumber a samm:Property;
+    samm:preferredName "Tracking Number"@en;
+    samm:description "Is a unique alphanumeric code assigned to a shipment by a logistics service provider, allowing it to be monitored and traced throughout its journey between origin and destination."@en;
+    samm:characteristic :TrackingNumberCharacteristic;
+    samm:exampleValue "1Z9829WDE02128".
+:incoterm a samm:Property;
+    samm:preferredName "Incoterm"@en;
+    samm:description "Incoterm which is assigned to a delivery."@en;
+    samm:characteristic :IncotermEnumeration;
+    samm:exampleValue "DAP";
+    samm:see <https://iccwbo.org/business-solutions/intoterms-rules/>.
+:OrderIdCharacteristic a samm:Characteristic;
+    samm:preferredName "Order ID Characteristic"@en;
+    samm:description "This is a proprietary order ID, generated by either the supplier side or customer side."@en;
+    samm:dataType xsd:string.
+:OrderPositionIdCharacteristic a samm:Characteristic;
+    samm:preferredName "Position ID within Order"@en;
+    samm:description "The position ID is unique for an order and used within business context to refer to a position."@en;
+    samm:dataType xsd:string.
+:QuantityCharacteristic a samm-c:Quantifiable;
+    samm:preferredName "Quantity Characteristic"@en;
+    samm:description "Describes the quantity and the unit of measure with which the delivery is measured."@en;
+    samm:dataType ext-quantity:ItemQuantityEntity.
+:TransitEventsTrait a samm-c:Trait;
+    samm-c:baseCharacteristic :TransitEventsSet;
+    samm-c:constraint :TransitEventsContstraint.
+:TransitLocationsCharacteristic a samm:Characteristic;
+    samm:preferredName "Transit Locations Characteristic"@en;
+    samm:description "Transit locations includes origin and destination points in the transportation of goods. It refers to specific location of the source or production facility (origin) or the designated endpoint (destination)."@en;
+    samm:dataType :TransitLocations.
+:TrackingNumberCharacteristic a samm:Characteristic;
+    samm:preferredName "Tracking Number Characteristic"@en;
+    samm:description "Alphanumeric string that is defined by the logistics service provider in order to track and identify the shipment."@en;
+    samm:dataType xsd:string.
+:IncotermEnumeration a samm-c:Enumeration;
+    samm:preferredName "Incoterm enumeration"@en;
+    samm:description "All 12 possible values for the incoterms."@en;
+    samm:dataType xsd:string;
+    samm:see <https://impargo.de/blog/incoterms-einfach-erklaert>;
+    samm-c:values ("EXW" "FCA" "CPT" "CIP" "DAP" "DAT" "DPU" "DDP" "FAS" "FOB" "CFR" "CIF").
+:TransitEventsSet a samm-c:Set;
+    samm:preferredName "Transit events set"@en;
+    samm:description "Transit events refer to the specific timeframes associated with the departure or arrival of products during their transportation from one location to another - from the supplier to the customer.\n\nIf the set has two elements, following restrictions apply:\n- one element MUST describe the departure and another element MUST describe the arrival\n- if the set contains a estimated departure, the set MUST NOT contain an actual arrival."@en;
+    samm:dataType :TransitEvent.
+:TransitEventsContstraint a samm-c:LengthConstraint;
+    samm:preferredName "Transit events constraint"@en;
+    samm:description "The TransitEventsSet MUST contain either 1 or 2 TransitEvents."@en;
+    samm-c:minValue "1"^^xsd:nonNegativeInteger;
+    samm-c:maxValue "2"^^xsd:nonNegativeInteger.
+:TransitLocations a samm:Entity;
+    samm:preferredName "Transit Locations"@en;
+    samm:description "Transit locations describes the specific location where products undergo the process of being transported from the source or production facility (origin) to the designated endpoint location (destination)."@en;
+    samm:properties (:origin :destination).
+:TransitEvent a samm:Entity;
+    samm:preferredName "Transit event"@en;
+    samm:description "Entity for specifying the departure or arrival time and date."@en;
+    samm:properties (:dateTimeOfEvent :eventType).
+:origin a samm:Property;
+    samm:preferredName "Origin"@en;
+    samm:description "Origin refers to the starting point or the location from which the items are being shipped to the customer. "@en;
+    samm:characteristic :LocationCharacteristic.
+:destination a samm:Property;
+    samm:preferredName "Destination"@en;
+    samm:description "Destination refers to the final endpoint or intended location where the items are meant to arrive (i.e. customer factory)."@en;
+    samm:characteristic :LocationCharacteristic.
+:dateTimeOfEvent a samm:Property;
+    samm:preferredName "Time of Event"@en;
+    samm:description "Time of Event signifies the time and date when the products leave (or will leave) the origin location of a delivery (i.e. supplier's production site) or when the products arrive (or will arrive) at the destination location of the delivery (i.e. customer's production site)."@en;
+    samm:characteristic :DateTimeStamp;
+    samm:exampleValue "2023-04-01T14:23:00+01:00"^^xsd:dateTime.
+:eventType a samm:Property;
+    samm:preferredName "Event Type"@en;
+    samm:description "Event type describes wether the mentioned timeOfEvent refers to a departure or arrival and provides the status of the delivery (estimated or actual)."@en;
+    samm:characteristic :EventTypeEnumeration;
+    samm:exampleValue "estimated-departure".
+:LocationCharacteristic a samm:Characteristic;
+    samm:preferredName "Location Characteristic"@en;
+    samm:description "Location characteristic describes a particular location of a business partner. It MUST include the information of the site and it MAY include the exact address."@en;
+    samm:dataType :Location.
+:EventTypeEnumeration a samm-c:Enumeration;
+    samm:preferredName "Event Type Enumeration"@en;
+    samm:description "Event type is the permutation of actual, estimated and departure, arrival."@en;
+    samm:dataType xsd:string;
+    samm-c:values ("estimated-departure" "estimated-arrival" "actual-departure" "actual-arrival").
+:Location a samm:Entity;
+    samm:preferredName "Location"@en;
+    samm:description "Location refers to a specific place that can be identified with two parameters - business partner number site (BPNS) and business partner number address (BPNA). Location MUST include BPNS and it MAY include BPNA. "@en;
+    samm:properties ([
+  samm:property ext-number:bpnaProperty;
+  samm:optional "true"^^xsd:boolean
+] ext-number:bpnsProperty).

--- a/io.catenax.delivery_information/2.0.0/metadata.json
+++ b/io.catenax.delivery_information/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.delivery_information/RELEASE_NOTES.md
+++ b/io.catenax.delivery_information/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ n/a
 - migrated samm version from 2.0.0 to 2.1.0
 - updated materialGlobalAssetId description to point to part type twin
 - Delivery: fixed lowercase start in preferred name
+- make materialGlobalAssetId mandatory
 
 ### Removed
 - Harmonization for Industry Core

--- a/io.catenax.delivery_information/RELEASE_NOTES.md
+++ b/io.catenax.delivery_information/RELEASE_NOTES.md
@@ -21,6 +21,7 @@ n/a
 - Delivery: fixed lowercase start in preferred name
 - make materialGlobalAssetId mandatory
 - fixed typo in eventType description
+- dateTimeOfEvent -> use samm datatype instead of custom Characteristic
 
 ### Removed
 - Harmonization for Industry Core

--- a/io.catenax.delivery_information/RELEASE_NOTES.md
+++ b/io.catenax.delivery_information/RELEASE_NOTES.md
@@ -1,6 +1,30 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
+## [2.0.0] - 2024-02-19
+### Added
+n/a
+
+### Changed
+- Update Collections to Set for stronger semantics
+  - PositionsCollection -> PositionsSet
+  - AllocatedPlannedProductionOutputCollection -> AllocatedPlannedProductionOutputSet
+- lastUpdatedOnDateTime
+  - move from position to AllocatedPlannedProductionOutput
+  - use samm datatype instead of custom Characteristic
+- updated dependencies
+  - io.catenax.shared.uuid
+  - io.catenax.shared.quantity
+  - io.catenax.shared.business_partner_number
+- migrated samm version from 2.0.0 to 2.1.0
+- updated materialGlobalAssetId description to point to part type twin
+- Delivery: fixed lowercase start in preferred name
+
+### Removed
+- Harmonization for Industry Core
+  - materialNumberSupplier
+  - materialNumberCustomer
+
 ## [1.0.0] - 2023-12-04
 ### Added
 - initial model

--- a/io.catenax.delivery_information/RELEASE_NOTES.md
+++ b/io.catenax.delivery_information/RELEASE_NOTES.md
@@ -20,6 +20,7 @@ n/a
 - updated materialGlobalAssetId description to point to part type twin
 - Delivery: fixed lowercase start in preferred name
 - make materialGlobalAssetId mandatory
+- fixed typo in eventType description
 
 ### Removed
 - Harmonization for Industry Core


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

Closes #544 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.5.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
