### PR TITLE
Update generate-artifacts.yml

### DIFF
--- a/.github/workflows/generate-artifacts.yml
+++ b/.github/workflows/generate-artifacts.yml
@@ -1,7 +1,7 @@
 #######################################################################
 # Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2024 Catena-X Automotive Network e.V.
-# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/workflows/generate-artifacts.yml
+++ b/.github/workflows/generate-artifacts.yml
@@ -1,5 +1,7 @@
 #######################################################################
 # Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2024 Catena-X Automotive Network e.V.
+# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -40,13 +42,20 @@ jobs:
           java-version: '17'
       - name: Generate artifacts for new models
         run: |
+          artifacts_generated=false
           mapfile -d ',' -t added_modified_files < <(printf '%s,' '${{ steps.changes.outputs.added_modified }}')
           for added_modified_file in "${added_modified_files[@]}"; do
-            echo "Generate model artifacts for ${added_modified_file}."
-            ./generate.sh ${added_modified_file}
-            git add $(dirname "${added_modified_file}")
+            if [[ $added_modified_file == *".ttl" ]]; then
+              echo "Generate model artifacts for ${added_modified_file}."
+              ./generate.sh ${added_modified_file}
+              git add $(dirname "${added_modified_file}")
+              artifacts_generated=true
+            fi
           done
+
+          echo "artifacts_generated=$artifacts_generated" >> $GITHUB_OUTPUT
       - name: Commit new artifacts
+        if: steps.generate_artifacts.outputs.artifacts_generated == 'true'
         run: |
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "username@users.noreply.github.com"

--- a/.github/workflows/generate-artifacts.yml
+++ b/.github/workflows/generate-artifacts.yml
@@ -1,4 +1,4 @@
-#######################################################################
+# ######################################################################
 # Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2024 Catena-X Automotive Network e.V.
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
@@ -6,13 +6,18 @@
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
 #
-# This work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
-# which is available at
-# https://creativecommons.org/licenses/by/4.0/legalcode.
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
 #
-# SPDX-License-Identifier: CC-BY-4.0
-#######################################################################
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ######################################################################
 
 name: Generate Model Artifacts
 


### PR DESCRIPTION
Each PR triggers the *[generate-artifacts.yml](https://github.com/eclipse-tractusx/sldt-semantic-models/blob/main/.github/workflows/generate-artifacts.yml)* workflow. This workflow generates the artefacts (e.g. AASX file) for the respective samm models. However, if a PR does not contain an updated ttl-file (e.g. updating the readme), the workflow fails (see screenshot).

This PR fixes this issue.

> ![image](https://github.com/user-attachments/assets/fcbdda90-51fa-4085-b2ce-7bd237fe6bef)

Closes: #786 

