### PR TITLE
Create re-generate-all-artefacts Workflow

### DIFF
--- a/.github/workflows/re-generate-all-artefacts
+++ b/.github/workflows/re-generate-all-artefacts
@@ -21,7 +21,7 @@
 name: Re-Generate All Artefacts
 
 on:
-  workflow_dispatch: # Nur manuelle Ausführung möglich
+  workflow_dispatch: # Only manual execution possible
 
 jobs:
   generate:

--- a/.github/workflows/re-generate-all-artefacts
+++ b/.github/workflows/re-generate-all-artefacts
@@ -1,0 +1,50 @@
+# ######################################################################
+# Copyright (c) 2025 Catena-X Automotive Network e.V.
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ######################################################################
+
+name: Re-Generate All Artefacts
+
+on:
+  workflow_dispatch: # Nur manuelle Ausführung möglich
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3 # Repository-Inhalt auschecken
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Generate artifacts for new models
+        id: generate_artifacts
+        run: |
+          find "." -type f -name "*.ttl" | while read -r file; do
+            ./generate.sh $file || printf "Artefact generation not possible for: $file \n"
+          done
+      
+      - name: Commit new artifacts
+        run: |
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "username@users.noreply.github.com"
+          git commit -a -m "Adding auto-generated artifacts for new models"
+          git push

--- a/.github/workflows/re-generate-all-artefacts
+++ b/.github/workflows/re-generate-all-artefacts
@@ -21,7 +21,7 @@
 name: Re-Generate All Artefacts
 
 on:
-  workflow_dispatch: # Only manual execution possible
+  workflow_dispatch:
 
 jobs:
   generate:
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3 # Repository-Inhalt auschecken
+        uses: actions/checkout@v3
 
       - uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
This PR adds a new workflow to the SLDT-Semantic-Model repository.

Context: The SAMM CLI is updated regularly. Some of the updates fix issues with the generated artefacts as it was the case between SAMM CLI version 2.6 and 2.9.7 (see: https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7). Since most of the models were generated with version 2.6, these artefacts are not generated according to the specification. All of these artefacts sometimes needs to be updated with the newest SAMM CLI version.

This PR adds a workflow which does exactly that. It re-generates all artefacts for each model, with the newest version (defined in the generate.sh).

Note: This script needs to be triggered manually, as it is only required, when the SAMM CLI is updated within this repository.
