### PR TITLE
Fix: Updated SAMM-CLI to 2.9.5 and AME version to 5.6.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Closes #
 <!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
 ## MS2 Criteria
 (to be filled out by PR reviewer)
-- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.6.0)
+- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.5)
 - [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
 - [ ] the identifiers for all model elements **start with a capital letter** except for properties
 - [ ] the identifier for **properties starts with a small letter**
@@ -23,7 +23,7 @@ Closes #
 - [ ] units are referenced from the SAMM unit catalog whenever possible
 - [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
 - [ ] when relying on **external standards**, they are referenced through a **"see"** element
-- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html) have an example value
+- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
 - [ ] metadata.json exists with status "release"
 - [ ] generated json schema validates against example json payload
 - [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 

--- a/.github/actions/model-validation/action.yml
+++ b/.github/actions/model-validation/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
   bamm_version: 
     description: The version of the used SAMM SDK
-    default: 2.6.0
+    default: 2.9.5
     required: true
   token:
     description: GitHub token

--- a/.github/workflows/bulk-validation.yml
+++ b/.github/workflows/bulk-validation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: validate models
         uses: ./.github/actions/model-validation
         with:
-          bamm_version: 2.6.0
+          bamm_version: 2.9.5
           bulk: true
       - name: Archive
         uses: actions/upload-artifact@v3

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -85,7 +85,7 @@ jobs:
         uses: ./.github/actions/model-validation
         with:
           pr_number: ${{ github.event.number }}
-          bamm_version: 2.6.0
+          bamm_version: 2.9.5
           added: ${{needs.synchronize-models.outputs.ADDED}}
           modified: ${{needs.synchronize-models.outputs.MODIFIED}}
       - name: Archive

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 /bamm-cli-*.jar
+/samm-cli-*.jar
 /Start.txt
 
 .DS_Store
 
 .BAMMCLI
+.SAMMCLI
 .idea
 .ttl-artifacts
 static

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Aspect Models for Eclipse Tractus-X Semantic Layer (SLDT)
-The repository contains the aspect models based on [SAMM (Semantic Aspect Meta Model)](https://eclipse-esmf.github.io/samm-specification/2.0.0/index.html) for the Tractus-X project for Catena-X.
+The repository contains the aspect models based on [SAMM (Semantic Aspect Meta Model)](https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html) for the Tractus-X project for Catena-X.
 
-**Currently, we assume the usage of the version 2.6.0 of the [SAMM-CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.6.0/tooling-guide/samm-cli.html) and version 5.1.1 of the [Aspect Model Editor](https://eclipse-esmf.github.io/ame-guide/5.1.1/introduction.html) **.
+**Currently, we assume the usage of the version 2.9.5 of the [SAMM-CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.5/tooling-guide/samm-cli.html) and version 5.6.0 of the [Aspect Model Editor](https://eclipse-esmf.github.io/ame-guide/5.6.0/introduction.html) **.
 
 # Using the models
-The models can locally be processed with the [SAMM CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.6.0/tooling-guide/samm-cli.html), which is documented [here](https://eclipse-esmf.github.io/esmf-developer-guide/2.6.0/tooling-guide/samm-cli.html).
+The models can locally be processed with the [SAMM CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.5/tooling-guide/samm-cli.html), which is documented [here](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.5/tooling-guide/samm-cli.html).
 It allows you to generate different artifacts (diagrams, example payload, java class files) out of it.
 
 For convenience you can also look into the `gen` folder of each model, which already contains often used  artifacts generated from the model.

--- a/generate.sh
+++ b/generate.sh
@@ -30,11 +30,11 @@
 
 
 # Adjust if SAMM CLI version changes
-JARNAME=samm-cli-2.6.0.jar
+JARNAME=samm-cli-2.9.5.jar
 SAMMFOLDER=.SAMMCLI/
 SAMMCLI=$SAMMFOLDER$JARNAME
 # Adjust if SAMM CLI version changes
-SAMMCLIURL=https://github.com/eclipse-esmf/esmf-sdk/releases/download/v2.6.0/samm-cli-2.6.0.jar
+SAMMCLIURL=https://github.com/eclipse-esmf/esmf-sdk/releases/download/v2.9.5/samm-cli-2.9.5.jar
 
 CATENAXCSS=$SAMMFOLDER/catena-template.css
 CATENAXCUSTOMCSSURL=https://raw.githubusercontent.com/eclipse-tractusx/sldt-semantic-hub/main/backend/src/main/resources/catena-template.css


### PR DESCRIPTION
This PR updates:
 - SAMM Speficiation from v2.0.0 to v2.1.0
 - SAMM SDK from v2.6.0 to v2.9.5
 - AME from v5.1.1 to v5.6.0
 - .gitignore (added SAMM-CLI)

Closes: #769 