### PR TITLE
[Model Update]: WeekBasedMaterialDemand 24.05 changes

### DIFF
--- a/io.catenax.week_based_material_demand/3.0.0/WeekBasedMaterialDemand.ttl
+++ b/io.catenax.week_based_material_demand/3.0.0/WeekBasedMaterialDemand.ttl
@@ -1,0 +1,276 @@
+#######################################################################
+# Copyright (c) 2023-2024 BASF SE
+# Copyright (c) 2023-2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IML and Fraunhofer ISST)
+# Copyright (c) 2023-2024 Henkel AG & Co. KGaA
+# Copyright (c) 2023-2024 ISTOS GmbH (a member of the DMG Mori Group)
+# Copyright (c) 2023-2024 Mercedes Benz AG
+# Copyright (c) 2023-2024 SAP SE
+# Copyright (c) 2023-2024 SupplyOn AG
+# Copyright (c) 2023-2024 TRUMPF Werkzeugmaschinen SE + Co. KG
+# Copyright (c) 2023-2024 Volkswagen AG
+# Copyright (c) 2023-2024 ZF Friedrichshafen AG
+# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.week_based_material_demand:3.0.0#> .
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:2.0.0#> .
+@prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:2.0.0#> .
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
+
+:WeekBasedMaterialDemand a samm:Aspect ;
+   samm:preferredName "Material Demand"@en ;
+   samm:description "The requirements of a customer towards a specific supplier for a specific material. Each material demand is unique by its Customer, Supplier and Material Number."@en ;
+   samm:properties ( :materialDemandId :demandSeries :customer :supplier [ samm:property :unitOfMeasure; samm:optional true ] :materialNumberCustomer [ samm:property :materialNumberSupplier; samm:optional true ] :materialDescriptionCustomer :changedAt [ samm:property :materialGlobalAssetId; samm:optional true ] :unitOfMeasureIsOmitted :materialDemandIsInactive ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:materialDemandId a samm:Property ;
+   samm:preferredName "Material Demand ID"@en ;
+   samm:description "The Material Demand ID uniquely identifies the material demand within the business relationship between a customer and its supplier."@en ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
+   samm:exampleValue "0157ba42-d2a8-4e28-8565-7b07830c1110" .
+
+:demandSeries a samm:Property ;
+   samm:preferredName "Demand Series"@en ;
+   samm:description "The demands for a dedicated material in a given time period of a given demand rate, distinguished by their demand location and demand category."@en ;
+   samm:characteristic :DemandSeriesSet .
+
+:customer a samm:Property ;
+   samm:preferredName "Customer"@en ;
+   samm:description "The Business Partner Number Legal Entity (BPNL) of the party requesting materials from a supplier."@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL8888888888XX" .
+
+:supplier a samm:Property ;
+   samm:preferredName "Supplier"@en ;
+   samm:description "The Business Partner Number Legal Entity (BPNL) of the party providing materials to a customer."@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL6666666666YY" .
+
+:unitOfMeasure a samm:Property ;
+   samm:preferredName "Unit of Measure"@en ;
+   samm:description "Unit of measurement for demand quantities."@en ;
+   samm:characteristic ext-quantity:ItemUnitEnumeration ;
+   samm:exampleValue "unit:piece"^^samm:curie .
+
+:materialNumberCustomer a samm:Property ;
+   samm:preferredName "Customer Material Number"@en ;
+   samm:description "Material identifier as assigned by customer. This material number identifies the material (as planned) in customer's database. Must be unique for each Material Demand in the customer-supplier relationship."@en ;
+   samm:characteristic :MaterialNumber ;
+   samm:exampleValue "MNR-7307-AU340474.002" .
+
+:materialNumberSupplier a samm:Property ;
+   samm:preferredName "Supplier Material Number"@en ;
+   samm:description "Material identifier as assigned by supplier. This material number identifies the material (as planned) in supplier's database."@en ;
+   samm:characteristic :MaterialNumber ;
+   samm:exampleValue "MNR-8101-ID146955.001" .
+
+:materialDescriptionCustomer a samm:Property ;
+   samm:preferredName "Customer Material Description"@en ;
+   samm:description "Description of the material."@en ;
+   samm:characteristic :MaterialDescription ;
+   samm:exampleValue "Spark Plug" .
+
+:changedAt a samm:Property ;
+   samm:preferredName "Changed At"@en ;
+   samm:description "Point in time when the content (any property according to the data model) of the material demand was changed, at the customer, either by a human user or an automated process."@en ;
+   samm:characteristic :Timestamp ;
+   samm:exampleValue "2023-11-05T08:15:30.123-05:00"^^xsd:dateTimeStamp .
+
+:materialGlobalAssetId a samm:Property ;
+   samm:preferredName "UUID of the Part Type Twin"@en ;
+   samm:description "Identifier used uniquely to identify part type twin."@en ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
+   samm:exampleValue "urn:uuid:48878d48-6f1d-47f5-8ded-a441d0d879df" .
+
+:unitOfMeasureIsOmitted a samm:Property ;
+   samm:preferredName "Unit Of Measure Is Omitted"@en ;
+   samm:description "Explicit indicator of whether the unit of measure is left out of the payload intentionally. If \"true\" it means the sending application sends demand values without unit of measure intentionally and the unit of measure MUST NOT be contained in the payload. If \"false\" a unit of measure MUST be supplied."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue false .
+
+:materialDemandIsInactive a samm:Property ;
+   samm:preferredName "Material Demand Is Inactive"@en ;
+   samm:description "Indicates that this material demand is currently not in use/maintained by the supplier."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:DemandSeriesSet a samm-c:Set ;
+   samm:preferredName "Demand Series Set"@en ;
+   samm:description "A set of demand series belonging to a certain material demand. Each demand series in the set must have a unique combination of customer location and demand category."@en ;
+   samm:dataType :DemandSeries .
+
+:MaterialNumber a samm:Characteristic ;
+   samm:preferredName "Material Number"@en ;
+   samm:description "The material number is a multi-character string, usually assigned by an ERP system."@en ;
+   samm:dataType xsd:string .
+
+:MaterialDescription a samm:Characteristic ;
+   samm:preferredName "Material Description"@en ;
+   samm:description "Description of a material demand."@en ;
+   samm:dataType xsd:string .
+
+:Timestamp a samm:Characteristic ;
+   samm:preferredName "Timestamp"@en ;
+   samm:description "Point in time."@en ;
+   samm:dataType xsd:dateTimeStamp .
+
+:DemandSeries a samm:Entity ;
+   samm:preferredName "Demand Series"@en ;
+   samm:description "Encapsulates the demand series related information."@en ;
+   samm:properties ( :customerLocation :demandCategory :demands [ samm:property :expectedSupplierLocation; samm:optional true ] ) .
+
+:customerLocation a samm:Property ;
+   samm:preferredName "Customer Location"@en ;
+   samm:description "The Business Partner Number Site (BPNS) of the site at which the customer needs the specified material for this demand series."@en ;
+   samm:characteristic ext-number:BpnsTrait ;
+   samm:exampleValue "BPNS8888888888XX" .
+
+:demandCategory a samm:Property ;
+   samm:preferredName "Demand Category"@en ;
+   samm:description "Type of demand for this demand series."@en ;
+   samm:characteristic :DemandCategoryCharacteristic .
+
+:demands a samm:Property ;
+   samm:preferredName "Demands"@en ;
+   samm:description "A time series with a specified demand rate along a given time period to describe the demand values for this demand series."@en ;
+   samm:characteristic :DemandDateSeries .
+
+:expectedSupplierLocation a samm:Property ;
+   samm:preferredName "Expected Supplier Location"@en ;
+   samm:description "The Business Partner Number Site (BPNS) of the site from where the customer expects the supplier to fulfill the demands of the demand series. The value is used for informational purposes only and is therefore not binding for the supplier."@en ;
+   samm:characteristic ext-number:BpnsTrait ;
+   samm:exampleValue "BPNS8888888888XX" .
+
+:DemandCategoryCharacteristic a samm-c:Enumeration ;
+   samm:preferredName "Demand Category Characteristic"@en ;
+   samm:description "The classification of demands used for prioritization or allocation."@en ;
+   samm:dataType :DemandCategoryType ;
+   samm-c:values ( :DemandCategoryDefault :DemandCategoryAfterSales :DemandCategorySeries :DemandCategoryPhaseInPeriod :DemandCategorySingleOrder :DemandCategorySmallSeries :DemandCategoryExtraordinaryDemand :DemandCategoryPhaseOutPeriod ) .
+
+:DemandDateSeries a samm-c:SortedSet ;
+   samm:preferredName "Demand Date Series"@en ;
+   samm:description "The demands in a given time period for a given demand rate."@en ;
+   samm:dataType :Demand .
+
+:DemandCategoryType a samm:Entity ;
+   samm:preferredName "Demand Category Type"@en ;
+   samm:description "Describes the type of a demand category."@en ;
+   samm:properties ( :demandCategoryCode [ samm:property :demandCategoryName; samm:notInPayload true ] ) .
+
+:DemandCategoryDefault a :DemandCategoryType ;
+   :demandCategoryCode "0001" ;
+   :demandCategoryName "Default"@en .
+
+:DemandCategoryAfterSales a :DemandCategoryType ;
+   :demandCategoryCode "A1S1" ;
+   :demandCategoryName "After-Sales"@en .
+
+:DemandCategorySeries a :DemandCategoryType ;
+   :demandCategoryCode "SR99" ;
+   :demandCategoryName "Series"@en .
+
+:DemandCategoryPhaseInPeriod a :DemandCategoryType ;
+   :demandCategoryCode "PI01" ;
+   :demandCategoryName "Phase-In Period"@en .
+
+:DemandCategorySingleOrder a :DemandCategoryType ;
+   :demandCategoryCode "OS01" ;
+   :demandCategoryName "Single Order"@en .
+
+:DemandCategorySmallSeries a :DemandCategoryType ;
+   :demandCategoryCode "OI01" ;
+   :demandCategoryName "Small Series"@en .
+
+:DemandCategoryExtraordinaryDemand a :DemandCategoryType ;
+   :demandCategoryCode "ED01" ;
+   :demandCategoryName "Extraordinary Demand"@en .
+
+:DemandCategoryPhaseOutPeriod a :DemandCategoryType ;
+   :demandCategoryCode "PO01" ;
+   :demandCategoryName "Phase-Out Period"@en .
+
+:Demand a samm:Entity ;
+   samm:preferredName "Demand"@en ;
+   samm:description "A single demand for a given point in time according to the demand rate."@en ;
+   samm:properties ( :demand :pointInTime ) .
+
+:demandCategoryCode a samm:Property ;
+   samm:preferredName "Demand Category Code"@en ;
+   samm:description "The code identifying a demand category."@en ;
+   samm:characteristic :DemandCategoryCodeCharacteristic ;
+   samm:exampleValue "0001" .
+
+:demandCategoryName a samm:Property ;
+   samm:preferredName "Demand Category Name"@en ;
+   samm:description "The name describing a demand category."@en ;
+   samm:characteristic samm-c:MultiLanguageText ;
+   samm:exampleValue "Default"@en .
+
+:demand a samm:Property ;
+   samm:preferredName "Demand"@en ;
+   samm:description " Quantity of materials required in the specified point in time according specified demand rate. This demand should be as close as possible to demand that is derived from the actual production program."@en ;
+   samm:characteristic :QuantityTrait ;
+   samm:exampleValue "1000"^^xsd:decimal .
+
+:pointInTime a samm:Property ;
+   samm:preferredName "Point in Time"@en ;
+   samm:description "Defines the start of the demand rate as a point in time. The point in time must be interpreted according to the demand rate."@en ;
+   samm:characteristic :PointInTimeCharacteristic ;
+   samm:exampleValue "2023-10-09"^^xsd:date .
+
+:DemandCategoryCodeCharacteristic a samm-c:Code ;
+   samm:preferredName "Demand Category Code Characteristic"@en ;
+   samm:description "The code identifying a demand category."@en ;
+   samm:dataType xsd:string .
+
+:QuantityTrait a samm-c:Trait ;
+   samm:preferredName "Quantity Trait"@en ;
+   samm:description "Defining the data type for a demand key figure."@en ;
+   samm-c:baseCharacteristic :Quantity ;
+   samm-c:constraint :QuantityFixedPoint ;
+   samm-c:constraint :QuantityRange .
+
+:PointInTimeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Point in Time Characteristic"@en ;
+   samm:description "- If demand rate is \"calendar week\": An ISO calendar week in which a given demand is needed. Must be given as date of the Monday in the week. (ISO-8601-1:2019)\n- If demand rate is \"day\": An ISO day on which a given demand is needed. Must be given as single day (consider the time zone of the customer's location). (ISO-8601)"@en ;
+   samm:see <https://www.iso.org/standard/70907.html> ;
+   samm:see <https://www.iso.org/iso-8601-date-and-time-format.html> ;
+   samm:dataType xsd:date .
+
+:Quantity a samm:Characteristic ;
+   samm:preferredName "Quantity"@en ;
+   samm:description "Quantities of demands."@en ;
+   samm:dataType xsd:decimal .
+
+:QuantityFixedPoint a samm-c:FixedPointConstraint ;
+   samm:preferredName "Quantity Fixed Point"@en ;
+   samm:description "Constraint to ensure size of quantities: 12 digits plus 3 decimal places."@en ;
+   samm-c:integer "15"^^xsd:positiveInteger ;
+   samm-c:scale "1000"^^xsd:positiveInteger .
+
+:QuantityRange a samm-c:RangeConstraint ;
+   samm:preferredName "Quantity Range"@en ;
+   samm:description "Constraint to ensure a non-negative value for quantities."@en ;
+   samm-c:minValue "0"^^xsd:decimal ;
+   samm-c:maxValue "999999999999999999.999"^^xsd:decimal ;
+   samm-c:lowerBoundDefinition samm-c:AT_LEAST ;
+   samm-c:upperBoundDefinition samm-c:AT_MOST .

--- a/io.catenax.week_based_material_demand/3.0.0/metadata.json
+++ b/io.catenax.week_based_material_demand/3.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release" }

--- a/io.catenax.week_based_material_demand/RELEASE_NOTES.md
+++ b/io.catenax.week_based_material_demand/RELEASE_NOTES.md
@@ -1,12 +1,40 @@
 # Changelog
+
 All notable changes to this model will be documented in this file.
 
-## [2.0.0]
-- Migrated from Bamm to Samm
+## [3.0.0] - 2024-03-xx
 
-## [1.0.0]
-- initial version of the aspect model for week-based material demands
+### Added
+
+- added `materialDemandIsInactive` as mandatory flag in aspect model header
+- added `materialGlobalAssetId` as optional property in aspect model header
+- added `unitOfMeasureIsOmitted` as mandatory property in aspect model header
+- added `unit:secondUnitOfTime`, `unit:minuteUnitOfTime`, `unit:hourUnitOfTime` and `unit:cycle` to list of unit of measure for load information
+
+### Changed
+
+- migrated from SAMM version `2.0.0` to `2.1.0`
+- unitOfMeasure uses value list of shared aspect `urn:samm:io.catenax.shared.quantity` now. Units are now represented as reference units instead of common codes
+- made `unitOfMeasure` optional
+- using external references of `urn:samm:io.catenax.shared.business_partner_number`, `urn:samm:io.catenax.shared.quantity` and `urn:samm:io.catenax.shared.uuid` of version `2.0.0` for respective property definitions
+- changed property name of `calendarWeeks` to `pointInTime`
+
+### Removed
+
+- removed 'blank' value in list of `unitOfMeasure`. `unitOfMeasureIsOmitted` flag taking over the function of the 'blank' value
+
+## [2.0.0]
+
+### Changed
+
+- migrated from BAMM to SAMM
 
 ## [1.0.1] - 2023-05-10
+
 ### Changed
-- Changed description for property changedAt
+
+- Changed description for property `changedAt`
+
+## [1.0.0]
+
+- initial version of the aspect model for week based material demands

--- a/io.catenax.week_based_material_demand/RELEASE_NOTES.md
+++ b/io.catenax.week_based_material_demand/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 All notable changes to this model will be documented in this file.
 
-## [3.0.0] - 2024-03-xx
+## [3.0.0] - 2024-03-11
 
 ### Added
 


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

This is now the same data model as `MaterialDemand` in #587 without the property `demandRate`

Changes on the data model see RELEASE_NOTES.txt contained in this PR.

Closes #674

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.5.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
