### PR TITLE
Update SAMM-CLI from 2.9.5 to 2.9.7

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Closes #
 <!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
 ## MS2 Criteria
 (to be filled out by PR reviewer)
-- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.5)
+- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
 - [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
 - [ ] the identifiers for all model elements **start with a capital letter** except for properties
 - [ ] the identifier for **properties starts with a small letter**

--- a/.github/actions/model-validation/action.yml
+++ b/.github/actions/model-validation/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
   bamm_version: 
     description: The version of the used SAMM SDK
-    default: 2.9.5
+    default: 2.9.7
     required: true
   token:
     description: GitHub token

--- a/.github/workflows/bulk-validation.yml
+++ b/.github/workflows/bulk-validation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: validate models
         uses: ./.github/actions/model-validation
         with:
-          bamm_version: 2.9.5
+          bamm_version: 2.9.7
           bulk: true
       - name: Archive
         uses: actions/upload-artifact@v3

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -85,7 +85,7 @@ jobs:
         uses: ./.github/actions/model-validation
         with:
           pr_number: ${{ github.event.number }}
-          bamm_version: 2.9.5
+          bamm_version: 2.9.7
           added: ${{needs.synchronize-models.outputs.ADDED}}
           modified: ${{needs.synchronize-models.outputs.MODIFIED}}
       - name: Archive

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Aspect Models for Eclipse Tractus-X Semantic Layer (SLDT)
 The repository contains the aspect models based on [SAMM (Semantic Aspect Meta Model)](https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html) for the Tractus-X project for Catena-X.
 
-**Currently, we assume the usage of the version 2.9.5 of the [SAMM-CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.5/tooling-guide/samm-cli.html) and version 5.6.0 of the [Aspect Model Editor](https://eclipse-esmf.github.io/ame-guide/5.6.0/introduction.html) **.
+**Currently, we assume the usage of the version 2.9.7 of the [SAMM-CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.7/tooling-guide/samm-cli.html) and version 5.6.0 of the [Aspect Model Editor](https://eclipse-esmf.github.io/ame-guide/5.6.0/introduction.html) **.
 
 # Using the models
-The models can locally be processed with the [SAMM CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.5/tooling-guide/samm-cli.html), which is documented [here](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.5/tooling-guide/samm-cli.html).
+The models can locally be processed with the [SAMM CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.7/tooling-guide/samm-cli.html), which is documented [here](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.7/tooling-guide/samm-cli.html).
 It allows you to generate different artifacts (diagrams, example payload, java class files) out of it.
 
 For convenience you can also look into the `gen` folder of each model, which already contains often used  artifacts generated from the model.

--- a/generate.sh
+++ b/generate.sh
@@ -30,11 +30,11 @@
 
 
 # Adjust if SAMM CLI version changes
-JARNAME=samm-cli-2.9.5.jar
+JARNAME=samm-cli-2.9.7.jar
 SAMMFOLDER=.SAMMCLI/
 SAMMCLI=$SAMMFOLDER$JARNAME
 # Adjust if SAMM CLI version changes
-SAMMCLIURL=https://github.com/eclipse-esmf/esmf-sdk/releases/download/v2.9.5/samm-cli-2.9.5.jar
+SAMMCLIURL=https://github.com/eclipse-esmf/esmf-sdk/releases/download/v2.9.7/samm-cli-2.9.7.jar
 
 CATENAXCSS=$SAMMFOLDER/catena-template.css
 CATENAXCUSTOMCSSURL=https://raw.githubusercontent.com/eclipse-tractusx/sldt-semantic-hub/main/backend/src/main/resources/catena-template.css


### PR DESCRIPTION
This PR updates the SAMM CLI from v2.9.5 to v2.9.7.

Remark: Version 2.9.5 contains issues which prevents the validation of shared models in some cases. This is fixed with 2.9.7.