### PR TITLE
[New Model]: Failure Pattern

### DIFF
--- a/io.catenax.failure_pattern/1.0.0/FailurePattern.ttl
+++ b/io.catenax.failure_pattern/1.0.0/FailurePattern.ttl
@@ -1,3 +1,5 @@
+
+
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
@@ -9,34 +11,216 @@
 
 :FailurePattern a samm:Aspect ;
    samm:description "Semantic model for a quality failure pattern."@en ;
-   samm:properties ( :referenceToAspectModel :failurePatternDefinition ) ;
+   samm:properties ( :failurePatternDefinition ) ;
    samm:operations ( ) ;
    samm:events ( ) .
+
+:failurePatternDefinition a samm:Property ;
+   samm:preferredName "Pattern definition"@en ;
+   samm:description "The definition of a failure pattern"@en ;
+   samm:characteristic :ListOfExpressions .
+
+:ListOfExpressions a samm-c:List ;
+   samm:preferredName "List of expresions"@en ;
+   samm:description "A List containing multiple expressions to describe a failure patterns"@en ;
+   samm:dataType :Expression .
+
+:Expression a samm:Entity ;
+   samm:preferredName "Expression"@en ;
+   samm:description "This entity describes a single expression for an failure pattern"@en ;
+   samm:properties ( [ samm:property :stringExpression; samm:optional true ] [ samm:property :booleanExpression; samm:optional true ] [ samm:property :subExpressionList; samm:optional true ] [ samm:property :timestampExpression; samm:optional true ] [ samm:property :numericExpression; samm:optional true ] [ samm:property :expressionConnector; samm:optional true ] ) .
+
+:stringExpression a samm:Property ;
+   samm:preferredName "String Expression"@en ;
+   samm:description "Describes an expression to compare string values"@en ;
+   samm:characteristic :StringExpressionCharacteristic .
+
+:booleanExpression a samm:Property ;
+   samm:preferredName "Boolean Expression"@en ;
+   samm:description "Describes an expression to compare boolean values"@en ;
+   samm:characteristic :BooleanExpressionCharacteristic .
+
+:subExpressionList a samm:Property ;
+   samm:preferredName "Sub Expression List"@en ;
+   samm:description "A List of Expressions which is inside of an expression to be able to describe complex expressions"@en ;
+   samm:characteristic :ListOfExpressions .
+
+:timestampExpression a samm:Property ;
+   samm:preferredName "Timestamp Expression"@en ;
+   samm:description "Describes an expression to compare timestamp values"@en ;
+   samm:characteristic :TimestampExpressionCharacteristic .
+
+:numericExpression a samm:Property ;
+   samm:preferredName "Numeric Expression"@en ;
+   samm:description "Describes an expression to compare numeric values"@en ;
+   samm:characteristic :NumericExpressionCharacteristic .
+
+:expressionConnector a samm:Property ;
+   samm:preferredName "Expression Connector"@en ;
+   samm:description "Describes how multiple expressions of a failure pattern are connected to eachother"@en ;
+   samm:characteristic :ExpressionConnectorEnumeration .
+
+:StringExpressionCharacteristic a samm:Characteristic ;
+   samm:preferredName "String expression characteristic"@en ;
+   samm:description "Characteristic to describe string expressions"@en ;
+   samm:dataType :StringExpression .
+
+:BooleanExpressionCharacteristic a samm:Characteristic ;
+   samm:preferredName "Boolean expression characteristic"@en ;
+   samm:description "Characteristic to describe boolean expressions"@en ;
+   samm:dataType :BooleanExpression .
+
+:TimestampExpressionCharacteristic a samm:Characteristic ;
+   samm:preferredName "Timestamp expression characteristic"@en ;
+   samm:description "Characteristic to describe timestamp expressions"@en ;
+   samm:dataType :TimestampExpression .
+
+:NumericExpressionCharacteristic a samm:Characteristic ;
+   samm:preferredName "Numeric expression characteristic"@en ;
+   samm:description "Characteristic to describe numeric expressions"@en ;
+   samm:dataType :NumericExpression .
+
+:ExpressionConnectorEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Expression connector enumeration"@en ;
+   samm:description "Provides a selection of several connectors for the expressions"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "AND" "OR" "XOR" ) .
+
+:StringExpression a samm:Entity ;
+   samm:preferredName "String expression"@en ;
+   samm:description "Describes the content of a string expression"@en ;
+   samm:properties ( :stringPropertyName :stringInsideOperator :stringValue :referenceToAspectModel ) .
+
+:BooleanExpression a samm:Entity ;
+   samm:preferredName "Boolean expression"@en ;
+   samm:description "Describes the content of a boolean expression"@en ;
+   samm:properties ( :booleanPropertyName :booleanInsideOperator :booleanValue :referenceToAspectModel ) .
+
+:TimestampExpression a samm:Entity ;
+   samm:preferredName "Timestamp expression"@en ;
+   samm:description "Describes the content of a timestamp expression"@en ;
+   samm:properties ( :timestampPropertyName :timestampInsideOperator :timestampValue :referenceToAspectModel ) .
+
+:NumericExpression a samm:Entity ;
+   samm:preferredName "Numeric expression"@en ;
+   samm:description "Describes the content of a numeric expression"@en ;
+   samm:properties ( :numericPropertyName :numericInsideOperator :numericValue :referenceToAspectModel ) .
+
+:stringPropertyName a samm:Property ;
+   samm:preferredName "String property name"@en ;
+   samm:description "A property name of type string from the model."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "vehicleSeries" .
+
+:stringInsideOperator a samm:Property ;
+   samm:preferredName "String inside operator"@en ;
+   samm:description "Describes the logical connector inside of a string expression"@en ;
+   samm:characteristic :StringInsideOperatorEnumeration ;
+   samm:exampleValue "equal" .
+
+:stringValue a samm:Property ;
+   samm:preferredName "String value"@en ;
+   samm:description "The value that is used within the string expression and with which it is to be compared"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "EA189" .
 
 :referenceToAspectModel a samm:Property ;
    samm:preferredName "Reference to aspect model"@en ;
    samm:description "This property describes the underlying aspect model to which this failure pattern definition should be applied to."@en ;
    samm:characteristic :LinkToAspectModel .
 
-:failurePatternDefinition a samm:Property ;
-   samm:preferredName "Pattern definition"@en ;
-   samm:characteristic :ListOfPatterns .
+:booleanPropertyName a samm:Property ;
+   samm:preferredName "Boolean property name"@en ;
+   samm:description "A property name of type booleanfrom the model."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "ecuList_dtcs_isMilOn" .
+
+:booleanInsideOperator a samm:Property ;
+   samm:preferredName "Boolean inside operator"@en ;
+   samm:description "Describes the logical connector inside of a boolean expression"@en ;
+   samm:characteristic :BooleanInsideOperatorEnumerator ;
+   samm:exampleValue "equal" .
+
+:booleanValue a samm:Property ;
+   samm:preferredName "Boolean value"@en ;
+   samm:description "The value that is used within the boolean expression and with which it is to be compared"@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:timestampPropertyName a samm:Property ;
+   samm:preferredName "Timestamp property name"@en ;
+   samm:description "A property name of type timestamp from the model."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "productionDate" .
+
+:timestampInsideOperator a samm:Property ;
+   samm:preferredName "Timestamp inside operator"@en ;
+   samm:description "Describes the logical connector inside of a timestamp expression"@en ;
+   samm:characteristic :TimtstampInsideOperatorEnumeration ;
+   samm:exampleValue "after" .
+
+:timestampValue a samm:Property ;
+   samm:preferredName "Timestamp value"@en ;
+   samm:description "The value that is used within the timestamp expression and with which it is to be compared"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2024-01-01T00:00:00"^^xsd:dateTime .
+
+:numericPropertyName a samm:Property ;
+   samm:preferredName "Numeric property name"@en ;
+   samm:description "A property name of a numeric type from the model."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "repairMileage" .
+
+:numericInsideOperator a samm:Property ;
+   samm:preferredName "Numeric inside operator"@en ;
+   samm:description "Describes the logical connector inside of a numeric expression"@en ;
+   samm:characteristic :NumericInsideOperatorEnumeration ;
+   samm:exampleValue "higher" .
+
+:numericValue a samm:Property ;
+   samm:preferredName "Numeric value"@en ;
+   samm:description "The value that is used within the numeric expression and with which it is to be compared"@en ;
+   samm:characteristic :NumericValueCharacteristic ;
+   samm:exampleValue "100"^^xsd:double .
+
+:StringInsideOperatorEnumeration a samm-c:Enumeration ;
+   samm:preferredName "String inside operator enumeration"@en ;
+   samm:description "Provides a selection of several logical operators for string expressions"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "equal" "not_equal" "like" ) .
 
 :LinkToAspectModel a samm:Characteristic ;
    samm:preferredName "Link to aspect model"@en ;
    samm:description "This characteristic groups all necessary properties to refer to an existing Catena-X aspect model."@en ;
    samm:dataType :AspectModel .
 
-:ListOfPatterns a samm-c:List ;
-   samm:dataType :Pattern .
+:BooleanInsideOperatorEnumerator a samm-c:Enumeration ;
+   samm:preferredName "Boolean inside operator enumeration"@en ;
+   samm:description "Provides a selection of several logical operators for boolean expressions"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "equal" "not_equal" ) .
+
+:TimtstampInsideOperatorEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Timestamp inside operator enumeration"@en ;
+   samm:description "Provides a selection of several logical operators for timestamp expressions"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "after" "before" "equal" "not_equal" ) .
+
+:NumericInsideOperatorEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Numeric inside operator enumeration"@en ;
+   samm:description "Provides a selection of several logical operators for numeric expressions"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "equal" "not_equal" "higher" "higher_equal" "lower" "lower_equal" ) .
+
+:NumericValueCharacteristic a samm:Characteristic ;
+   samm:preferredName "Numeric value characteristic"@en ;
+   samm:description "The characteristic to describe numeric values as double"@en ;
+   samm:dataType xsd:double .
 
 :AspectModel a samm:Entity ;
    samm:preferredName "Aspect model"@en ;
    samm:description "One existing Catena-X aspect model"@en ;
    samm:properties ( :nameSpace :ttlFile :modelVersion ) .
-
-:Pattern a samm:Entity ;
-   samm:properties ( [ samm:property :stringExpressions; samm:optional true ] [ samm:property :booleanExpressions; samm:optional true ] [ samm:property :childPattern; samm:optional true ] [ samm:property :dateRangeExpressions; samm:optional true ] ) .
 
 :nameSpace a samm:Property ;
    samm:preferredName "Name space"@en ;
@@ -57,18 +241,6 @@
    samm:characteristic :ModelVersionTrait ;
    samm:exampleValue "2.1.0" .
 
-:stringExpressions a samm:Property ;
-   samm:characteristic :StringExpressionList .
-
-:booleanExpressions a samm:Property ;
-   samm:characteristic :BooleanExpressionList .
-
-:childPattern a samm:Property ;
-   samm:characteristic :ListOfPatterns .
-
-:dateRangeExpressions a samm:Property ;
-   samm:characteristic :DateRangeExpressionList .
-
 :QAXNamespaces a samm-c:Enumeration ;
    samm:preferredName "Aspect model from CX use case quality."@en ;
    samm:description "A list to all existing qax namespaces."@en ;
@@ -81,87 +253,21 @@
    samm-c:baseCharacteristic samm-c:Text ;
    samm-c:constraint :RegexForAspectModelVersions .
 
-:StringExpressionList a samm-c:List ;
-   samm:dataType :StringExpression .
-
-:BooleanExpressionList a samm-c:List ;
-   samm:dataType :BooleanExpression .
-
-:DateRangeExpressionList a samm-c:List ;
-   samm:dataType :DateRangeExpression .
-
 :RegexForAspectModelVersions a samm-c:RegularExpressionConstraint ;
    samm:preferredName "Regex for aspect model versions"@en ;
    samm:description "This regular expression ensures that the version is [1-9].[0-9].[0.9]"@en ;
    samm:value "^[1-9].[0-9].[0-9]$" .
 
-:StringExpression a samm:Entity ;
-   samm:properties ( [ samm:property :outsideOperator; samm:optional true ] :stringPropertyName :stringInsideOperator :stringValue ) .
+:StringExpressionList a samm-c:List ;
+   samm:dataType :StringExpression .
 
-:BooleanExpression a samm:Entity ;
-   samm:properties ( [ samm:property :outsideOperator; samm:optional true ] :booleanPropertyName :booleanInsideOperator :booleanValue ) .
+:DateExpressionList a samm-c:List ;
+   samm:dataType :TimestampExpression .
 
-:DateRangeExpression a samm:Entity ;
-   samm:properties ( [ samm:property :outsideOperator; samm:optional true ] :datePropertyName :dateRangeInsideOperator :dateFrom :dateTo ) .
-
-:outsideOperator a samm:Property ;
-   samm:description "The outside operator can be AND or OR."@en ;
-   samm:characteristic :OutsideOperatorEnumeration .
-
-:stringPropertyName a samm:Property ;
-   samm:description "A property name of type string from the model."@en ;
-   samm:characteristic samm-c:Text ;
-   samm:exampleValue "vehicleSeries" .
-
-:stringInsideOperator a samm:Property ;
-   samm:characteristic :StringInsideOperatorEnumeration ;
-   samm:exampleValue "equal" .
-
-:stringValue a samm:Property ;
-   samm:characteristic samm-c:Text ;
-   samm:exampleValue "EA189" .
-
-:booleanPropertyName a samm:Property ;
-   samm:description "A property name of type booleanfrom the model."@en ;
-   samm:characteristic samm-c:Text .
-
-:booleanInsideOperator a samm:Property ;
-   samm:characteristic :BooleanInsideOperatorEnumerator ;
-   samm:exampleValue "equal" .
-
-:booleanValue a samm:Property ;
-   samm:characteristic samm-c:Boolean ;
-   samm:exampleValue true .
-
-:datePropertyName a samm:Property ;
-   samm:description "A property name of type timestamp from the model."@en ;
-   samm:characteristic samm-c:Text .
-
-:dateRangeInsideOperator a samm:Property ;
-   samm:characteristic :DateRangeInsideOperatorEnumeration ;
-   samm:exampleValue "from_to" .
-
-:dateFrom a samm:Property ;
-   samm:characteristic samm-c:Timestamp ;
-   samm:exampleValue "2024-01-01T00:00:00"^^xsd:dateTime .
-
-:dateTo a samm:Property ;
-   samm:characteristic samm-c:Timestamp ;
-   samm:exampleValue "2024-12-01T00:00:00"^^xsd:dateTime .
+:BooleanExpressionList a samm-c:List ;
+   samm:dataType :BooleanExpression .
 
 :OutsideOperatorEnumeration a samm-c:Enumeration ;
    samm:dataType xsd:string ;
    samm-c:values ( "and" "or" ) .
-
-:StringInsideOperatorEnumeration a samm-c:Enumeration ;
-   samm:dataType xsd:string ;
-   samm-c:values ( "equal" "not" "like" ) .
-
-:BooleanInsideOperatorEnumerator a samm-c:Enumeration ;
-   samm:dataType xsd:string ;
-   samm-c:values ( "equal" "not_equal" ) .
-
-:DateRangeInsideOperatorEnumeration a samm-c:Enumeration ;
-   samm:dataType xsd:string ;
-   samm-c:values ( "from_to" "not_from_to" ) .
 

--- a/io.catenax.failure_pattern/1.0.0/FailurePattern.ttl
+++ b/io.catenax.failure_pattern/1.0.0/FailurePattern.ttl
@@ -1,0 +1,167 @@
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.qax:1.0.0#> .
+
+:FailurePattern a samm:Aspect ;
+   samm:description "Semantic model for a quality failure pattern."@en ;
+   samm:properties ( :referenceToAspectModel :failurePatternDefinition ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:referenceToAspectModel a samm:Property ;
+   samm:preferredName "Reference to aspect model"@en ;
+   samm:description "This property describes the underlying aspect model to which this failure pattern definition should be applied to."@en ;
+   samm:characteristic :LinkToAspectModel .
+
+:failurePatternDefinition a samm:Property ;
+   samm:preferredName "Pattern definition"@en ;
+   samm:characteristic :ListOfPatterns .
+
+:LinkToAspectModel a samm:Characteristic ;
+   samm:preferredName "Link to aspect model"@en ;
+   samm:description "This characteristic groups all necessary properties to refer to an existing Catena-X aspect model."@en ;
+   samm:dataType :AspectModel .
+
+:ListOfPatterns a samm-c:List ;
+   samm:dataType :Pattern .
+
+:AspectModel a samm:Entity ;
+   samm:preferredName "Aspect model"@en ;
+   samm:description "One existing Catena-X aspect model"@en ;
+   samm:properties ( :nameSpace :ttlFile :modelVersion ) .
+
+:Pattern a samm:Entity ;
+   samm:properties ( [ samm:property :stringExpressions; samm:optional true ] [ samm:property :booleanExpressions; samm:optional true ] [ samm:property :childPattern; samm:optional true ] [ samm:property :dateRangeExpressions; samm:optional true ] ) .
+
+:nameSpace a samm:Property ;
+   samm:preferredName "Name space"@en ;
+   samm:description "Name space of the model"@en ;
+   samm:see <https://github.com/eclipse-tractusx/sldt-semantic-models> ;
+   samm:characteristic :QAXNamespaces ;
+   samm:exampleValue "io.catenax.fleet.vehicles" .
+
+:ttlFile a samm:Property ;
+   samm:preferredName "TTl file name"@en ;
+   samm:description "A defined ttl file"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Vehicles.ttl" .
+
+:modelVersion a samm:Property ;
+   samm:preferredName "Model version"@en ;
+   samm:description "Version of aspect model."@en ;
+   samm:characteristic :ModelVersionTrait ;
+   samm:exampleValue "2.1.0" .
+
+:stringExpressions a samm:Property ;
+   samm:characteristic :StringExpressionList .
+
+:booleanExpressions a samm:Property ;
+   samm:characteristic :BooleanExpressionList .
+
+:childPattern a samm:Property ;
+   samm:characteristic :ListOfPatterns .
+
+:dateRangeExpressions a samm:Property ;
+   samm:characteristic :DateRangeExpressionList .
+
+:QAXNamespaces a samm-c:Enumeration ;
+   samm:preferredName "Aspect model from CX use case quality."@en ;
+   samm:description "A list to all existing qax namespaces."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "io.catenax.fleet.claim_data" "io.catenax.fleet.diagnostic_data" "io.catenax.fleet.vehicles" "io.catenax.manufactured_parts_quality_information" "io.catenax.parts_analyses" "io.catenax.quality_task" ) .
+
+:ModelVersionTrait a samm-c:Trait ;
+   samm:preferredName "Model Versioning Trait"@en ;
+   samm:description "This trait ensures proper versioning of an aspect model."@en ;
+   samm-c:baseCharacteristic samm-c:Text ;
+   samm-c:constraint :RegexForAspectModelVersions .
+
+:StringExpressionList a samm-c:List ;
+   samm:dataType :StringExpression .
+
+:BooleanExpressionList a samm-c:List ;
+   samm:dataType :BooleanExpression .
+
+:DateRangeExpressionList a samm-c:List ;
+   samm:dataType :DateRangeExpression .
+
+:RegexForAspectModelVersions a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Regex for aspect model versions"@en ;
+   samm:description "This regular expression ensures that the version is [1-9].[0-9].[0.9]"@en ;
+   samm:value "^[1-9].[0-9].[0-9]$" .
+
+:StringExpression a samm:Entity ;
+   samm:properties ( [ samm:property :outsideOperator; samm:optional true ] :stringPropertyName :stringInsideOperator :stringValue ) .
+
+:BooleanExpression a samm:Entity ;
+   samm:properties ( [ samm:property :outsideOperator; samm:optional true ] :booleanPropertyName :booleanInsideOperator :booleanValue ) .
+
+:DateRangeExpression a samm:Entity ;
+   samm:properties ( [ samm:property :outsideOperator; samm:optional true ] :datePropertyName :dateRangeInsideOperator :dateFrom :dateTo ) .
+
+:outsideOperator a samm:Property ;
+   samm:description "The outside operator can be AND or OR."@en ;
+   samm:characteristic :OutsideOperatorEnumeration .
+
+:stringPropertyName a samm:Property ;
+   samm:description "A property name of type string from the model."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "vehicleSeries" .
+
+:stringInsideOperator a samm:Property ;
+   samm:characteristic :StringInsideOperatorEnumeration ;
+   samm:exampleValue "equal" .
+
+:stringValue a samm:Property ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "EA189" .
+
+:booleanPropertyName a samm:Property ;
+   samm:description "A property name of type booleanfrom the model."@en ;
+   samm:characteristic samm-c:Text .
+
+:booleanInsideOperator a samm:Property ;
+   samm:characteristic :BooleanInsideOperatorEnumerator ;
+   samm:exampleValue "equal" .
+
+:booleanValue a samm:Property ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:datePropertyName a samm:Property ;
+   samm:description "A property name of type timestamp from the model."@en ;
+   samm:characteristic samm-c:Text .
+
+:dateRangeInsideOperator a samm:Property ;
+   samm:characteristic :DateRangeInsideOperatorEnumeration ;
+   samm:exampleValue "from_to" .
+
+:dateFrom a samm:Property ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2024-01-01T00:00:00"^^xsd:dateTime .
+
+:dateTo a samm:Property ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2024-12-01T00:00:00"^^xsd:dateTime .
+
+:OutsideOperatorEnumeration a samm-c:Enumeration ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "and" "or" ) .
+
+:StringInsideOperatorEnumeration a samm-c:Enumeration ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "equal" "not" "like" ) .
+
+:BooleanInsideOperatorEnumerator a samm-c:Enumeration ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "equal" "not_equal" ) .
+
+:DateRangeInsideOperatorEnumeration a samm-c:Enumeration ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "from_to" "not_from_to" ) .
+

--- a/io.catenax.failure_pattern/1.0.0/FailurePattern.ttl
+++ b/io.catenax.failure_pattern/1.0.0/FailurePattern.ttl
@@ -3,11 +3,10 @@
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
-@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.qax:1.0.0#> .
+@prefix : <urn:samm:io.catenax.failure_pattern:1.0.0#> .
 
 :FailurePattern a samm:Aspect ;
    samm:description "Semantic model for a quality failure pattern."@en ;

--- a/io.catenax.failure_pattern/1.0.0/FailurePattern.ttl
+++ b/io.catenax.failure_pattern/1.0.0/FailurePattern.ttl
@@ -1,4 +1,22 @@
-
+#######################################################################
+# Copyright (c) 2022, 2024 Robert Bosch GmbH
+# Copyright (c) 2022, 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022, 2024 Volkswagen AG
+# Copyright (c) 2022, 2024 ZF Friedrichshafen AG
+# Copyright (c) 2022, 2024 SAP SE
+# Copyright (c) 2022, 2024 Siemens AG
+# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
@@ -9,6 +27,7 @@
 @prefix : <urn:samm:io.catenax.failure_pattern:1.0.0#> .
 
 :FailurePattern a samm:Aspect ;
+   samm:preferredName "Failure Pattern"@en ;
    samm:description "Semantic model for a quality failure pattern."@en ;
    samm:properties ( :failurePatternDefinition ) ;
    samm:operations ( ) ;
@@ -130,7 +149,7 @@
 
 :booleanPropertyName a samm:Property ;
    samm:preferredName "Boolean property name"@en ;
-   samm:description "A property name of type booleanfrom the model."@en ;
+   samm:description "A property name of type boolean from the model."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "ecuList_dtcs_isMilOn" .
 
@@ -155,7 +174,7 @@
 :timestampInsideOperator a samm:Property ;
    samm:preferredName "Timestamp inside operator"@en ;
    samm:description "Describes the logical connector inside of a timestamp expression"@en ;
-   samm:characteristic :TimtstampInsideOperatorEnumeration ;
+   samm:characteristic :TimestampInsideOperatorEnumeration ;
    samm:exampleValue "after" .
 
 :timestampValue a samm:Property ;
@@ -199,7 +218,7 @@
    samm:dataType xsd:string ;
    samm-c:values ( "equal" "not_equal" ) .
 
-:TimtstampInsideOperatorEnumeration a samm-c:Enumeration ;
+:TimestampInsideOperatorEnumeration a samm-c:Enumeration ;
    samm:preferredName "Timestamp inside operator enumeration"@en ;
    samm:description "Provides a selection of several logical operators for timestamp expressions"@en ;
    samm:dataType xsd:string ;
@@ -256,17 +275,4 @@
    samm:preferredName "Regex for aspect model versions"@en ;
    samm:description "This regular expression ensures that the version is [1-9].[0-9].[0.9]"@en ;
    samm:value "^[1-9].[0-9].[0-9]$" .
-
-:StringExpressionList a samm-c:List ;
-   samm:dataType :StringExpression .
-
-:DateExpressionList a samm-c:List ;
-   samm:dataType :TimestampExpression .
-
-:BooleanExpressionList a samm-c:List ;
-   samm:dataType :BooleanExpression .
-
-:OutsideOperatorEnumeration a samm-c:Enumeration ;
-   samm:dataType xsd:string ;
-   samm-c:values ( "and" "or" ) .
 

--- a/io.catenax.failure_pattern/1.0.0/FailurePattern.ttl
+++ b/io.catenax.failure_pattern/1.0.0/FailurePattern.ttl
@@ -1,11 +1,11 @@
 #######################################################################
-# Copyright (c) 2022, 2024 Robert Bosch GmbH
-# Copyright (c) 2022, 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# Copyright (c) 2022, 2024 Volkswagen AG
-# Copyright (c) 2022, 2024 ZF Friedrichshafen AG
-# Copyright (c) 2022, 2024 SAP SE
-# Copyright (c) 2022, 2024 Siemens AG
-# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2024 Robert Bosch GmbH
+# Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2024 Volkswagen AG
+# Copyright (c) 2024 ZF Friedrichshafen AG
+# Copyright (c) 2024 SAP SE
+# Copyright (c) 2024 Siemens AG
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.failure_pattern/1.0.0/metadata.json
+++ b/io.catenax.failure_pattern/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.failure_pattern/RELEASE_NOTES.md
+++ b/io.catenax.failure_pattern/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
-## [1.0.0] - 2024-02-19
+## [1.0.0] - 2024-03-04
 ### Added
 - initial version of this model
 

--- a/io.catenax.failure_pattern/RELEASE_NOTES.md
+++ b/io.catenax.failure_pattern/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [Unreleased]
+
+## [1.0.0] - 2024-02-19
+### Added
+- initial version of this model
+
+### Changed
+n/a
+
+### Removed
+

--- a/io.catenax.failure_pattern/RELEASE_NOTES.md
+++ b/io.catenax.failure_pattern/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
-## [1.0.0] - 2024-03-04
+## [1.0.0] - 2024-03-11
 ### Added
 - initial version of this model
 


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

Closes #[620](https://github.com/eclipse-tractusx/sldt-semantic-models/issues/620)

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.5.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
