### PR TITLE
[Model Update]: business partner certificate update

### DIFF
--- a/io.catenax.shared.business_partner_certificate/1.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.shared.business_partner_certificate/1.0.0/BusinessPartnerCertificate.ttl
@@ -74,24 +74,23 @@
     samm:exampleValue "Development, Marketing und Sales and also Procurement for interior components".
  
   
- :enclosedSites a samm:Property ;
-   samm:preferredName "Enclosed sites"@en ;
-   samm:description "Additional sites covered by the certificate, which can be either BPNS or BPNA"@en ;
-   samm:characteristic [ a samm-c:List ;
-       samm:dataType :EnclosedSiteEntity ;
-       samm:allowedValues (ext-number:BpnsTrait ext-number:BpnaTrait) ;
-   ] .
+ :enclosedSites a samm:Property;
+    samm:preferredName "Enclosed sites"@en;
+    samm:description "Optional enclosed sites of the legal entity which are enclosed by the certification "@en;
+	samm:characteristic  [ a samm-c:List ; samm:dataType :EnclosedSiteEntity].
 	
- :EnclosedSiteEntity a samm:Entity ;
-   samm:preferredName "Enclosed Site Entity"@en ;
-   samm:description "Entity representing an enclosed site, can be BPNS or BPNA"@en ;
-   samm:properties (:enclosedSiteBpn [samm:property :areaOfApplication; samm:optional true]) .
+	  
+ :EnclosedSiteEntity a samm:Entity;
+    samm:preferredName "Defines enclosed sites "@en;
+    samm:description "Optional enclosed sites where certification is valid including details about area of application"@en;
+    samm:properties (:enclosedSiteBpn [samm:property :areaOfApplication;samm:optional true]).
 
   :enclosedSiteBpn a samm:Property ;
    samm:preferredName "enclosedSite BPN"@en ;
-   samm:description "The BPN of an enclosed site"@en ;
-   samm:characteristic ext-number:BpnsTrait ;  # This can be set to handle BPNS and BPNA
-   samm:exampleValue "BPNS00000003AYRE" .
+   samm:description "The BPN of an enclosed site "@en ;
+   samm:characteristic ext-number:BpnsTrait ;
+   samm:exampleValue "BPNS00000003AYRE".
+
  
   :validFrom a samm:Property;
     samm:preferredName "Valid from"@en;
@@ -125,7 +124,7 @@
 :TrustValidatorEntitity a samm:Entity ;
    samm:preferredName "Trust validator entity"@en ;
    samm:description "The BPN of the data service provider who validated the given certificate"@en ;
-   samm:properties ([samm:property :validatorName; samm:optional true] [samm:property :validatorBpn; samm:optional true]).
+   samm:properties ([samm:property :validatorName; samm:optional true] :validatorBpn).
 
 :validatorName a samm:Property ;
    samm:preferredName "Validator name"@en ;

--- a/io.catenax.shared.business_partner_certificate/1.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.shared.business_partner_certificate/1.0.0/BusinessPartnerCertificate.ttl
@@ -74,23 +74,24 @@
     samm:exampleValue "Development, Marketing und Sales and also Procurement for interior components".
  
   
- :enclosedSites a samm:Property;
-    samm:preferredName "Enclosed sites"@en;
-    samm:description "Optional enclosed sites of the legal entity which are enclosed by the certification "@en;
-	samm:characteristic  [ a samm-c:List ; samm:dataType :EnclosedSiteEntity].
+ :enclosedSites a samm:Property ;
+   samm:preferredName "Enclosed sites"@en ;
+   samm:description "Additional sites covered by the certificate, which can be either BPNS or BPNA"@en ;
+   samm:characteristic [ a samm-c:List ;
+       samm:dataType :EnclosedSiteEntity ;
+       samm:allowedValues (ext-number:BpnsTrait ext-number:BpnaTrait) ;
+   ] .
 	
-	  
- :EnclosedSiteEntity a samm:Entity;
-    samm:preferredName "Defines enclosed sites "@en;
-    samm:description "Optional enclosed sites where certification is valid including details about area of application"@en;
-    samm:properties (:enclosedSiteBpn [samm:property :areaOfApplication;samm:optional true]).
+ :EnclosedSiteEntity a samm:Entity ;
+   samm:preferredName "Enclosed Site Entity"@en ;
+   samm:description "Entity representing an enclosed site, can be BPNS or BPNA"@en ;
+   samm:properties (:enclosedSiteBpn [samm:property :areaOfApplication; samm:optional true]) .
 
   :enclosedSiteBpn a samm:Property ;
    samm:preferredName "enclosedSite BPN"@en ;
-   samm:description "The BPN of an enclosed site "@en ;
-   samm:characteristic ext-number:BpnsTrait ;
-   samm:exampleValue "BPNS00000003AYRE".
-
+   samm:description "The BPN of an enclosed site"@en ;
+   samm:characteristic ext-number:BpnsTrait ;  # This can be set to handle BPNS and BPNA
+   samm:exampleValue "BPNS00000003AYRE" .
  
   :validFrom a samm:Property;
     samm:preferredName "Valid from"@en;
@@ -124,7 +125,7 @@
 :TrustValidatorEntitity a samm:Entity ;
    samm:preferredName "Trust validator entity"@en ;
    samm:description "The BPN of the data service provider who validated the given certificate"@en ;
-   samm:properties ([samm:property :validatorName; samm:optional true] :validatorBpn).
+   samm:properties ([samm:property :validatorName; samm:optional true] [samm:property :validatorBpn; samm:optional true]).
 
 :validatorName a samm:Property ;
    samm:preferredName "Validator name"@en ;

--- a/io.catenax.shared.business_partner_certificate/2.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.shared.business_partner_certificate/2.0.0/BusinessPartnerCertificate.ttl
@@ -1,0 +1,173 @@
+#######################################################################
+# Copyright (c) 2024 Mercedes-Benz Group AG
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.business_partner_certificate:1.0.0#> .
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:2.0.0#> .
+
+:BusinessPartnerCertificate a samm:Aspect ;
+   samm:preferredName "Business Partner certificate"@en ;
+   samm:description "A business partner certifcate describes a certificate (eg ISO9001, IATF-16949) via a certifcate document  of a Catena-X business partner"@en ;
+   samm:properties ( :businessPartnerNumber :type :registrationNumber [samm:property :areaOfApplication; samm:optional true] [samm:property :enclosedSites; samm:optional true] :validFrom :validUntil [samm:property :issuer; samm:optional true] :trustLevel [samm:property :validator; samm:optional true] [samm:property :uploader; samm:optional true] [samm:property :documentID; samm:optional true] );
+   samm:operations ( ) ;
+   samm:events ( ) .
+ 
+:businessPartnerNumber a samm:Property ;
+   samm:preferredName "Business Partner number"@en ;
+   samm:description "The BPN of the certified legal entity "@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL00000003AYRE".
+
+
+ :type a samm:Property;
+    samm:preferredName "Certificate type"@en;
+    samm:description "Type of the certificate as defined on the document like IS09001, IATF 16949 or other"@en;
+    samm:characteristic [ a samm-c:SingleEntity ; samm:dataType :CertificateTypeEntity].
+	
+	
+ :CertificateTypeEntity a samm:Entity;
+    samm:preferredName "Entity of a certificate type"@en;
+    samm:description "Detailed entity of the certificate like IS09001:2015, IATF 16949:2015 or other, valid types are registered at BPN metadatacontroller"@en;
+    samm:properties (:certificateType [samm:property :certificateVersion; samm:optional true]).
+ 
+  :certificateType a samm:Property;
+    samm:preferredName "Certificate type"@en;
+    samm:description "Type of the certificate as defined on the document,valid types are registered at BPN metadatacontroller"@en;
+    samm:characteristic samm-c:Text ;
+    samm:exampleValue "ISO9001".
+ 
+ :certificateVersion a samm:Property;
+    samm:preferredName "Certificate version"@en;
+    samm:description "Version of the certificate as defined on the document, usually the specific version of a certification standard"@en;
+    samm:characteristic samm-c:Text ;
+    samm:exampleValue "2015". 
+  
+ :registrationNumber a samm:Property;
+    samm:preferredName "Certificate registration number"@en;
+    samm:description "Registration number of the certificate as defined on the certificate"@en;
+    samm:characteristic samm-c:Text;
+    samm:exampleValue "12 198 54182 TMS".
+
+
+  :areaOfApplication a samm:Property;
+    samm:preferredName "area of application"@en;
+    samm:description "Details on which areas / application types a certificate is valid for a company"@en;
+    samm:characteristic samm-c:Text;
+    samm:exampleValue "Development, Marketing und Sales and also Procurement for interior components".
+ 
+  
+ :enclosedSites a samm:Property ;
+   samm:preferredName "Enclosed sites"@en ;
+   samm:description "Additional sites covered by the certificate, which can be either BPNS or BPNA"@en ;
+   samm:characteristic [ a samm-c:List ;
+       samm:dataType :EnclosedSiteEntity ;
+       samm:allowedValues (ext-number:BpnsTrait ext-number:BpnaTrait) ;
+   ] .
+	
+ :EnclosedSiteEntity a samm:Entity ;
+   samm:preferredName "Enclosed Site Entity"@en ;
+   samm:description "Entity representing an enclosed site, can be BPNS or BPNA"@en ;
+   samm:properties (:enclosedSiteBpn [samm:property :areaOfApplication; samm:optional true]) .
+
+  :enclosedSiteBpn a samm:Property ;
+   samm:preferredName "enclosedSite BPN"@en ;
+   samm:description "The BPN of an enclosed site"@en ;
+   samm:characteristic ext-number:BpnsTrait ;  # This can be set to handle BPNS and BPNA
+   samm:exampleValue "BPNS00000003AYRE" .
+ 
+  :validFrom a samm:Property;
+    samm:preferredName "Valid from"@en;
+    samm:description "Valid from date as defined on the certificate."@en;
+    samm:characteristic :Date;
+    samm:exampleValue "2023-01-25"^^xsd:date.
+
+ :validUntil a samm:Property;
+    samm:preferredName "Valid until"@en;
+    samm:description "Valid valid until as defined on the certificate. If certificate never expires value until expected to be 9999-12-31"@en;
+    samm:characteristic :Date;
+	samm:exampleValue "2026-01-24"^^xsd:date.
+    
+ :Date a samm:Characteristic ;
+   samm:preferredName "Date"@en ;
+   samm:description "Describes a property which contains the date in english format."@en ;
+   samm:dataType xsd:date;
+   samm:exampleValue "2026-01-24"^^xsd:date.
+  
+:validator a samm:Property ;
+   samm:preferredName "Validator"@en ;
+   samm:description "The BPN of the data service provider who validate the given certificate"@en ;
+   samm:characteristic :TrustValidatorCharacteristic.
+
+:TrustValidatorCharacteristic a samm:Characteristic;
+	samm:preferredName "Validiator caracteristic"@en;
+	samm:description "The BPN of the data service provider who validated the given certificate"@en ;
+    samm:dataType :TrustValidatorEntitity . 
+   
+   
+:TrustValidatorEntitity a samm:Entity ;
+   samm:preferredName "Trust validator entity"@en ;
+   samm:description "The BPN of the data service provider who validated the given certificate"@en ;
+   samm:properties ([samm:property :validatorName; samm:optional true] [samm:property :validatorBpn; samm:optional true]).
+
+:validatorName a samm:Property ;
+   samm:preferredName "Validator name"@en ;
+   samm:description "The optional name of the data service provider who validated the given certificate"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Data service provider X".
+
+:validatorBpn a samm:Property ;
+   samm:preferredName "Certifcate validator Bpn"@en ;
+   samm:description "The BPN of the data service provider who validated the given certificate"@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL00000007YREZ".
+ 
+ :issuer a samm:Property ;
+   samm:preferredName "Issuing authority"@en ;
+   samm:description "The BPN of the issuing authority e.g. TUEV Sued "@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL00000023ZAVC".
+
+ :trustLevel a samm:Property;
+	samm:preferredName "Trust level"@en ; 
+	samm:description "The trust level of the given certificate - none,low, high, trusted"@en ;
+	samm:characteristic :TrustLevelValue ;
+	samm:exampleValue "high".
+	
+ :TrustLevelValue a samm-c:Enumeration;
+   samm:preferredName "Trust level value"@en ;
+   samm:description "The possible trust level values of certificate"@en ;
+   samm:dataType xsd:string;
+   samm-c:values ("none" "low" "high" "trusted").
+  
+ 
+ :uploader a samm:Property ;
+   samm:preferredName "Certifcate uploader"@en ;
+   samm:description "The BPN of the business partner who originally provided the certifcate data or document e.g. Mercedes Benz AG"@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL00000003AYRE".
+
+
+ :documentID a samm:Property ;
+   samm:preferredName "Document ID"@en ;
+   samm:description "The id of the certificate document as stored by the data service provider for physical download via API"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "UUID--123456789".
+

--- a/io.catenax.shared.business_partner_certificate/2.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.shared.business_partner_certificate/2.0.0/BusinessPartnerCertificate.ttl
@@ -146,10 +146,10 @@
    samm:exampleValue "BPNL00000023ZAVC".
 
  :trustLevel a samm:Property ;
-	samm:preferredName "Trust level"@en ; 
-	samm:description "The trust level of the given certificate - none,low, high, trusted"@en ;
-	samm:characteristic :TrustLevelValue ;
-	samm:exampleValue "high".
+   samm:preferredName "Trust level"@en ; 
+   samm:description "The trust level of the given certificate - none,low, high, trusted"@en ;
+   samm:characteristic :TrustLevelValue ;
+   samm:exampleValue "high".
 	
  :TrustLevelValue a samm-c:Enumeration;
    samm:preferredName "Trust level value"@en ;

--- a/io.catenax.shared.business_partner_certificate/2.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.shared.business_partner_certificate/2.0.0/BusinessPartnerCertificate.ttl
@@ -20,7 +20,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.business_partner_certificate:1.0.0#> .
+@prefix : <urn:samm:io.catenax.business_partner_certificate:2.0.0#> .
 @prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:2.0.0#> .
 
 :BusinessPartnerCertificate a samm:Aspect ;
@@ -31,7 +31,7 @@
    samm:events ( ) .
  
 :businessPartnerNumber a samm:Property ;
-   samm:preferredName "Business Partner number"@en ;
+   samm:preferredName "Business Partner Number"@en ;
    samm:description "The BPN of the certified legal entity "@en ;
    samm:characteristic ext-number:BpnlTrait ;
    samm:exampleValue "BPNL00000003AYRE".
@@ -68,7 +68,7 @@
 
 
   :areaOfApplication a samm:Property;
-    samm:preferredName "area of application"@en;
+    samm:preferredName "Area of application"@en;
     samm:description "Details on which areas / application types a certificate is valid for a company"@en;
     samm:characteristic samm-c:Text;
     samm:exampleValue "Development, Marketing und Sales and also Procurement for interior components".

--- a/io.catenax.shared.business_partner_certificate/2.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.shared.business_partner_certificate/2.0.0/BusinessPartnerCertificate.ttl
@@ -145,7 +145,7 @@
    samm:characteristic ext-number:BpnlTrait ;
    samm:exampleValue "BPNL00000023ZAVC".
 
- :trustLevel a samm:Property;
+ :trustLevel a samm:Property ;
 	samm:preferredName "Trust level"@en ; 
 	samm:description "The trust level of the given certificate - none,low, high, trusted"@en ;
 	samm:characteristic :TrustLevelValue ;

--- a/io.catenax.shared.business_partner_certificate/2.0.0/metadata.json
+++ b/io.catenax.shared.business_partner_certificate/2.0.0/metadata.json
@@ -1,0 +1,1 @@
+{"status": "release"}

--- a/io.catenax.shared.business_partner_certificate/RELEASE_NOTES.md
+++ b/io.catenax.shared.business_partner_certificate/RELEASE_NOTES.md
@@ -5,3 +5,10 @@ All notable changes to this model will be documented in this file.
 ## [1.0.0] 11.03.2024
 
 - initial version of the aspect model for Business Partner Certificate.
+
+## [2.0.0] 29.08.2024
+
+### Changed
+
+- Updated enclosedSiteBpn property to accept both site and address type for Business Partner Certificate.
+- Updated validator object. Now validator object is optional including validatorName and validatorBpn attributes, for increased flexibility in validation details.


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->
This pull request updates `enclosedSiteBpn` property to accept both site and address type business partner. Additionally, the Validator object is made optional, including `validatorName` and `validatorBpn`, for increased flexibility in validation details.


Closes https://github.com/eclipse-tractusx/sldt-semantic-models/issues/771

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.6.0)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
