### PR TITLE
Fix (re-generate-all-artefacts.yml): Cover edge cases, where the gen-folder does not exist

### DIFF
--- a/.github/workflows/re-generate-all-artefacts.yml
+++ b/.github/workflows/re-generate-all-artefacts.yml
@@ -36,14 +36,18 @@ jobs:
           distribution: temurin
           java-version: '17'
       - name: Generate artifacts for new models
-        id: generate_artifacts
         run: |
           find "." -type f -name "*.ttl" | while read -r file; do
+            # Create "gen"-folder per model
+            mkdir -p "$(dirname "$file")/gen"
+
+            # Generate artefacts for each model
             ./generate.sh $file || printf "Artefact generation not possible for: $file \n"
           done
       
-      - name: Commit new artifacts
+      - name: Add and commit new artifacts
         run: |
+          git add -A
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "username@users.noreply.github.com"
           git commit -a -m "Adding auto-generated artifacts for new models"


### PR DESCRIPTION
One last fix is required. 

The re-generation of all model artifacts worked completely fine. Unfortunately, I was not aware, that the artifacts won't be committed, if the "gen" folder does not exist in advance - in this case, the artifacts are created successfully, but for some reason not committed.

This PR fixes this.