### PR TITLE
[MODEL_UPDATE] PCF for CX Rel. 24.08

### DIFF
--- a/io.catenax.pcf/7.0.0/Pcf.ttl
+++ b/io.catenax.pcf/7.0.0/Pcf.ttl
@@ -48,7 +48,7 @@
    samm:description "Mandatory: Version of the product footprint data specification as defined in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Text ;
-   samm:exampleValue "urn:io.catenax.pcf:datamodel:version:1.0.0 \t" .
+   samm:exampleValue "urn:io.catenax.pcf:datamodel:version:7.0.0" .
 
 :partialFullPcf a samm:Property ;
    samm:preferredName "Partial Or Full PCF (Product Carbon Footprint)"@en ;
@@ -356,7 +356,7 @@
 
 :packagingEmissionsIncluded a samm:Property ;
    samm:preferredName "Packaging Emissions Included"@en ;
-   samm:description "Mandatory: C-X PCF Rulebook requires to include packaging from a system boundary perspective. \"FALSE\" is only possible due to the application of the cut-off rule.\nFlag indicating whether packaging emissions are included in a PCF (Product Carbon Footprint) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension."@en ;
+   samm:description "Mandatory: The Catena-X PCF Rulebook requires to include packaging from a system boundary perspective. \"FALSE\" is only possible due to the application of the cut-off rule.\nFlag indicating whether packaging emissions are included in a PCF (Product Carbon Footprint) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Boolean .
 
@@ -790,7 +790,7 @@
    samm:description "Characteristic for defining the enumeration of valid accounting standards used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType xsd:string ;
-   samm-c:values ( "GHG Protocol Product standard" "ISO Standard 14067" "ISO Standard 14044" ) .
+   samm-c:values ( "ISO Standard 14067" "ISO Standard 14044" "Pathfinder v1" "Pathfinder v2" "PAS 2050" "ISO Standard 14040" "ISO Standard 14041" "ISO Standard 14042" "ISO Standard 14043" "PEF" "Other" "GHG Protocol Product Standard" ) .
 
 :ProductOrSectorSpecificRuleOperator a samm-c:Enumeration ;
    samm:preferredName "Product Or Sector Specific Rule Operator"@en ;

--- a/io.catenax.pcf/7.0.0/Pcf.ttl
+++ b/io.catenax.pcf/7.0.0/Pcf.ttl
@@ -1,0 +1,851 @@
+#######################################################################
+# Copyright (c) 2022, 2023, 2024 ZF Friedrichshafen AG
+# Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
+# Copyright (c) 2022, 2023, 2024 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2022, 2023, 2024 Siemens AG
+# Copyright (c) 2022, 2023, 2024 SAP AG
+# Copyright (c) 2022, 2023, 2024 BASF SE
+# Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.pcf:7.0.0#> .
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
+
+:Pcf a samm:Aspect ;
+   samm:preferredName "Product (Carbon) Footprint"@en ;
+   samm:description "A Product (Carbon) Footprint represents the carbon footprint of a product with values as specified in the Catena-X PCF Rulebook in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:properties ( [ samm:property :id; samm:payloadName "id" ] [ samm:property :specVersion; samm:payloadName "specVersion" ] [ samm:property :partialFullPcf; samm:payloadName "partialFullPcf" ] [ samm:property :precedingPfIds; samm:optional true; samm:payloadName "precedingPfIds" ] [ samm:property :version; samm:payloadName "version" ] [ samm:property :created; samm:payloadName "created" ] [ samm:property :status; samm:payloadName "extWBCSD_pfStatus" ] [ samm:property :validityPeriodStart; samm:optional true; samm:payloadName "validityPeriodStart" ] [ samm:property :validityPeriodEnd; samm:optional true; samm:payloadName "validityPeriodEnd" ] [ samm:property :comment; samm:optional true; samm:payloadName "comment" ] [ samm:property :companyName; samm:payloadName "companyName" ] [ samm:property :companyIds; samm:payloadName "companyIds" ] [ samm:property :productDescription; samm:optional true; samm:payloadName "productDescription" ] [ samm:property :productIds; samm:payloadName "productIds" ] [ samm:property :productCategoryCpc; samm:payloadName "extWBCSD_productCodeCpc" ] [ samm:property :productNameCompany; samm:payloadName "productName" ] [ samm:property :pcf; samm:payloadName "pcf" ] [ samm:property :pcfLegalStatement; samm:optional true; samm:payloadName "pcfLegalStatement" ] ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:id a samm:Property ;
+   samm:preferredName "Product Footprint Identifier"@en ;
+   samm:description "Mandatory: The product footprint identifier as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
+   samm:exampleValue "3893bb5d-da16-4dc1-9185-11d97476c254" .
+
+:specVersion a samm:Property ;
+   samm:preferredName "Product Footprint Specification Version"@en ;
+   samm:description "Mandatory: Version of the product footprint data specification as defined in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "urn:io.catenax.pcf:datamodel:version:1.0.0 \t" .
+
+:partialFullPcf a samm:Property ;
+   samm:preferredName "Partial Or Full PCF (Product Carbon Footprint)"@en ;
+   samm:description "Mandatory: Indicator for partial or full PCF (Product Carbon Footprint) declaration as specified in the Catena-X PCF Rulebook."@en ;
+   samm:characteristic :PartialFullPcfCharacteristic ;
+   samm:exampleValue "Cradle-to-gate" .
+
+:precedingPfIds a samm:Property ;
+   samm:preferredName "Previous PCF (Product Carbon Footprint) Identifiers"@en ;
+   samm:description "Optional: Set of preceding PCF (Product Carbon Footprint) identifiers without duplicates as specified in the Catena-X PCF Rulebook in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative. Declared as \"optional\" in WBCSD, needs to be covered by application."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :PrecedingPfIdsCharacteristic .
+
+:version a samm:Property ;
+   samm:preferredName "Product (Carbon) Footprint Version"@en ;
+   samm:description "Mandatory: Version of the product (carbon) footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to \"0\" per default."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :ProductFootprintVersion ;
+   samm:exampleValue "0"^^xsd:nonNegativeInteger .
+
+:created a samm:Property ;
+   samm:preferredName "Creation of the Product (Carbon) Footprint"@en ;
+   samm:description "Mandatory: Timestamp of the creation of the Product (Carbon) Footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2022-05-22T21:47:32Z"^^xsd:dateTime .
+
+:status a samm:Property ;
+   samm:preferredName "Status"@en ;
+   samm:description "Mandatory: Status indicator of a product (carbon) footprint as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example set to \"Active\" per default."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :PfStatusCharacteristic ;
+   samm:exampleValue "Active" .
+
+:validityPeriodStart a samm:Property ;
+   samm:preferredName "Validity Period Start"@en ;
+   samm:description "Optional: Start of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. If specified, the validity period start must be equal to or greater than the reference period end."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2022-01-01T00:00:01Z"^^xsd:dateTime .
+
+:validityPeriodEnd a samm:Property ;
+   samm:preferredName "Validity Period End"@en ;
+   samm:description "Optional: End of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2022-12-31T23:59:59Z"^^xsd:dateTime .
+
+:comment a samm:Property ;
+   samm:preferredName "Comment"@en ;
+   samm:description "Optional: Additional information and instructions related to the calculation of the product (carbon) footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Additional explanatory information not reflected by other attributes" .
+
+:companyName a samm:Property ;
+   samm:preferredName "Company Name"@en ;
+   samm:description "Mandatory: Name of the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :NonEmptyStringTrait ;
+   samm:exampleValue "My Corp" .
+
+:companyIds a samm:Property ;
+   samm:preferredName "Company IDs"@en ;
+   samm:description "Mandatory: Non-empty set of Uniform Resource Names (URN). Each value is supposed to uniquely identify the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. For Catena-X Industry Core compliance the set of URNs must contain at least the Business Partner Number Legal Entity (BPNL) in the specified format urn:bpn:id:BPNL[a-zA-Z0-9]{12}. "@en ;
+   samm:see <urn:samm:io.catenax.shared.business_partner_number:2.0.0#bpnlProperty> ;
+   samm:characteristic :IdsTrait ;
+   samm:exampleValue "urn:bpn:BPNL000000000DWF"^^xsd:anyURI .
+
+:productDescription a samm:Property ;
+   samm:preferredName "Product Description"@en ;
+   samm:description "Optional: Free-form description of the product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Ethanol, 95% solution" .
+
+:productIds a samm:Property ;
+   samm:preferredName "Product IDs"@en ;
+   samm:description "Mandatory: Non-empty set of product identifiers. Each value is supposed to uniquely identify the product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productId corresponds with Industry Core manufacturerPartId."@en ;
+   samm:see <urn:samm:io.catenax.part_type_information:1.0.0#manufacturerPartId> ;
+   samm:characteristic :IdsTrait ;
+   samm:exampleValue "urn:gtin:4712345060507"^^xsd:anyURI .
+
+:productCategoryCpc a samm:Property ;
+   samm:preferredName "Product Category"@en ;
+   samm:description "Mandatory: UN (United Nations) Product Classification Code (CPC - Central Classification Code) of a given product as specified the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, which will probably be declared as \"optional\" in a later WBCSD specification version. In Catena-X for example specified with default value \"011-99000\"."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "011-99000" .
+
+:productNameCompany a samm:Property ;
+   samm:preferredName "Product Trade Name"@en ;
+   samm:description "Mandatory: Non-empty trade name of a product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productNameCompany corresponds with Industry Core nameAtManufacturer. "@en ;
+   samm:see <urn:samm:io.catenax.part_type_information:1.0.0#nameAtManufacturer> ;
+   samm:characteristic :NonEmptyStringTrait ;
+   samm:exampleValue "My Product Name" .
+
+:pcf a samm:Property ;
+   samm:preferredName "PCF (Product Carbon Footprint)"@en ;
+   samm:description "A PCF (Product Carbon Footprint) represents the carbon footprint of a product and related data as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :CarbonFootprint .
+
+:pcfLegalStatement a samm:Property ;
+   samm:preferredName "PCF (Product Carbon Footprint) Legal Statement"@en ;
+   samm:description "Optional: Option for legal statement/ disclaimer as specified in the Catena-X PCF Rulebook."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "This PCF (Product Carbon Footprint) is for information purposes only. It is based upon the standards mentioned above." .
+
+:PartialFullPcfCharacteristic a samm-c:Enumeration ;
+   samm:preferredName "Partial Or Full PCF (Product Carbon Footprint) Characteristic"@en ;
+   samm:description "Characteristic for defining an indicator for partial or full PCF (Product Carbon Footprint) declaration as specified in the Catena-X PCF Rulebook."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Cradle-to-gate" "Cradle-to-grave" ) .
+
+:PrecedingPfIdsCharacteristic a samm-c:List ;
+   samm:preferredName "Previous PCF (Product Carbon Footprint) Identifiers Characteristic"@en ;
+   samm:description "Characteristic for defining a non-empty set of product (carbon) footprint identifiers as specified in the Catena-X PCF Rulebook in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType :PrecedingPfId .
+
+:ProductFootprintVersion a samm:Characteristic ;
+   samm:preferredName "Product (Carbon) Footprint Version Characteristic"@en ;
+   samm:description "Characteristic for defining a product footprint version as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType xsd:nonNegativeInteger .
+
+:PfStatusCharacteristic a samm-c:Enumeration ;
+   samm:preferredName "PF (Product Footprint) Status Characteristic"@en ;
+   samm:description "Characteristic for defining a status indicator of a product (carbon) footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Enumeration with possible \"Active\" and \"Deprecated\"."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Active" "Deprecated" ) .
+
+:NonEmptyStringTrait a samm-c:Trait ;
+   samm:preferredName "Non Empty String Trait"@en ;
+   samm:description "Trait for defining a string with at least one character."@en ;
+   samm-c:baseCharacteristic samm-c:Text ;
+   samm-c:constraint :NonEmptyString .
+
+:IdsTrait a samm-c:Trait ;
+   samm:preferredName "IDs Trait"@en ;
+   samm:description "Trait for URIs (Uniform Resource Identifiers)."@en ;
+   samm-c:baseCharacteristic :IdSet ;
+   samm-c:constraint :NonEmptySetConstraint .
+
+:CarbonFootprint a samm-c:SingleEntity ;
+   samm:preferredName "PCF (Product Carbon Footprint) Characteristic"@en ;
+   samm:description "Characteristic for defining a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:dataType :PcfEntity .
+
+:PrecedingPfId a samm:Entity ;
+   samm:preferredName "Preceding PCF (Product Carbon Footprint) Identifier Entity"@en ;
+   samm:description "Entity for defining a preceding PCF (Product Carbon Footprint) identifier entity as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:properties ( :id ) .
+
+:NonEmptyString a samm-c:LengthConstraint ;
+   samm:preferredName "Non Empty String Constraint"@en ;
+   samm:description "Constraint for ensuring that a string has at least one character."@en ;
+   samm-c:minValue "1"^^xsd:nonNegativeInteger .
+
+:IdSet a samm-c:List ;
+   samm:preferredName "ID Set Characteristic"@en ;
+   samm:description "Characteristic for defining a set of URIs (Uniform Resource Identifiers)."@en ;
+   samm:dataType xsd:anyURI .
+
+:NonEmptySetConstraint a samm-c:LengthConstraint ;
+   samm:preferredName "Non Empty Set Constraint"@en ;
+   samm:description "Constraint for defining a non-empty set of URIs (Uniform Resource Identifieres)."@en ;
+   samm-c:minValue "1"^^xsd:nonNegativeInteger .
+
+:PcfEntity a samm:Entity ;
+   samm:preferredName "PCF (Product Carbon Footprint) Entity"@en ;
+   samm:description "Entity for defining a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:properties ( [ samm:property :declaredUnit; samm:payloadName "declaredUnit" ] [ samm:property :unitaryProductAmount; samm:payloadName "unitaryProductAmount" ] [ samm:property :productMassPerDeclaredUnit; samm:payloadName "productMassPerDeclaredUnit" ] [ samm:property :exemptedEmissionsPercent; samm:payloadName "exemptedEmissionsPercent" ] [ samm:property :exemptedEmissionsDescription; samm:optional true; samm:payloadName "exemptedEmissionsDescription" ] [ samm:property :boundaryProcessesDescription; samm:optional true; samm:payloadName "boundaryProcessesDescription" ] [ samm:property :geographyCountrySubdivision; samm:optional true; samm:payloadName "geographyCountrySubdivision" ] [ samm:property :geographyCountry; samm:optional true; samm:payloadName "geographyCountry" ] [ samm:property :geographyRegionOrSubregion; samm:payloadName "geographyRegionOrSubregion" ] [ samm:property :referencePeriodStart; samm:payloadName "referencePeriodStart" ] [ samm:property :referencePeriodEnd; samm:payloadName "referencePeriodEnd" ] [ samm:property :crossSectoralStandardsUsed; samm:payloadName "crossSectoralStandardsUsed" ] [ samm:property :productOrSectorSpecificRules; samm:payloadName "productOrSectorSpecificRules" ] [ samm:property :characterizationFactors; samm:payloadName "extWBCSD_characterizationFactors" ] [ samm:property :allocationRulesDescription; samm:optional true; samm:payloadName "extWBCSD_allocationRulesDescription" ] [ samm:property :allocationWasteIncineration; samm:payloadName "extTFS_allocationWasteIncineration" ] [ samm:property :primaryDataShare; samm:optional true; samm:payloadName "primaryDataShare" ] [ samm:property :secondaryEmissionFactorSources; samm:payloadName "secondaryEmissionFactorSources" ] [ samm:property :dqi; samm:optional true; samm:payloadName "dataQualityRating" ] [ samm:property :packagingEmissionsIncluded; samm:payloadName "extWBCSD_packagingEmissionsIncluded" ] [ samm:property :pcfExcludingBiogenic; samm:payloadName "pcfExcludingBiogenic" ] [ samm:property :pcfIncludingBiogenic; samm:optional true; samm:payloadName "pcfIncludingBiogenic" ] [ samm:property :fossilGhgEmissions; samm:optional true; samm:payloadName "fossilGhgEmissions" ] [ samm:property :biogenicCarbonEmissionsOtherThanCO2; samm:optional true; samm:payloadName "biogenicCarbonEmissionsOtherThanCO2" ] [ samm:property :biogenicCarbonWithdrawal; samm:optional true; samm:payloadName "biogenicCarbonWithdrawal" ] [ samm:property :dlucGhgEmissions; samm:optional true; samm:payloadName "dlucGhgEmissions" ] [ samm:property :luGhgEmissions; samm:optional true; samm:payloadName "extTFS_luGhgEmissions" ] [ samm:property :aircraftGhgEmissions; samm:optional true; samm:payloadName "aircraftGhgEmissions" ] [ samm:property :packagingGhgEmissions; samm:optional true; samm:payloadName "extWBCSD_packagingGhgEmissions" ] [ samm:property :distributionStagePcfExcludingBiogenic; samm:optional true; samm:payloadName "distributionStagePcfExcludingBiogenic" ] [ samm:property :distributionStagePcfIncludingBiogenic; samm:optional true; samm:payloadName "distributionStagePcfIncludingBiogenic" ] [ samm:property :distributionStageFossilGhgEmissions; samm:optional true; samm:payloadName "distributionStageFossilGhgEmissions" ] [ samm:property :distributionStageBiogenicCarbonEmissionsOtherThanCO2; samm:optional true; samm:payloadName "distributionStageBiogenicCarbonEmissionsOtherThanCO2" ] [ samm:property :distributionStageBiogenicCarbonWithdrawal; samm:optional true; samm:payloadName "distributionStageBiogenicCarbonWithdrawal" ] [ samm:property :distributionStageDlucGhgEmissions; samm:optional true; samm:payloadName "extTFS_distributionStageDlucGhgEmissions" ] [ samm:property :distributionStageLuGhgEmissions; samm:optional true; samm:payloadName "extTFS_distributionStageLuGhgEmissions" ] [ samm:property :carbonContentTotal; samm:optional true; samm:payloadName "carbonContentTotal" ] [ samm:property :fossilCarbonContent; samm:optional true; samm:payloadName "extWBCSD_fossilCarbonContent" ] [ samm:property :biogenicCarbonContent; samm:optional true; samm:payloadName "carbonContentBiogenic" ] [ samm:property :distributionStageAircraftGhgEmissions; samm:optional true; samm:payloadName "distributionStageAircraftGhgEmissions" ] ) .
+
+:declaredUnit a samm:Property ;
+   samm:preferredName "Unit of measurement"@en ;
+   samm:description "Mandatory: Unit of analysis of a product in context of the PCF (product carbon footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example list of valid units includes \"piece\"."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :DeclaredUnitCharacteristic ;
+   samm:exampleValue "kilogram" .
+
+:unitaryProductAmount a samm:Property ;
+   samm:preferredName "Unitary Product Amount"@en ;
+   samm:description "Mandatory: Amount of units contained within a product in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :StrictlyPositiveDecimalTrait ;
+   samm:exampleValue "1000.0"^^xsd:float .
+
+:productMassPerDeclaredUnit a samm:Property ;
+   samm:preferredName "Product Mass Per Declared Unit"@en ;
+   samm:description "Mandatory: Mass of a product per declared unit (net, unpackaged) in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook."@en ;
+   samm:characteristic :PositiveDecimalWeightTrait ;
+   samm:exampleValue "0.456"^^xsd:decimal .
+
+:exemptedEmissionsPercent a samm:Property ;
+   samm:preferredName "Exempted Emissions Percent"@en ;
+   samm:description "Mandatory: Applied cut-off percentage of emissions excluded from PCF (Product Carbon Footprint).\nFor accordance with Catena-X PCF Rulebook V3.0 <3%."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :ExemptedEmissionsPercentTrait ;
+   samm:exampleValue "0.0"^^xsd:decimal .
+
+:exemptedEmissionsDescription a samm:Property ;
+   samm:preferredName "Exempted Emissions Description"@en ;
+   samm:description "Optional: Rationale behind exclusion of specific PCF (Product Carbon Footprint) emissions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "No exemption" .
+
+:boundaryProcessesDescription a samm:Property ;
+   samm:preferredName "Boundary Processes Description"@en ;
+   samm:description "Optional: Processes attributable to each lifecycle stage as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Electricity consumption included as an input in the production phase" .
+
+:geographyCountrySubdivision a samm:Property ;
+   samm:preferredName "Geography Country Subdivision"@en ;
+   samm:description "Optional: Subdivision of a country which must be an ISO 3166-2 subdivision code as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :GeographyCountrySubdivisionTrait ;
+   samm:exampleValue "US-NY" .
+
+:geographyCountry a samm:Property ;
+   samm:preferredName "Geography Country"@en ;
+   samm:description "Optional: Two letter country code that must conform to data type ISO 3166CC as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :GeographyCountryTrait ;
+   samm:exampleValue "DE" .
+
+:geographyRegionOrSubregion a samm:Property ;
+   samm:preferredName "Region"@en ;
+   samm:description "Mandatory: Region according to list as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :GeographyRegionOrSubregionCharacteristic ;
+   samm:exampleValue "Europe" .
+
+:referencePeriodStart a samm:Property ;
+   samm:preferredName "Reference Period Start"@en ;
+   samm:description "Mandatory: Start of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2022-01-01T00:00:01Z"^^xsd:dateTime .
+
+:referencePeriodEnd a samm:Property ;
+   samm:preferredName "Reference Period End"@en ;
+   samm:description "Mandatory: End of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2022-12-31T23:59:59Z"^^xsd:dateTime .
+
+:crossSectoralStandardsUsed a samm:Property ;
+   samm:preferredName "Cross Sectoral Standards Used"@en ;
+   samm:description "Mandatory: Discloses the cross-sectoral standards applied for calculating or allocating GHG (Greenhouse Gas) emissions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :CrossSectoralStandardSet .
+
+:productOrSectorSpecificRules a samm:Property ;
+   samm:preferredName "Product or Sector Specific Rules"@en ;
+   samm:description "Mandatory: Product or sector specific rules applied for calculating or allocating GHG (Greenhouse Gas) emissions, e.g. PCRs (Product Category Rules), including operators or publishers and according rule names as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :ProductOrSectorSpecificRuleSet .
+
+:characterizationFactors a samm:Property ;
+   samm:preferredName "Characterization Factors"@en ;
+   samm:description "Mandatory: IPCC (Intergovernmental Panel on Climate Change) version of the GWP (Global Warming Potential) characterization factors used for calculating the PCF (Product Carbon Footprint) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by default with value \\\"AR6\\\". Default value can be overwritten."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :CharacterizationFactorsCharacteristic ;
+   samm:exampleValue "AR6" .
+
+:allocationRulesDescription a samm:Property ;
+   samm:preferredName "Allocation Rules Description"@en ;
+   samm:description "Optional: Allocation rules used and underlying reasoning in context of a product carbon footprint as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by default with value \"In accordance with Catena-X PCF Rulebook\"."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "In accordance with Catena-X PCF Rulebook" .
+
+:allocationWasteIncineration a samm:Property ;
+   samm:preferredName "Allocation Waste Incineration"@en ;
+   samm:description "Mandatory: Allocation approach used for waste incineration with energy recovery as specified by the TFS (Together For Sustainability) initiative."@en ;
+   samm:characteristic :AllocationWasteIncinerationCharacteristic ;
+   samm:exampleValue "cut-off" .
+
+:primaryDataShare a samm:Property ;
+   samm:preferredName "Primary Data Share"@en ;
+   samm:description "Mandatory starting 2025: Share of primary data in percent as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :PercentTrait ;
+   samm:exampleValue "56.12"^^xsd:decimal .
+
+:secondaryEmissionFactorSources a samm:Property ;
+   samm:preferredName "Secondary Emission Factor Sources"@en ;
+   samm:description "Mandatory: Emission factors used for the PCF (Product Carbon Footprint) calculation as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :EmissionFactorDSSet .
+
+:dqi a samm:Property ;
+   samm:preferredName "DQI (Data Quality Indicators)"@en ;
+   samm:description "Mandatory starting 2025: Quantitative data quality indicators of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :DataQualityIndicators .
+
+:packagingEmissionsIncluded a samm:Property ;
+   samm:preferredName "Packaging Emissions Included"@en ;
+   samm:description "Mandatory: C-X PCF Rulebook requires to include packaging from a system boundary perspective. \"FALSE\" is only possible due to the application of the cut-off rule.\nFlag indicating whether packaging emissions are included in a PCF (Product Carbon Footprint) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Boolean .
+
+:pcfExcludingBiogenic a samm:Property ;
+   samm:preferredName "PCF (Product Carbon Footprint) Excluding Biogenic"@en ;
+   samm:description "Mandatory: Product carbon footprint of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "2.0"^^xsd:decimal .
+
+:pcfIncludingBiogenic a samm:Property ;
+   samm:preferredName "PCF (Product Carbon Footprint) Including Biogenic"@en ;
+   samm:description "Mandatory starting 2025: Product carbon footprint of a product including biogenic emissions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Optional value in current specification version but will be mandatory in future version."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :PositiveOrNegativeEmission ;
+   samm:exampleValue "1.0"^^xsd:decimal .
+
+:fossilGhgEmissions a samm:Property ;
+   samm:preferredName "Fossil Emissions"@en ;
+   samm:description "Mandatory starting 2025: Emissions from combustion of fossil sources as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Identical to \"pcfExcludingBiogenic\", will be removed in later version."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "0.5"^^xsd:decimal .
+
+:biogenicCarbonEmissionsOtherThanCO2 a samm:Property ;
+   samm:preferredName "Biogenic Carbon Emissions Other Than CO2"@en ;
+   samm:description "Mandatory starting 2025: GWP (Global Warming Potential) of biogenic CO2e-emissions in production phase which contain only GHG (Greenhouse Gas) emissions other than CO2 - excludes biogenic CO2. For specification see Catena-X PCF Rulebook."@en ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "1.0"^^xsd:decimal .
+
+:biogenicCarbonWithdrawal a samm:Property ;
+   samm:preferredName "Biogenic Carbon Withdrawal"@en ;
+   samm:description "Mandatory starting 2025: Biogenic carbon content in the product converted to CO2e as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20231207/> ;
+   samm:characteristic :NegativeEmissionsTrait ;
+   samm:exampleValue "0.0"^^xsd:decimal .
+
+:dlucGhgEmissions a samm:Property ;
+   samm:preferredName "dLUC (direct land use change) GHG (Greenhouse Gas) Emissions"@en ;
+   samm:description "Mandatory starting 2025: Direct land use change CO2e emissions in context of a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "0.4"^^xsd:decimal .
+
+:luGhgEmissions a samm:Property ;
+   samm:preferredName "LU (Land Use) GHG (Greenhouse Gas) Emissions"@en ;
+   samm:description "Mandatory starting 2025: Land use CO2 emissions in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension."@en ;
+   samm:characteristic :PositiveOrNegativeEmission ;
+   samm:exampleValue "0.3"^^xsd:decimal .
+
+:aircraftGhgEmissions a samm:Property ;
+   samm:preferredName "Aircraft GHG Emissions"@en ;
+   samm:description "Mandatory starting 2025: GHG (Greenhouse Gas) emissions resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "0.0"^^xsd:decimal .
+
+:packagingGhgEmissions a samm:Property ;
+   samm:preferredName "Packaging GHG (Greenhouse Gas) Emissions"@en ;
+   samm:description "Optional: Emissions resulting from the packaging of the product as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "0"^^xsd:decimal .
+
+:distributionStagePcfExcludingBiogenic a samm:Property ;
+   samm:preferredName "Distribution Stage PCF (Product Carbon Footprint) Excluding Biogenic"@en ;
+   samm:description "Optional: Product carbon footprint for the distribution stage of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook."@en ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "1.5"^^xsd:decimal .
+
+:distributionStagePcfIncludingBiogenic a samm:Property ;
+   samm:preferredName "Distribution Stage PCF (Product Carbon Footprint) Including Biogenic"@en ;
+   samm:description "Optional: Product carbon footprint for the distribution stage of a product including biogenic emissions as specified in the Catena-X PCF Rulebook."@en ;
+   samm:characteristic :PositiveOrNegativeEmission ;
+   samm:exampleValue "0.0"^^xsd:decimal .
+
+:distributionStageFossilGhgEmissions a samm:Property ;
+   samm:preferredName "Distribution Stage Fossil GHG (Greenhouse Gas) Emissions"@en ;
+   samm:description "Optional: Emissions from the combustion of fossil sources in the distribution stage as specified in the Catena-X PCF Rulebook."@en ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "0.5"^^xsd:decimal .
+
+:distributionStageBiogenicCarbonEmissionsOtherThanCO2 a samm:Property ;
+   samm:preferredName "Distribution Stage Biogenic Carbon Emissions Other Than CO2"@en ;
+   samm:description "Optional: GWP (Global Warming Potential) of biogenic CO2e-emissions in distribution phase which contain only GHG (Greenhouse Gas) emissions other than CO2 ? excludes biogenic CO2. For specification see Catena-X PCF Rulebook."@en ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "1.0"^^xsd:decimal .
+
+:distributionStageBiogenicCarbonWithdrawal a samm:Property ;
+   samm:preferredName "Distribution Stage Biogenic Carbon Withdrawal"@en ;
+   samm:description "Optional: GWP (Global Warming Potential) of biogenic CO2-withdrawal in distribution stage (biogenic CO2 contained in the product) as specified in the Catena-X PCF Rulebook."@en ;
+   samm:characteristic :NegativeEmissionsTrait ;
+   samm:exampleValue "0.0"^^xsd:decimal .
+
+:distributionStageDlucGhgEmissions a samm:Property ;
+   samm:preferredName "Distribution Stage dLUC (direct land use change) GHG (Greenhouse Gas) Emissions"@en ;
+   samm:description "Optional: Direct land use change CO2 emissions during distribution stage in context of a product carbon footprint as specified in the Catena-X PCF Rulebook. TFS specific extension."@en ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "1.0"^^xsd:decimal .
+
+:distributionStageLuGhgEmissions a samm:Property ;
+   samm:preferredName "Distribution Stage LU (Land Use) GHG (Greenhouse Gas) Emissions"@en ;
+   samm:description "Optional: Land use CO2 emissions in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension."@en ;
+   samm:characteristic :PositiveOrNegativeEmission ;
+   samm:exampleValue "1.1"^^xsd:decimal .
+
+:carbonContentTotal a samm:Property ;
+   samm:preferredName "Carbon Content Total"@en ;
+   samm:description "Mandatory starting 2025: Total carbon content per declared unit in context of a product carbon footprint as specified in the Catena-X PCF Rulebook."@en ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "2.5"^^xsd:decimal .
+
+:fossilCarbonContent a samm:Property ;
+   samm:preferredName "Fossil Carbon Content"@en ;
+   samm:description "Mandatory starting 2025: Fossil carbon amount embodied in a product as specified in the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Must be calculated with kgC (kilogram Carbon) / declaredUnit equal to or greater zero; WBCSD specific extension, in Catena-X specified by a calculated value."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20231207/> ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "0.1"^^xsd:decimal .
+
+:biogenicCarbonContent a samm:Property ;
+   samm:preferredName "Biogenic Carbon Content"@en ;
+   samm:description "Mandatory starting 2025: Biogenic carbon amount embodied in a product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Must be calculated with kgC (kilogram Carbon) / declaredUnit equal to or greater zero."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20231207/> ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "0.0"^^xsd:decimal .
+
+:distributionStageAircraftGhgEmissions a samm:Property ;
+   samm:preferredName "Distribution Stage Aircraft GHG Emissions"@en ;
+   samm:description "Optional: GHG (Greenhouse Gas) emissions for the distribution stage resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :PositiveEmissionsTrait ;
+   samm:exampleValue "0.0"^^xsd:decimal .
+
+:DeclaredUnitCharacteristic a samm-c:Enumeration ;
+   samm:preferredName "Declared Unit Characteristic"@en ;
+   samm:description "Unit of analysis of the product with accepted values as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. For countable products/ components/ materials, Catena-X for example adds the unit \"piece\" to the value list specified by WBCSD."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "liter" "kilogram" "cubic meter" "kilowatt hour" "megajoule" "ton kilometer" "square meter" "piece" ) .
+
+:StrictlyPositiveDecimalTrait a samm-c:Trait ;
+   samm:preferredName "Strictly Positive Decimal Trait"@en ;
+   samm:description "Trait for defining a positive, non-zero decimal."@en ;
+   samm-c:baseCharacteristic :StrictlyPositiveDecimal ;
+   samm-c:constraint :StrictlyPositiveDecimalConstraint .
+
+:PositiveDecimalWeightTrait a samm-c:Trait ;
+   samm:preferredName "Positive Decimal Weight Trait"@en ;
+   samm:description "Trait for defining a decimal weight value declared in kg equal to or greater than zero."@en ;
+   samm-c:baseCharacteristic :PositiveDecimalWeight ;
+   samm-c:constraint :PositiveDecimalConstraint .
+
+:ExemptedEmissionsPercentTrait a samm-c:Trait ;
+   samm:preferredName "Exempted Emissions Percent Trait"@en ;
+   samm:description "Trait for defining a percentage value for exempted emissions in context of a product carbon footprint."@en ;
+   samm-c:baseCharacteristic :ExemptedEmissionsPercentCharacteristic ;
+   samm-c:constraint :ExemptedEmissionsPercentConstraint .
+
+:GeographyCountrySubdivisionTrait a samm-c:Trait ;
+   samm:preferredName "Geography Country Subdivision Trait"@en ;
+   samm:description "Trait for defining a country subdivision in context of a product carbon footprint."@en ;
+   samm-c:baseCharacteristic samm-c:Text ;
+   samm-c:constraint :GeographyCountrySubdivisionConstraint .
+
+:GeographyCountryTrait a samm-c:Trait ;
+   samm:preferredName "Geography Country Trait"@en ;
+   samm:description "Trait for defining a geography country in context of a product carbon footprint."@en ;
+   samm-c:baseCharacteristic samm-c:Text ;
+   samm-c:constraint :GeographyCountryConstraint .
+
+:GeographyRegionOrSubregionCharacteristic a samm-c:Enumeration ;
+   samm:preferredName "Geography Region Or Subregion Characteristic"@en ;
+   samm:description "Characteristic for defining a list of valid geographic regions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example \"Global\" has been added to the value list."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Africa" "Americas" "Asia" "Europe" "Oceania" "Australia and New Zealand" "Central Asia" "Eastern Asia" "Eastern Europe" "Latin America and the Caribbean" "Melanesia" "Micronesia" "Northern Africa" "Northern America" "Northern Europe" "Polynesia" "South-eastern Asia" "Southern Asia" "Southern Europe" "Sub-Saharan Africa" "Western Asia" "Western Europe" "Global" "Several" ) .
+
+:CrossSectoralStandardSet a samm-c:List ;
+   samm:preferredName "Cross Sectoral Standards Used Characteristic"@en ;
+   samm:description "Characteristic for defining the list of valid accounting standards used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType :CrossSectoralStandard .
+
+:ProductOrSectorSpecificRuleSet a samm-c:Set ;
+   samm:preferredName "Product Or Sector Specific Rules Set"@en ;
+   samm:description "Characteristic for defining the set of product or sector specific rules of a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType :ProductOrSectorSpecificRule .
+
+:CharacterizationFactorsCharacteristic a samm-c:Enumeration ;
+   samm:preferredName "Characterization Factors Characteristic"@en ;
+   samm:description "Characteristic for defining the characterization factors of a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example specified by a default value."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "AR5" "AR6" ) .
+
+:AllocationWasteIncinerationCharacteristic a samm-c:Enumeration ;
+   samm:preferredName "Allocation Waste Incineration Characteristic"@en ;
+   samm:description "Characteristic for defining the allocation approach used for waste incineration as specified by the TFS (Together For Sustainability) initiative."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "cut-off" "reverse cut-off" "system expansion" ) .
+
+:PercentTrait a samm-c:Trait ;
+   samm:preferredName "Percent Trait"@en ;
+   samm:description "Trait for a decimal number in the range of and including 0 and 100."@en ;
+   samm-c:baseCharacteristic :Percent ;
+   samm-c:constraint :PercentConstraint .
+
+:EmissionFactorDSSet a samm-c:Set ;
+   samm:preferredName "Emission Factor Data Sources Set Characteristic"@en ;
+   samm:description "Characteristic for defining a set of emission factor sources used for calculating a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType :EmissionFactorDS .
+
+:DataQualityIndicators a samm:Characteristic ;
+   samm:preferredName "Data Quality Indicators"@en ;
+   samm:description "Characteristic for defining the quantitative data quality indicators of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType :DataQualityIndicator .
+
+:PositiveEmissionsTrait a samm-c:Trait ;
+   samm:preferredName "Positive Emissions Trait"@en ;
+   samm:description "Trait for emissions equal to or greater than zero in context of a PCF (Product Carbon Footprint)."@en ;
+   samm-c:baseCharacteristic :PositiveEmission ;
+   samm-c:constraint :PositiveEmissionConstraint .
+
+:PositiveOrNegativeEmission a samm-c:Quantifiable ;
+   samm:preferredName "Positive Or Negative Emission"@en ;
+   samm:description "Characteristic for defining (positive or negative) emissions in context of a PCF (Product Carbon Footprint) as specified by the WBCSD (World Business Council for Sustainable Development) Pathfinder initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType xsd:decimal .
+
+:NegativeEmissionsTrait a samm-c:Trait ;
+   samm:preferredName "Negative Emissions Trait"@en ;
+   samm:description "Trait for emissions equal to or less than zero in context of a PCF (Product Carbon Footprint)."@en ;
+   samm-c:baseCharacteristic :NegativeEmission ;
+   samm-c:constraint :NegativeEmissionConstraint .
+
+:StrictlyPositiveDecimal a samm:Characteristic ;
+   samm:preferredName "Strictly Positive Decimal"@en ;
+   samm:description "A positive, non-zero decimal."@en ;
+   samm:dataType xsd:float .
+
+:StrictlyPositiveDecimalConstraint a samm-c:RangeConstraint ;
+   samm:preferredName "Strictly Positive Decimal Constraint"@en ;
+   samm:description "Constraint for defining a positive, non-zero decimal."@en ;
+   samm-c:minValue "0.0"^^xsd:float ;
+   samm-c:lowerBoundDefinition samm-c:GREATER_THAN ;
+   samm-c:upperBoundDefinition samm-c:LESS_THAN .
+
+:PositiveDecimalWeight a samm-c:Quantifiable ;
+   samm:preferredName "Positive Decimal Weight"@en ;
+   samm:description "Characteristic for defining a decimal weight value declared in unit kilogram equal to or greater than zero."@en ;
+   samm:dataType xsd:decimal ;
+   samm-c:unit unit:kilogram .
+
+:PositiveDecimalConstraint a samm-c:RangeConstraint ;
+   samm:preferredName "Positive Decimal Constraint"@en ;
+   samm:description "Constraint for defining a decimal equal to or greater than zero."@en ;
+   samm-c:minValue "0"^^xsd:decimal ;
+   samm-c:lowerBoundDefinition samm-c:AT_LEAST ;
+   samm-c:upperBoundDefinition samm-c:LESS_THAN .
+
+:ExemptedEmissionsPercentCharacteristic a samm-c:Quantifiable ;
+   samm:preferredName "Exempted Emissions Percent Characteristic"@en ;
+   samm:description "Characteristic for defining the percentage of emissions excluded from a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType xsd:decimal .
+
+:ExemptedEmissionsPercentConstraint a samm-c:RangeConstraint ;
+   samm:preferredName "Exempted Emissions Percent Constraint"@en ;
+   samm:description "Characteristic for defining the percentage of emissions excluded from a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm-c:minValue "0.0"^^xsd:decimal ;
+   samm-c:maxValue "5.0"^^xsd:decimal ;
+   samm-c:lowerBoundDefinition samm-c:AT_LEAST ;
+   samm-c:upperBoundDefinition samm-c:AT_MOST .
+
+:GeographyCountrySubdivisionConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Subdivision Constraint"@en ;
+   samm:description "Constraint for defining a geography country subdivision in compliance to ISO 3166-2 as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:value "([A-Z]{2}-[A-Z0-9]{1,3}|)" .
+
+:GeographyCountryConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Country Constraint"@en ;
+   samm:description "Constraint for defining a geography country conform to ISO 3166CC as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:value "([A-Z]{2})" .
+
+:CrossSectoralStandard a samm:Entity ;
+   samm:preferredName "Cross Sectoral Standard Entity"@en ;
+   samm:description "Entity for defining an accounting standard used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:properties ( [ samm:property :crossSectoralStandard; samm:payloadName "crossSectoralStandard" ] ) .
+
+:ProductOrSectorSpecificRule a samm:Entity ;
+   samm:preferredName "Product Or Sector Specific Rule"@en ;
+   samm:description "Entity for defining a product or sector specific rule of a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:properties ( [ samm:property :operator; samm:payloadName "extWBCSD_operator" ] [ samm:property :ruleNames; samm:payloadName "productOrSectorSpecificRules" ] [ samm:property :otherOperatorName; samm:optional true; samm:payloadName "extWBCSD_otherOperatorName" ] ) .
+
+:Percent a samm-c:Quantifiable ;
+   samm:preferredName "Percent"@en ;
+   samm:description "Decimal number in the range of and including 0 and 100."@en ;
+   samm:dataType xsd:decimal ;
+   samm-c:unit unit:percent .
+
+:PercentConstraint a samm-c:RangeConstraint ;
+   samm:preferredName "Percent Constraint"@en ;
+   samm:description "Constraint for a decimal number in the range of and including 0 and 100."@en ;
+   samm-c:minValue "0.0"^^xsd:decimal ;
+   samm-c:maxValue "100.0"^^xsd:decimal ;
+   samm-c:lowerBoundDefinition samm-c:AT_LEAST ;
+   samm-c:upperBoundDefinition samm-c:AT_MOST .
+
+:EmissionFactorDS a samm:Entity ;
+   samm:preferredName "Emission Factor Data Source Entity"@en ;
+   samm:description "Entity for defining an emission factor data source used to calculate a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:properties ( [ samm:property :emissionFactorDS; samm:payloadName "secondaryEmissionFactorSource" ] ) .
+
+:DataQualityIndicator a samm:Entity ;
+   samm:preferredName "Data Quality Indicator"@en ;
+   samm:description "Entity for defining a quantitative data quality indicator of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:properties ( [ samm:property :coveragePercent; samm:optional true; samm:payloadName "coveragePercent" ] [ samm:property :technologicalDQR; samm:optional true; samm:payloadName "technologicalDQR" ] [ samm:property :temporalDQR; samm:optional true; samm:payloadName "temporalDQR" ] [ samm:property :geographicalDQR; samm:optional true; samm:payloadName "geographicalDQR" ] [ samm:property :completenessDQR; samm:optional true; samm:payloadName "completenessDQR" ] [ samm:property :reliabilityDQR; samm:optional true; samm:payloadName "reliabilityDQR" ] ) .
+
+:PositiveEmission a samm-c:Quantifiable ;
+   samm:preferredName "Positive Emission"@en ;
+   samm:description "Characteristic for defining emissions expressed as a decimal equal to or greater than zero in context of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType xsd:decimal .
+
+:PositiveEmissionConstraint a samm-c:RangeConstraint ;
+   samm:preferredName "PositiveEmissionConstraint"@en ;
+   samm:description "Only positive emission values (>0) are valid "@en ;
+   samm-c:minValue "0.0"^^xsd:decimal ;
+   samm-c:lowerBoundDefinition samm-c:AT_LEAST ;
+   samm-c:upperBoundDefinition samm-c:LESS_THAN .
+
+:NegativeEmission a samm-c:Quantifiable ;
+   samm:preferredName "Negative Emission"@en ;
+   samm:description "Characteristic for defining emissions expressed as a decimal equal to or less than zero in context of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:dataType xsd:decimal .
+
+:NegativeEmissionConstraint a samm-c:RangeConstraint ;
+   samm:preferredName "Negative Emission Constraint"@en ;
+   samm:description "Only negative emission values (<=0) are valid."@en ;
+   samm-c:maxValue "0.0"^^xsd:decimal ;
+   samm-c:lowerBoundDefinition samm-c:GREATER_THAN ;
+   samm-c:upperBoundDefinition samm-c:AT_MOST .
+
+:crossSectoralStandard a samm:Property ;
+   samm:preferredName "Cross Sectoral Standard"@en ;
+   samm:description "Mandatory: Discloses a cross-sectoral standard applied for calculating or allocating GHG (Greenhouse Gas) emissions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :CrossSectoralStandardsUsedEnumerationCharacteristic ;
+   samm:exampleValue "ISO Standard 14044" .
+
+:operator a samm:Property ;
+   samm:preferredName "Operator or Publisher of Sector Specific Rules"@en ;
+   samm:description "Mandatory: Operator of PCR (Product Category Rule)/ PSR (Product Specific Rule) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example must always be \"Other\"."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :ProductOrSectorSpecificRuleOperator ;
+   samm:exampleValue "Other" .
+
+:ruleNames a samm:Property ;
+   samm:preferredName "Product or Sector Specific Rule Names"@en ;
+   samm:description "Mandatory: Product-specific or sector-specific set of rules used for calculating or allocating GHG (Greenhouse Gas) emissions applied from the specified operator as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :RuleNamesTrait .
+
+:otherOperatorName a samm:Property ;
+   samm:preferredName "Other Operator Name"@en ;
+   samm:description "Optional: Other operator of PCR (Product Category Rule)/ PSR (Product Specific Rule) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by a default value."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :NonEmptyStringTrait ;
+   samm:exampleValue "NSF" .
+
+:emissionFactorDS a samm:Property ;
+   samm:preferredName "Emission Factor Data Source"@en ;
+   samm:description "Mandatory: Emission factor data source used to calculate a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "ecoinvent 3.8" .
+
+:coveragePercent a samm:Property ;
+   samm:preferredName "Coverage Percent"@en ;
+   samm:description "Mandatory starting 2025: Percentage of PCF (Product Carbon Footprint) included in the data quality assessment based on the >5% emissions threshold as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to \"100\" per default."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :PercentTrait ;
+   samm:exampleValue "100"^^xsd:decimal .
+
+:technologicalDQR a samm:Property ;
+   samm:preferredName "Technological DQR (Data Quality Rating)"@en ;
+   samm:description "Optional: Technological representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :DqiNumberTrait ;
+   samm:exampleValue "2.0"^^xsd:decimal .
+
+:temporalDQR a samm:Property ;
+   samm:preferredName "Temporal DQR (Data Quality Rating)"@en ;
+   samm:description "Optional: Temporal representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :DqiNumberTrait ;
+   samm:exampleValue "2.0"^^xsd:decimal .
+
+:geographicalDQR a samm:Property ;
+   samm:preferredName "Geographical DQR (Data Quality Rating)"@en ;
+   samm:description "Optional: Geographical representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :DqiNumberTrait ;
+   samm:exampleValue "2.0"^^xsd:decimal .
+
+:completenessDQR a samm:Property ;
+   samm:preferredName "Completeness DQR (Data Quality Rating)"@en ;
+   samm:description "Optional: Completeness of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :DqiNumberTrait ;
+   samm:exampleValue "2.0"^^xsd:decimal .
+
+:reliabilityDQR a samm:Property ;
+   samm:preferredName "Reliability DQR (Data Quality Rating)"@en ;
+   samm:description "Optional: Reliability of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :DqiNumberTrait ;
+   samm:exampleValue "2.0"^^xsd:decimal .
+
+:CrossSectoralStandardsUsedEnumerationCharacteristic a samm-c:Enumeration ;
+   samm:preferredName "Cross Sectoral Standards Used Enumeration Characteristic"@en ;
+   samm:description "Characteristic for defining the enumeration of valid accounting standards used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "GHG Protocol Product standard" "ISO Standard 14067" "ISO Standard 14044" ) .
+
+:ProductOrSectorSpecificRuleOperator a samm-c:Enumeration ;
+   samm:preferredName "Product Or Sector Specific Rule Operator"@en ;
+   samm:description "Enumeration of PCR (Product Category Rule) operators as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension for example in Catena-X."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "PEF" "EPD International" "Other" ) .
+
+:RuleNamesTrait a samm-c:Trait ;
+   samm:preferredName "Rule Names Trait"@en ;
+   samm:description "Trait for defining a non-empty set of rule names as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm-c:baseCharacteristic :RuleNamesCharacteristic ;
+   samm-c:constraint :RuleNamesConstraint .
+
+:DqiNumberTrait a samm-c:Trait ;
+   samm:preferredName "DQI (Data Quality Indicator) Number Trait"@en ;
+   samm:description "Trait for defining a decimal between 1 and 3 including."@en ;
+   samm-c:baseCharacteristic :DqiNumber ;
+   samm-c:constraint :DqiNumberConstraint .
+
+:RuleNamesCharacteristic a samm-c:Set ;
+   samm:preferredName "Rule Names Characteristic"@en ;
+   samm:description "Non-empty set of rules applied by the specified operator. Defined by the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:dataType :RuleName .
+
+:RuleNamesConstraint a samm-c:LengthConstraint ;
+   samm:preferredName "Rule Names Constraint"@en ;
+   samm:description "Constraint for defining a non-empty set of rule names as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm-c:minValue "1"^^xsd:nonNegativeInteger .
+
+:DqiNumber a samm:Characteristic ;
+   samm:preferredName "DQI (Data Quality Indicator) Number"@en ;
+   samm:description "Decimal between 1 and 3 including"@en ;
+   samm:dataType xsd:decimal .
+
+:DqiNumberConstraint a samm-c:RangeConstraint ;
+   samm:preferredName "DQI (Data Quality Indicator) Number Constraint"@en ;
+   samm:description "Constraint for defining a decimal between 1 and 3 including."@en ;
+   samm-c:minValue "1"^^xsd:decimal ;
+   samm-c:maxValue "3"^^xsd:decimal ;
+   samm-c:lowerBoundDefinition samm-c:AT_LEAST ;
+   samm-c:upperBoundDefinition samm-c:AT_MOST .
+
+:RuleName a samm:Entity ;
+   samm:preferredName "Rule Name"@en ;
+   samm:description "Name of a rule applied by a specified operator as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:properties ( :ruleName ) .
+
+:ruleName a samm:Property ;
+   samm:preferredName "Rule Name"@en ;
+   samm:description "Name of a rule applied by a specific operator as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
+   samm:characteristic :NonEmptyStringTrait ;
+   samm:exampleValue "urn:tfs-initiative.com:PCR:The Product Carbon Footprint Guideline for the Chemical Industry:version:v2.0" .
+

--- a/io.catenax.pcf/7.0.0/Pcf.ttl
+++ b/io.catenax.pcf/7.0.0/Pcf.ttl
@@ -116,7 +116,7 @@
    samm:description "Mandatory: Non-empty set of Uniform Resource Names (URN). Each value is supposed to uniquely identify the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. For Catena-X Industry Core compliance the set of URNs must contain at least the Business Partner Number Legal Entity (BPNL) in the specified format urn:bpn:id:BPNL[a-zA-Z0-9]{12}. "@en ;
    samm:see <urn:samm:io.catenax.shared.business_partner_number:2.0.0#bpnlProperty> ;
    samm:characteristic :IdsTrait ;
-   samm:exampleValue "urn:bpn:BPNL000000000DWF"^^xsd:anyURI .
+   samm:exampleValue "urn:bpn:id:BPNL000000000DW"^^xsd:anyURI .
 
 :productDescription a samm:Property ;
    samm:preferredName "Product Description"@en ;
@@ -331,7 +331,7 @@
 
 :allocationWasteIncineration a samm:Property ;
    samm:preferredName "Allocation Waste Incineration"@en ;
-   samm:description "Mandatory: Allocation approach used for waste incineration with energy recovery as specified by the TFS (Together For Sustainability) initiative."@en ;
+   samm:description "Mandatory: Allocation approach used for waste incineration with energy recovery as specified by the TFS (Together For Sustainability) initiative. In Catena-X for example must be specified by value \"cut-off\"."@en ;
    samm:characteristic :AllocationWasteIncinerationCharacteristic ;
    samm:exampleValue "cut-off" .
 
@@ -415,7 +415,7 @@
 
 :packagingGhgEmissions a samm:Property ;
    samm:preferredName "Packaging GHG (Greenhouse Gas) Emissions"@en ;
-   samm:description "Optional: Emissions resulting from the packaging of the product as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension."@en ;
+   samm:description "Optional: Emissions resulting from the packaging of the product as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension. In Catena-X not relevant to be reported separately."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "0"^^xsd:decimal .

--- a/io.catenax.pcf/7.0.0/Pcf.ttl
+++ b/io.catenax.pcf/7.0.0/Pcf.ttl
@@ -30,7 +30,7 @@
 
 :Pcf a samm:Aspect ;
    samm:preferredName "Product (Carbon) Footprint"@en ;
-   samm:description "A Product (Carbon) Footprint represents the carbon footprint of a product with values as specified in the Catena-X PCF Rulebook in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative."@en ;
+   samm:description "A Product (Carbon) Footprint represents the carbon footprint of a product with values as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:properties ( [ samm:property :id; samm:payloadName "id" ] [ samm:property :specVersion; samm:payloadName "specVersion" ] [ samm:property :partialFullPcf; samm:payloadName "partialFullPcf" ] [ samm:property :precedingPfIds; samm:optional true; samm:payloadName "precedingPfIds" ] [ samm:property :version; samm:payloadName "version" ] [ samm:property :created; samm:payloadName "created" ] [ samm:property :status; samm:payloadName "extWBCSD_pfStatus" ] [ samm:property :validityPeriodStart; samm:optional true; samm:payloadName "validityPeriodStart" ] [ samm:property :validityPeriodEnd; samm:optional true; samm:payloadName "validityPeriodEnd" ] [ samm:property :comment; samm:optional true; samm:payloadName "comment" ] [ samm:property :companyName; samm:payloadName "companyName" ] [ samm:property :companyIds; samm:payloadName "companyIds" ] [ samm:property :productDescription; samm:optional true; samm:payloadName "productDescription" ] [ samm:property :productIds; samm:payloadName "productIds" ] [ samm:property :productCategoryCpc; samm:payloadName "extWBCSD_productCodeCpc" ] [ samm:property :productNameCompany; samm:payloadName "productName" ] [ samm:property :pcf; samm:payloadName "pcf" ] [ samm:property :pcfLegalStatement; samm:optional true; samm:payloadName "pcfLegalStatement" ] ) ;
    samm:operations ( ) ;
@@ -38,40 +38,40 @@
 
 :id a samm:Property ;
    samm:preferredName "Product Footprint Identifier"@en ;
-   samm:description "Mandatory: The product footprint identifier as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: The product footprint identifier as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic ext-uuid:UuidV4Trait ;
    samm:exampleValue "3893bb5d-da16-4dc1-9185-11d97476c254" .
 
 :specVersion a samm:Property ;
    samm:preferredName "Product Footprint Specification Version"@en ;
-   samm:description "Mandatory: Version of the product footprint data specification as defined in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Version of the product footprint data specification as defined in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "urn:io.catenax.pcf:datamodel:version:7.0.0" .
 
 :partialFullPcf a samm:Property ;
    samm:preferredName "Partial Or Full PCF (Product Carbon Footprint)"@en ;
-   samm:description "Mandatory: Indicator for partial or full PCF (Product Carbon Footprint) declaration as specified in the Catena-X PCF Rulebook."@en ;
+   samm:description "Mandatory: Indicator for partial or full PCF (Product Carbon Footprint) declaration as specified in the Catena-X PCF Rulebook (Version 3.0.0)."@en ;
    samm:characteristic :PartialFullPcfCharacteristic ;
    samm:exampleValue "Cradle-to-gate" .
 
 :precedingPfIds a samm:Property ;
    samm:preferredName "Previous PCF (Product Carbon Footprint) Identifiers"@en ;
-   samm:description "Optional: Set of preceding PCF (Product Carbon Footprint) identifiers without duplicates as specified in the Catena-X PCF Rulebook in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative. Declared as \"optional\" in WBCSD, needs to be covered by application."@en ;
+   samm:description "Optional: Set of preceding PCF (Product Carbon Footprint) identifiers without duplicates as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative. Declared as \"optional\" in WBCSD, needs to be covered by application."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :PrecedingPfIdsCharacteristic .
 
 :version a samm:Property ;
    samm:preferredName "Product (Carbon) Footprint Version"@en ;
-   samm:description "Mandatory: Version of the product (carbon) footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to \"0\" per default."@en ;
+   samm:description "Mandatory: Version of the product (carbon) footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to \"0\" per default."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :ProductFootprintVersion ;
    samm:exampleValue "0"^^xsd:nonNegativeInteger .
 
 :created a samm:Property ;
    samm:preferredName "Creation of the Product (Carbon) Footprint"@en ;
-   samm:description "Mandatory: Timestamp of the creation of the Product (Carbon) Footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Timestamp of the creation of the Product (Carbon) Footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Timestamp ;
    samm:exampleValue "2022-05-22T21:47:32Z"^^xsd:dateTime .
@@ -85,49 +85,49 @@
 
 :validityPeriodStart a samm:Property ;
    samm:preferredName "Validity Period Start"@en ;
-   samm:description "Optional: Start of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. If specified, the validity period start must be equal to or greater than the reference period end."@en ;
+   samm:description "Optional: Start of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. If specified, the validity period start must be equal to or greater than the reference period end."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Timestamp ;
    samm:exampleValue "2022-01-01T00:00:01Z"^^xsd:dateTime .
 
 :validityPeriodEnd a samm:Property ;
    samm:preferredName "Validity Period End"@en ;
-   samm:description "Optional: End of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: End of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Timestamp ;
    samm:exampleValue "2022-12-31T23:59:59Z"^^xsd:dateTime .
 
 :comment a samm:Property ;
    samm:preferredName "Comment"@en ;
-   samm:description "Optional: Additional information and instructions related to the calculation of the product (carbon) footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: Additional information and instructions related to the calculation of the product (carbon) footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Additional explanatory information not reflected by other attributes" .
 
 :companyName a samm:Property ;
    samm:preferredName "Company Name"@en ;
-   samm:description "Mandatory: Name of the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Name of the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :NonEmptyStringTrait ;
    samm:exampleValue "My Corp" .
 
 :companyIds a samm:Property ;
    samm:preferredName "Company IDs"@en ;
-   samm:description "Mandatory: Non-empty set of Uniform Resource Names (URN). Each value is supposed to uniquely identify the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. For Catena-X Industry Core compliance the set of URNs must contain at least the Business Partner Number Legal Entity (BPNL) in the specified format urn:bpn:id:BPNL[a-zA-Z0-9]{12}. "@en ;
+   samm:description "Mandatory: Non-empty set of Uniform Resource Names (URN). Each value is supposed to uniquely identify the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. For Catena-X Industry Core compliance the set of URNs must contain at least the Business Partner Number Legal Entity (BPNL) in the specified format urn:bpn:id:BPNL[a-zA-Z0-9]{12}. "@en ;
    samm:see <urn:samm:io.catenax.shared.business_partner_number:2.0.0#bpnlProperty> ;
    samm:characteristic :IdsTrait ;
    samm:exampleValue "urn:bpn:id:BPNL000000000DW"^^xsd:anyURI .
 
 :productDescription a samm:Property ;
    samm:preferredName "Product Description"@en ;
-   samm:description "Optional: Free-form description of the product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: Free-form description of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Ethanol, 95% solution" .
 
 :productIds a samm:Property ;
    samm:preferredName "Product IDs"@en ;
-   samm:description "Mandatory: Non-empty set of product identifiers. Each value is supposed to uniquely identify the product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productId corresponds with Industry Core manufacturerPartId."@en ;
+   samm:description "Mandatory: Non-empty set of product identifiers. Each value is supposed to uniquely identify the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productId corresponds with Industry Core manufacturerPartId."@en ;
    samm:see <urn:samm:io.catenax.part_type_information:1.0.0#manufacturerPartId> ;
    samm:characteristic :IdsTrait ;
    samm:exampleValue "urn:gtin:4712345060507"^^xsd:anyURI .
@@ -141,44 +141,44 @@
 
 :productNameCompany a samm:Property ;
    samm:preferredName "Product Trade Name"@en ;
-   samm:description "Mandatory: Non-empty trade name of a product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productNameCompany corresponds with Industry Core nameAtManufacturer. "@en ;
+   samm:description "Mandatory: Non-empty trade name of a product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productNameCompany corresponds with Industry Core nameAtManufacturer. "@en ;
    samm:see <urn:samm:io.catenax.part_type_information:1.0.0#nameAtManufacturer> ;
    samm:characteristic :NonEmptyStringTrait ;
    samm:exampleValue "My Product Name" .
 
 :pcf a samm:Property ;
    samm:preferredName "PCF (Product Carbon Footprint)"@en ;
-   samm:description "A PCF (Product Carbon Footprint) represents the carbon footprint of a product and related data as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "A PCF (Product Carbon Footprint) represents the carbon footprint of a product and related data as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :CarbonFootprint .
 
 :pcfLegalStatement a samm:Property ;
    samm:preferredName "PCF (Product Carbon Footprint) Legal Statement"@en ;
-   samm:description "Optional: Option for legal statement/ disclaimer as specified in the Catena-X PCF Rulebook."@en ;
+   samm:description "Optional: Option for legal statement/ disclaimer as specified in the Catena-X PCF Rulebook (Version 3.0.0)."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "This PCF (Product Carbon Footprint) is for information purposes only. It is based upon the standards mentioned above." .
 
 :PartialFullPcfCharacteristic a samm-c:Enumeration ;
    samm:preferredName "Partial Or Full PCF (Product Carbon Footprint) Characteristic"@en ;
-   samm:description "Characteristic for defining an indicator for partial or full PCF (Product Carbon Footprint) declaration as specified in the Catena-X PCF Rulebook."@en ;
+   samm:description "Characteristic for defining an indicator for partial or full PCF (Product Carbon Footprint) declaration as specified in the Catena-X PCF Rulebook (Version 3.0.0)."@en ;
    samm:dataType xsd:string ;
    samm-c:values ( "Cradle-to-gate" "Cradle-to-grave" ) .
 
 :PrecedingPfIdsCharacteristic a samm-c:List ;
    samm:preferredName "Previous PCF (Product Carbon Footprint) Identifiers Characteristic"@en ;
-   samm:description "Characteristic for defining a non-empty set of product (carbon) footprint identifiers as specified in the Catena-X PCF Rulebook in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative."@en ;
+   samm:description "Characteristic for defining a non-empty set of product (carbon) footprint identifiers as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType :PrecedingPfId .
 
 :ProductFootprintVersion a samm:Characteristic ;
    samm:preferredName "Product (Carbon) Footprint Version Characteristic"@en ;
-   samm:description "Characteristic for defining a product footprint version as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Characteristic for defining a product footprint version as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType xsd:nonNegativeInteger .
 
 :PfStatusCharacteristic a samm-c:Enumeration ;
    samm:preferredName "PF (Product Footprint) Status Characteristic"@en ;
-   samm:description "Characteristic for defining a status indicator of a product (carbon) footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Enumeration with possible \"Active\" and \"Deprecated\"."@en ;
+   samm:description "Characteristic for defining a status indicator of a product (carbon) footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Enumeration with possible \"Active\" and \"Deprecated\"."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType xsd:string ;
    samm-c:values ( "Active" "Deprecated" ) .
@@ -197,12 +197,12 @@
 
 :CarbonFootprint a samm-c:SingleEntity ;
    samm:preferredName "PCF (Product Carbon Footprint) Characteristic"@en ;
-   samm:description "Characteristic for defining a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Characteristic for defining a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:dataType :PcfEntity .
 
 :PrecedingPfId a samm:Entity ;
    samm:preferredName "Preceding PCF (Product Carbon Footprint) Identifier Entity"@en ;
-   samm:description "Entity for defining a preceding PCF (Product Carbon Footprint) identifier entity as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Entity for defining a preceding PCF (Product Carbon Footprint) identifier entity as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:properties ( :id ) .
 
@@ -223,95 +223,95 @@
 
 :PcfEntity a samm:Entity ;
    samm:preferredName "PCF (Product Carbon Footprint) Entity"@en ;
-   samm:description "Entity for defining a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Entity for defining a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:properties ( [ samm:property :declaredUnit; samm:payloadName "declaredUnit" ] [ samm:property :unitaryProductAmount; samm:payloadName "unitaryProductAmount" ] [ samm:property :productMassPerDeclaredUnit; samm:payloadName "productMassPerDeclaredUnit" ] [ samm:property :exemptedEmissionsPercent; samm:payloadName "exemptedEmissionsPercent" ] [ samm:property :exemptedEmissionsDescription; samm:optional true; samm:payloadName "exemptedEmissionsDescription" ] [ samm:property :boundaryProcessesDescription; samm:optional true; samm:payloadName "boundaryProcessesDescription" ] [ samm:property :geographyCountrySubdivision; samm:optional true; samm:payloadName "geographyCountrySubdivision" ] [ samm:property :geographyCountry; samm:optional true; samm:payloadName "geographyCountry" ] [ samm:property :geographyRegionOrSubregion; samm:payloadName "geographyRegionOrSubregion" ] [ samm:property :referencePeriodStart; samm:payloadName "referencePeriodStart" ] [ samm:property :referencePeriodEnd; samm:payloadName "referencePeriodEnd" ] [ samm:property :crossSectoralStandardsUsed; samm:payloadName "crossSectoralStandardsUsed" ] [ samm:property :productOrSectorSpecificRules; samm:payloadName "productOrSectorSpecificRules" ] [ samm:property :characterizationFactors; samm:payloadName "extWBCSD_characterizationFactors" ] [ samm:property :allocationRulesDescription; samm:optional true; samm:payloadName "extWBCSD_allocationRulesDescription" ] [ samm:property :allocationWasteIncineration; samm:payloadName "extTFS_allocationWasteIncineration" ] [ samm:property :primaryDataShare; samm:optional true; samm:payloadName "primaryDataShare" ] [ samm:property :secondaryEmissionFactorSources; samm:payloadName "secondaryEmissionFactorSources" ] [ samm:property :dqi; samm:optional true; samm:payloadName "dataQualityRating" ] [ samm:property :packagingEmissionsIncluded; samm:payloadName "extWBCSD_packagingEmissionsIncluded" ] [ samm:property :pcfExcludingBiogenic; samm:payloadName "pcfExcludingBiogenic" ] [ samm:property :pcfIncludingBiogenic; samm:optional true; samm:payloadName "pcfIncludingBiogenic" ] [ samm:property :fossilGhgEmissions; samm:optional true; samm:payloadName "fossilGhgEmissions" ] [ samm:property :biogenicCarbonEmissionsOtherThanCO2; samm:optional true; samm:payloadName "biogenicCarbonEmissionsOtherThanCO2" ] [ samm:property :biogenicCarbonWithdrawal; samm:optional true; samm:payloadName "biogenicCarbonWithdrawal" ] [ samm:property :dlucGhgEmissions; samm:optional true; samm:payloadName "dlucGhgEmissions" ] [ samm:property :luGhgEmissions; samm:optional true; samm:payloadName "extTFS_luGhgEmissions" ] [ samm:property :aircraftGhgEmissions; samm:optional true; samm:payloadName "aircraftGhgEmissions" ] [ samm:property :packagingGhgEmissions; samm:optional true; samm:payloadName "extWBCSD_packagingGhgEmissions" ] [ samm:property :distributionStagePcfExcludingBiogenic; samm:optional true; samm:payloadName "distributionStagePcfExcludingBiogenic" ] [ samm:property :distributionStagePcfIncludingBiogenic; samm:optional true; samm:payloadName "distributionStagePcfIncludingBiogenic" ] [ samm:property :distributionStageFossilGhgEmissions; samm:optional true; samm:payloadName "distributionStageFossilGhgEmissions" ] [ samm:property :distributionStageBiogenicCarbonEmissionsOtherThanCO2; samm:optional true; samm:payloadName "distributionStageBiogenicCarbonEmissionsOtherThanCO2" ] [ samm:property :distributionStageBiogenicCarbonWithdrawal; samm:optional true; samm:payloadName "distributionStageBiogenicCarbonWithdrawal" ] [ samm:property :distributionStageDlucGhgEmissions; samm:optional true; samm:payloadName "extTFS_distributionStageDlucGhgEmissions" ] [ samm:property :distributionStageLuGhgEmissions; samm:optional true; samm:payloadName "extTFS_distributionStageLuGhgEmissions" ] [ samm:property :carbonContentTotal; samm:optional true; samm:payloadName "carbonContentTotal" ] [ samm:property :fossilCarbonContent; samm:optional true; samm:payloadName "extWBCSD_fossilCarbonContent" ] [ samm:property :biogenicCarbonContent; samm:optional true; samm:payloadName "carbonContentBiogenic" ] [ samm:property :distributionStageAircraftGhgEmissions; samm:optional true; samm:payloadName "distributionStageAircraftGhgEmissions" ] ) .
 
 :declaredUnit a samm:Property ;
    samm:preferredName "Unit of measurement"@en ;
-   samm:description "Mandatory: Unit of analysis of a product in context of the PCF (product carbon footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example list of valid units includes \"piece\"."@en ;
+   samm:description "Mandatory: Unit of analysis of a product in context of the PCF (product carbon footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example list of valid units includes \"piece\"."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :DeclaredUnitCharacteristic ;
    samm:exampleValue "kilogram" .
 
 :unitaryProductAmount a samm:Property ;
    samm:preferredName "Unitary Product Amount"@en ;
-   samm:description "Mandatory: Amount of units contained within a product in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Amount of units contained within a product in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :StrictlyPositiveDecimalTrait ;
    samm:exampleValue "1000.0"^^xsd:float .
 
 :productMassPerDeclaredUnit a samm:Property ;
    samm:preferredName "Product Mass Per Declared Unit"@en ;
-   samm:description "Mandatory: Mass of a product per declared unit (net, unpackaged) in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook."@en ;
+   samm:description "Mandatory: Mass of a product per declared unit (net, unpackaged) in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0)."@en ;
    samm:characteristic :PositiveDecimalWeightTrait ;
    samm:exampleValue "0.456"^^xsd:decimal .
 
 :exemptedEmissionsPercent a samm:Property ;
    samm:preferredName "Exempted Emissions Percent"@en ;
-   samm:description "Mandatory: Applied cut-off percentage of emissions excluded from PCF (Product Carbon Footprint).\nFor accordance with Catena-X PCF Rulebook V3.0 <3%."@en ;
+   samm:description "Mandatory: Applied cut-off percentage of emissions excluded from PCF (Product Carbon Footprint).\nFor accordance with Catena-X PCF Rulebook (Version 3.0.0) <3%."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :ExemptedEmissionsPercentTrait ;
    samm:exampleValue "0.0"^^xsd:decimal .
 
 :exemptedEmissionsDescription a samm:Property ;
    samm:preferredName "Exempted Emissions Description"@en ;
-   samm:description "Optional: Rationale behind exclusion of specific PCF (Product Carbon Footprint) emissions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: Rationale behind exclusion of specific PCF (Product Carbon Footprint) emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "No exemption" .
 
 :boundaryProcessesDescription a samm:Property ;
    samm:preferredName "Boundary Processes Description"@en ;
-   samm:description "Optional: Processes attributable to each lifecycle stage as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: Processes attributable to each lifecycle stage as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Electricity consumption included as an input in the production phase" .
 
 :geographyCountrySubdivision a samm:Property ;
    samm:preferredName "Geography Country Subdivision"@en ;
-   samm:description "Optional: Subdivision of a country which must be an ISO 3166-2 subdivision code as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: Subdivision of a country which must be an ISO 3166-2 subdivision code as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :GeographyCountrySubdivisionTrait ;
    samm:exampleValue "US-NY" .
 
 :geographyCountry a samm:Property ;
    samm:preferredName "Geography Country"@en ;
-   samm:description "Optional: Two letter country code that must conform to data type ISO 3166CC as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: Two letter country code that must conform to data type ISO 3166CC as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :GeographyCountryTrait ;
    samm:exampleValue "DE" .
 
 :geographyRegionOrSubregion a samm:Property ;
    samm:preferredName "Region"@en ;
-   samm:description "Mandatory: Region according to list as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Region according to list as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :GeographyRegionOrSubregionCharacteristic ;
    samm:exampleValue "Europe" .
 
 :referencePeriodStart a samm:Property ;
    samm:preferredName "Reference Period Start"@en ;
-   samm:description "Mandatory: Start of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Start of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Timestamp ;
    samm:exampleValue "2022-01-01T00:00:01Z"^^xsd:dateTime .
 
 :referencePeriodEnd a samm:Property ;
    samm:preferredName "Reference Period End"@en ;
-   samm:description "Mandatory: End of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: End of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Timestamp ;
    samm:exampleValue "2022-12-31T23:59:59Z"^^xsd:dateTime .
 
 :crossSectoralStandardsUsed a samm:Property ;
    samm:preferredName "Cross Sectoral Standards Used"@en ;
-   samm:description "Mandatory: Discloses the cross-sectoral standards applied for calculating or allocating GHG (Greenhouse Gas) emissions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Discloses the cross-sectoral standards applied for calculating or allocating GHG (Greenhouse Gas) emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :CrossSectoralStandardSet .
 
 :productOrSectorSpecificRules a samm:Property ;
    samm:preferredName "Product or Sector Specific Rules"@en ;
-   samm:description "Mandatory: Product or sector specific rules applied for calculating or allocating GHG (Greenhouse Gas) emissions, e.g. PCRs (Product Category Rules), including operators or publishers and according rule names as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Product or sector specific rules applied for calculating or allocating GHG (Greenhouse Gas) emissions, e.g. PCRs (Product Category Rules), including operators or publishers and according rule names as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :ProductOrSectorSpecificRuleSet .
 
@@ -324,7 +324,7 @@
 
 :allocationRulesDescription a samm:Property ;
    samm:preferredName "Allocation Rules Description"@en ;
-   samm:description "Optional: Allocation rules used and underlying reasoning in context of a product carbon footprint as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by default with value \"In accordance with Catena-X PCF Rulebook\"."@en ;
+   samm:description "Optional: Allocation rules used and underlying reasoning in context of a product carbon footprint as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by default with value \"In accordance with Catena-X PCF Rulebook (Version 3.0.0)\"."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "In accordance with Catena-X PCF Rulebook" .
@@ -337,20 +337,20 @@
 
 :primaryDataShare a samm:Property ;
    samm:preferredName "Primary Data Share"@en ;
-   samm:description "Mandatory starting 2025: Share of primary data in percent as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory starting 2025: Share of primary data in percent as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :PercentTrait ;
    samm:exampleValue "56.12"^^xsd:decimal .
 
 :secondaryEmissionFactorSources a samm:Property ;
    samm:preferredName "Secondary Emission Factor Sources"@en ;
-   samm:description "Mandatory: Emission factors used for the PCF (Product Carbon Footprint) calculation as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Emission factors used for the PCF (Product Carbon Footprint) calculation as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :EmissionFactorDSSet .
 
 :dqi a samm:Property ;
    samm:preferredName "DQI (Data Quality Indicators)"@en ;
-   samm:description "Mandatory starting 2025: Quantitative data quality indicators of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory starting 2025: Quantitative data quality indicators of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :DataQualityIndicators .
 
@@ -362,41 +362,41 @@
 
 :pcfExcludingBiogenic a samm:Property ;
    samm:preferredName "PCF (Product Carbon Footprint) Excluding Biogenic"@en ;
-   samm:description "Mandatory: Product carbon footprint of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Product carbon footprint of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "2.0"^^xsd:decimal .
 
 :pcfIncludingBiogenic a samm:Property ;
    samm:preferredName "PCF (Product Carbon Footprint) Including Biogenic"@en ;
-   samm:description "Mandatory starting 2025: Product carbon footprint of a product including biogenic emissions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Optional value in current specification version but will be mandatory in future version."@en ;
+   samm:description "Mandatory starting 2025: Product carbon footprint of a product including biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Optional value in current specification version but will be mandatory in future version."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :PositiveOrNegativeEmission ;
    samm:exampleValue "1.0"^^xsd:decimal .
 
 :fossilGhgEmissions a samm:Property ;
    samm:preferredName "Fossil Emissions"@en ;
-   samm:description "Mandatory starting 2025: Emissions from combustion of fossil sources as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Identical to \"pcfExcludingBiogenic\", will be removed in later version."@en ;
+   samm:description "Mandatory starting 2025: Emissions from combustion of fossil sources as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Identical to \"pcfExcludingBiogenic\", will be removed in later version."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "0.5"^^xsd:decimal .
 
 :biogenicCarbonEmissionsOtherThanCO2 a samm:Property ;
    samm:preferredName "Biogenic Carbon Emissions Other Than CO2"@en ;
-   samm:description "Mandatory starting 2025: GWP (Global Warming Potential) of biogenic CO2e-emissions in production phase which contain only GHG (Greenhouse Gas) emissions other than CO2 - excludes biogenic CO2. For specification see Catena-X PCF Rulebook."@en ;
+   samm:description "Mandatory starting 2025: GWP (Global Warming Potential) of biogenic CO2e-emissions in production phase which contain only GHG (Greenhouse Gas) emissions other than CO2 - excludes biogenic CO2. For specification see Catena-X PCF Rulebook (Version 3.0.0)."@en ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "1.0"^^xsd:decimal .
 
 :biogenicCarbonWithdrawal a samm:Property ;
    samm:preferredName "Biogenic Carbon Withdrawal"@en ;
-   samm:description "Mandatory starting 2025: Biogenic carbon content in the product converted to CO2e as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory starting 2025: Biogenic carbon content in the product converted to CO2e as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20231207/> ;
    samm:characteristic :NegativeEmissionsTrait ;
    samm:exampleValue "0.0"^^xsd:decimal .
 
 :dlucGhgEmissions a samm:Property ;
    samm:preferredName "dLUC (direct land use change) GHG (Greenhouse Gas) Emissions"@en ;
-   samm:description "Mandatory starting 2025: Direct land use change CO2e emissions in context of a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory starting 2025: Direct land use change CO2e emissions in context of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "0.4"^^xsd:decimal .
 
@@ -408,7 +408,7 @@
 
 :aircraftGhgEmissions a samm:Property ;
    samm:preferredName "Aircraft GHG Emissions"@en ;
-   samm:description "Mandatory starting 2025: GHG (Greenhouse Gas) emissions resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory starting 2025: GHG (Greenhouse Gas) emissions resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "0.0"^^xsd:decimal .
@@ -422,37 +422,37 @@
 
 :distributionStagePcfExcludingBiogenic a samm:Property ;
    samm:preferredName "Distribution Stage PCF (Product Carbon Footprint) Excluding Biogenic"@en ;
-   samm:description "Optional: Product carbon footprint for the distribution stage of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook."@en ;
+   samm:description "Optional: Product carbon footprint for the distribution stage of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0)."@en ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "1.5"^^xsd:decimal .
 
 :distributionStagePcfIncludingBiogenic a samm:Property ;
    samm:preferredName "Distribution Stage PCF (Product Carbon Footprint) Including Biogenic"@en ;
-   samm:description "Optional: Product carbon footprint for the distribution stage of a product including biogenic emissions as specified in the Catena-X PCF Rulebook."@en ;
+   samm:description "Optional: Product carbon footprint for the distribution stage of a product including biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0)."@en ;
    samm:characteristic :PositiveOrNegativeEmission ;
    samm:exampleValue "0.0"^^xsd:decimal .
 
 :distributionStageFossilGhgEmissions a samm:Property ;
    samm:preferredName "Distribution Stage Fossil GHG (Greenhouse Gas) Emissions"@en ;
-   samm:description "Optional: Emissions from the combustion of fossil sources in the distribution stage as specified in the Catena-X PCF Rulebook."@en ;
+   samm:description "Optional: Emissions from the combustion of fossil sources in the distribution stage as specified in the Catena-X PCF Rulebook (Version 3.0.0)."@en ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "0.5"^^xsd:decimal .
 
 :distributionStageBiogenicCarbonEmissionsOtherThanCO2 a samm:Property ;
    samm:preferredName "Distribution Stage Biogenic Carbon Emissions Other Than CO2"@en ;
-   samm:description "Optional: GWP (Global Warming Potential) of biogenic CO2e-emissions in distribution phase which contain only GHG (Greenhouse Gas) emissions other than CO2 ? excludes biogenic CO2. For specification see Catena-X PCF Rulebook."@en ;
+   samm:description "Optional: GWP (Global Warming Potential) of biogenic CO2e-emissions in distribution phase which contain only GHG (Greenhouse Gas) emissions other than CO2 ? excludes biogenic CO2. For specification see Catena-X PCF Rulebook (Version 3.0.0)."@en ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "1.0"^^xsd:decimal .
 
 :distributionStageBiogenicCarbonWithdrawal a samm:Property ;
    samm:preferredName "Distribution Stage Biogenic Carbon Withdrawal"@en ;
-   samm:description "Optional: GWP (Global Warming Potential) of biogenic CO2-withdrawal in distribution stage (biogenic CO2 contained in the product) as specified in the Catena-X PCF Rulebook."@en ;
+   samm:description "Optional: GWP (Global Warming Potential) of biogenic CO2-withdrawal in distribution stage (biogenic CO2 contained in the product) as specified in the Catena-X PCF Rulebook (Version 3.0.0)."@en ;
    samm:characteristic :NegativeEmissionsTrait ;
    samm:exampleValue "0.0"^^xsd:decimal .
 
 :distributionStageDlucGhgEmissions a samm:Property ;
    samm:preferredName "Distribution Stage dLUC (direct land use change) GHG (Greenhouse Gas) Emissions"@en ;
-   samm:description "Optional: Direct land use change CO2 emissions during distribution stage in context of a product carbon footprint as specified in the Catena-X PCF Rulebook. TFS specific extension."@en ;
+   samm:description "Optional: Direct land use change CO2 emissions during distribution stage in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension."@en ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "1.0"^^xsd:decimal .
 
@@ -464,7 +464,7 @@
 
 :carbonContentTotal a samm:Property ;
    samm:preferredName "Carbon Content Total"@en ;
-   samm:description "Mandatory starting 2025: Total carbon content per declared unit in context of a product carbon footprint as specified in the Catena-X PCF Rulebook."@en ;
+   samm:description "Mandatory starting 2025: Total carbon content per declared unit in context of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0)."@en ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "2.5"^^xsd:decimal .
 
@@ -477,21 +477,21 @@
 
 :biogenicCarbonContent a samm:Property ;
    samm:preferredName "Biogenic Carbon Content"@en ;
-   samm:description "Mandatory starting 2025: Biogenic carbon amount embodied in a product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Must be calculated with kgC (kilogram Carbon) / declaredUnit equal to or greater zero."@en ;
+   samm:description "Mandatory starting 2025: Biogenic carbon amount embodied in a product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Must be calculated with kgC (kilogram Carbon) / declaredUnit equal to or greater zero."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20231207/> ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "0.0"^^xsd:decimal .
 
 :distributionStageAircraftGhgEmissions a samm:Property ;
    samm:preferredName "Distribution Stage Aircraft GHG Emissions"@en ;
-   samm:description "Optional: GHG (Greenhouse Gas) emissions for the distribution stage resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: GHG (Greenhouse Gas) emissions for the distribution stage resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :PositiveEmissionsTrait ;
    samm:exampleValue "0.0"^^xsd:decimal .
 
 :DeclaredUnitCharacteristic a samm-c:Enumeration ;
    samm:preferredName "Declared Unit Characteristic"@en ;
-   samm:description "Unit of analysis of the product with accepted values as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. For countable products/ components/ materials, Catena-X for example adds the unit \"piece\" to the value list specified by WBCSD."@en ;
+   samm:description "Unit of analysis of the product with accepted values as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. For countable products/ components/ materials, Catena-X for example adds the unit \"piece\" to the value list specified by WBCSD."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType xsd:string ;
    samm-c:values ( "liter" "kilogram" "cubic meter" "kilowatt hour" "megajoule" "ton kilometer" "square meter" "piece" ) .
@@ -528,26 +528,26 @@
 
 :GeographyRegionOrSubregionCharacteristic a samm-c:Enumeration ;
    samm:preferredName "Geography Region Or Subregion Characteristic"@en ;
-   samm:description "Characteristic for defining a list of valid geographic regions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example \"Global\" has been added to the value list."@en ;
+   samm:description "Characteristic for defining a list of valid geographic regions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example \"Global\" has been added to the value list."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType xsd:string ;
    samm-c:values ( "Africa" "Americas" "Asia" "Europe" "Oceania" "Australia and New Zealand" "Central Asia" "Eastern Asia" "Eastern Europe" "Latin America and the Caribbean" "Melanesia" "Micronesia" "Northern Africa" "Northern America" "Northern Europe" "Polynesia" "South-eastern Asia" "Southern Asia" "Southern Europe" "Sub-Saharan Africa" "Western Asia" "Western Europe" "Global" "Several" ) .
 
 :CrossSectoralStandardSet a samm-c:List ;
    samm:preferredName "Cross Sectoral Standards Used Characteristic"@en ;
-   samm:description "Characteristic for defining the list of valid accounting standards used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Characteristic for defining the list of valid accounting standards used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType :CrossSectoralStandard .
 
 :ProductOrSectorSpecificRuleSet a samm-c:Set ;
    samm:preferredName "Product Or Sector Specific Rules Set"@en ;
-   samm:description "Characteristic for defining the set of product or sector specific rules of a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Characteristic for defining the set of product or sector specific rules of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType :ProductOrSectorSpecificRule .
 
 :CharacterizationFactorsCharacteristic a samm-c:Enumeration ;
    samm:preferredName "Characterization Factors Characteristic"@en ;
-   samm:description "Characteristic for defining the characterization factors of a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example specified by a default value."@en ;
+   samm:description "Characteristic for defining the characterization factors of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example specified by a default value."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType xsd:string ;
    samm-c:values ( "AR5" "AR6" ) .
@@ -566,13 +566,13 @@
 
 :EmissionFactorDSSet a samm-c:Set ;
    samm:preferredName "Emission Factor Data Sources Set Characteristic"@en ;
-   samm:description "Characteristic for defining a set of emission factor sources used for calculating a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Characteristic for defining a set of emission factor sources used for calculating a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType :EmissionFactorDS .
 
 :DataQualityIndicators a samm:Characteristic ;
    samm:preferredName "Data Quality Indicators"@en ;
-   samm:description "Characteristic for defining the quantitative data quality indicators of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Characteristic for defining the quantitative data quality indicators of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType :DataQualityIndicator .
 
@@ -621,13 +621,13 @@
 
 :ExemptedEmissionsPercentCharacteristic a samm-c:Quantifiable ;
    samm:preferredName "Exempted Emissions Percent Characteristic"@en ;
-   samm:description "Characteristic for defining the percentage of emissions excluded from a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Characteristic for defining the percentage of emissions excluded from a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType xsd:decimal .
 
 :ExemptedEmissionsPercentConstraint a samm-c:RangeConstraint ;
    samm:preferredName "Exempted Emissions Percent Constraint"@en ;
-   samm:description "Characteristic for defining the percentage of emissions excluded from a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Characteristic for defining the percentage of emissions excluded from a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm-c:minValue "0.0"^^xsd:decimal ;
    samm-c:maxValue "5.0"^^xsd:decimal ;
@@ -636,25 +636,25 @@
 
 :GeographyCountrySubdivisionConstraint a samm-c:RegularExpressionConstraint ;
    samm:preferredName "Subdivision Constraint"@en ;
-   samm:description "Constraint for defining a geography country subdivision in compliance to ISO 3166-2 as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Constraint for defining a geography country subdivision in compliance to ISO 3166-2 as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:value "([A-Z]{2}-[A-Z0-9]{1,3}|)" .
 
 :GeographyCountryConstraint a samm-c:RegularExpressionConstraint ;
    samm:preferredName "Country Constraint"@en ;
-   samm:description "Constraint for defining a geography country conform to ISO 3166CC as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Constraint for defining a geography country conform to ISO 3166CC as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:value "([A-Z]{2})" .
 
 :CrossSectoralStandard a samm:Entity ;
    samm:preferredName "Cross Sectoral Standard Entity"@en ;
-   samm:description "Entity for defining an accounting standard used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Entity for defining an accounting standard used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:properties ( [ samm:property :crossSectoralStandard; samm:payloadName "crossSectoralStandard" ] ) .
 
 :ProductOrSectorSpecificRule a samm:Entity ;
    samm:preferredName "Product Or Sector Specific Rule"@en ;
-   samm:description "Entity for defining a product or sector specific rule of a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Entity for defining a product or sector specific rule of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:properties ( [ samm:property :operator; samm:payloadName "extWBCSD_operator" ] [ samm:property :ruleNames; samm:payloadName "productOrSectorSpecificRules" ] [ samm:property :otherOperatorName; samm:optional true; samm:payloadName "extWBCSD_otherOperatorName" ] ) .
 
@@ -674,19 +674,19 @@
 
 :EmissionFactorDS a samm:Entity ;
    samm:preferredName "Emission Factor Data Source Entity"@en ;
-   samm:description "Entity for defining an emission factor data source used to calculate a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Entity for defining an emission factor data source used to calculate a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:properties ( [ samm:property :emissionFactorDS; samm:payloadName "secondaryEmissionFactorSource" ] ) .
 
 :DataQualityIndicator a samm:Entity ;
    samm:preferredName "Data Quality Indicator"@en ;
-   samm:description "Entity for defining a quantitative data quality indicator of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Entity for defining a quantitative data quality indicator of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:properties ( [ samm:property :coveragePercent; samm:optional true; samm:payloadName "coveragePercent" ] [ samm:property :technologicalDQR; samm:optional true; samm:payloadName "technologicalDQR" ] [ samm:property :temporalDQR; samm:optional true; samm:payloadName "temporalDQR" ] [ samm:property :geographicalDQR; samm:optional true; samm:payloadName "geographicalDQR" ] [ samm:property :completenessDQR; samm:optional true; samm:payloadName "completenessDQR" ] [ samm:property :reliabilityDQR; samm:optional true; samm:payloadName "reliabilityDQR" ] ) .
 
 :PositiveEmission a samm-c:Quantifiable ;
    samm:preferredName "Positive Emission"@en ;
-   samm:description "Characteristic for defining emissions expressed as a decimal equal to or greater than zero in context of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Characteristic for defining emissions expressed as a decimal equal to or greater than zero in context of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType xsd:decimal .
 
@@ -699,7 +699,7 @@
 
 :NegativeEmission a samm-c:Quantifiable ;
    samm:preferredName "Negative Emission"@en ;
-   samm:description "Characteristic for defining emissions expressed as a decimal equal to or less than zero in context of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Characteristic for defining emissions expressed as a decimal equal to or less than zero in context of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:dataType xsd:decimal .
 
 :NegativeEmissionConstraint a samm-c:RangeConstraint ;
@@ -711,7 +711,7 @@
 
 :crossSectoralStandard a samm:Property ;
    samm:preferredName "Cross Sectoral Standard"@en ;
-   samm:description "Mandatory: Discloses a cross-sectoral standard applied for calculating or allocating GHG (Greenhouse Gas) emissions as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Discloses a cross-sectoral standard applied for calculating or allocating GHG (Greenhouse Gas) emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :CrossSectoralStandardsUsedEnumerationCharacteristic ;
    samm:exampleValue "ISO Standard 14044" .
@@ -725,7 +725,7 @@
 
 :ruleNames a samm:Property ;
    samm:preferredName "Product or Sector Specific Rule Names"@en ;
-   samm:description "Mandatory: Product-specific or sector-specific set of rules used for calculating or allocating GHG (Greenhouse Gas) emissions applied from the specified operator as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Product-specific or sector-specific set of rules used for calculating or allocating GHG (Greenhouse Gas) emissions applied from the specified operator as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :RuleNamesTrait .
 
@@ -738,56 +738,56 @@
 
 :emissionFactorDS a samm:Property ;
    samm:preferredName "Emission Factor Data Source"@en ;
-   samm:description "Mandatory: Emission factor data source used to calculate a product carbon footprint as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Mandatory: Emission factor data source used to calculate a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "ecoinvent 3.8" .
 
 :coveragePercent a samm:Property ;
    samm:preferredName "Coverage Percent"@en ;
-   samm:description "Mandatory starting 2025: Percentage of PCF (Product Carbon Footprint) included in the data quality assessment based on the >5% emissions threshold as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to \"100\" per default."@en ;
+   samm:description "Mandatory starting 2025: Percentage of PCF (Product Carbon Footprint) included in the data quality assessment based on the >5% emissions threshold as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to \"100\" per default."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :PercentTrait ;
    samm:exampleValue "100"^^xsd:decimal .
 
 :technologicalDQR a samm:Property ;
    samm:preferredName "Technological DQR (Data Quality Rating)"@en ;
-   samm:description "Optional: Technological representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: Technological representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :DqiNumberTrait ;
    samm:exampleValue "2.0"^^xsd:decimal .
 
 :temporalDQR a samm:Property ;
    samm:preferredName "Temporal DQR (Data Quality Rating)"@en ;
-   samm:description "Optional: Temporal representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: Temporal representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :DqiNumberTrait ;
    samm:exampleValue "2.0"^^xsd:decimal .
 
 :geographicalDQR a samm:Property ;
    samm:preferredName "Geographical DQR (Data Quality Rating)"@en ;
-   samm:description "Optional: Geographical representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: Geographical representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :DqiNumberTrait ;
    samm:exampleValue "2.0"^^xsd:decimal .
 
 :completenessDQR a samm:Property ;
    samm:preferredName "Completeness DQR (Data Quality Rating)"@en ;
-   samm:description "Optional: Completeness of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: Completeness of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :DqiNumberTrait ;
    samm:exampleValue "2.0"^^xsd:decimal .
 
 :reliabilityDQR a samm:Property ;
    samm:preferredName "Reliability DQR (Data Quality Rating)"@en ;
-   samm:description "Optional: Reliability of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Optional: Reliability of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :DqiNumberTrait ;
    samm:exampleValue "2.0"^^xsd:decimal .
 
 :CrossSectoralStandardsUsedEnumerationCharacteristic a samm-c:Enumeration ;
    samm:preferredName "Cross Sectoral Standards Used Enumeration Characteristic"@en ;
-   samm:description "Characteristic for defining the enumeration of valid accounting standards used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Characteristic for defining the enumeration of valid accounting standards used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType xsd:string ;
    samm-c:values ( "ISO Standard 14067" "ISO Standard 14044" "Pathfinder v1" "Pathfinder v2" "PAS 2050" "ISO Standard 14040" "ISO Standard 14041" "ISO Standard 14042" "ISO Standard 14043" "PEF" "Other" "GHG Protocol Product Standard" ) .
@@ -801,7 +801,7 @@
 
 :RuleNamesTrait a samm-c:Trait ;
    samm:preferredName "Rule Names Trait"@en ;
-   samm:description "Trait for defining a non-empty set of rule names as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Trait for defining a non-empty set of rule names as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm-c:baseCharacteristic :RuleNamesCharacteristic ;
    samm-c:constraint :RuleNamesConstraint .
 
@@ -813,13 +813,13 @@
 
 :RuleNamesCharacteristic a samm-c:Set ;
    samm:preferredName "Rule Names Characteristic"@en ;
-   samm:description "Non-empty set of rules applied by the specified operator. Defined by the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Non-empty set of rules applied by the specified operator. Defined by the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:dataType :RuleName .
 
 :RuleNamesConstraint a samm-c:LengthConstraint ;
    samm:preferredName "Rule Names Constraint"@en ;
-   samm:description "Constraint for defining a non-empty set of rule names as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Constraint for defining a non-empty set of rule names as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm-c:minValue "1"^^xsd:nonNegativeInteger .
 
@@ -838,13 +838,13 @@
 
 :RuleName a samm:Entity ;
    samm:preferredName "Rule Name"@en ;
-   samm:description "Name of a rule applied by a specified operator as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Name of a rule applied by a specified operator as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:properties ( :ruleName ) .
 
 :ruleName a samm:Property ;
    samm:preferredName "Rule Name"@en ;
-   samm:description "Name of a rule applied by a specific operator as specified in the Catena-X PCF Rulebook in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
+   samm:description "Name of a rule applied by a specific operator as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative."@en ;
    samm:see <https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/> ;
    samm:characteristic :NonEmptyStringTrait ;
    samm:exampleValue "urn:tfs-initiative.com:PCR:The Product Carbon Footprint Guideline for the Chemical Industry:version:v2.0" .

--- a/io.catenax.pcf/7.0.0/metadata.json
+++ b/io.catenax.pcf/7.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.pcf/RELEASE_NOTES.md
+++ b/io.catenax.pcf/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
-## [7.0.0] 2024-05-20
+## [7.0.0] 2024-05-27
 ### Changed
 - adapted as aligned with and specified by the Catena-X use case team
 - extended enumeration list of property "crossSectoralStandard" for compliance with the TfS (Together for Sustainability) standard

--- a/io.catenax.pcf/RELEASE_NOTES.md
+++ b/io.catenax.pcf/RELEASE_NOTES.md
@@ -3,6 +3,12 @@ All notable changes to this model will be documented in this file.
 
 ## [Unreleased]
 
+## [7.0.0] 2024-05-20
+### Changed
+- adapted as aligned with and specified by the Catena-X use case team
+- extended enumeration list of property "crossSectoralStandard" for compliance with the TfS (Together for Sustainability) standard
+- updated descriptions and examples for compliance with the PCF Rulebook v3 standard
+
 ## [6.0.0] 2024-02-26
 ### Changed
 - adapted as aligned with and specified by the Catena-X use case team


### PR DESCRIPTION
Update of the PCF data model in context of CX Rel. 24.08

## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

Closes #717 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.6.0)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
