### PR TITLE
[Model Deprecation]: urn:bamm:io.catenax.time_series_reference:1.0.0

### DIFF
--- a/io.catenax.time_series_reference/1.0.0/metadata.json
+++ b/io.catenax.time_series_reference/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{ "status" : "deprecate"} 


### PR DESCRIPTION
## Description
deprecating model

closes #376 