### PR TITLE
[New Flattened Model] io.catenax.quality_task:2.0.0-FlattenedQualityTask

### DIFF
--- a/io.catenax.quality_task/2.0.0/FlattenedQualityTask.ttl
+++ b/io.catenax.quality_task/2.0.0/FlattenedQualityTask.ttl
@@ -1,0 +1,115 @@
+#######################################################################
+# Copyright (c) 2025 Robert Bosch GmbH
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.quality_task:2.0.0#> .
+
+:FlattenedQualityTask a samm:Aspect ;
+   samm:preferredName "flattenedQualityTasks"@en ;
+   samm:description "Flattened view of quality tasks (qTask). "@en ;
+   samm:properties ( [ samm:property :metaInformationSelectionEnd; samm:payloadName "metaInformation_selectionEnd" ] [ samm:property :metaInformationselectionStart; samm:payloadName "metaInformation_selectionStart" ] [ samm:property :metaInformationSelectionCriteria; samm:payloadName "metaInformation_selectionCriteria" ] [ samm:property :listOfQualityTasksComponent; samm:payloadName "listOfQualityTasks_component" ] [ samm:property :listOfQualityTasksRecordStatus; samm:payloadName "listOfQualityTasks_recordStatus" ] [ samm:property :listOfQualityTasksListOfCompaniesName; samm:payloadName "listOfQualityTasks_listOfCompanies_name" ] [ samm:property :listOfQualityTasksListOfCompaniesEmail; samm:payloadName "listOfQualityTasks_listOfCompanies_email" ] [ samm:property :listOfQualityTasksListOfCompaniesCxBusinessPartnerNumber; samm:payloadName "listOfQualityTasks_listOfCompanies_cxBusinessPartnerNumber" ] [ samm:property :listOfQualityTasksQualityTaskID; samm:payloadName "listOfQualityTasks_qualityTaskId" ] [ samm:property :listOfQualityTasksDescription; samm:payloadName "listOfQualityTasks_description" ] [ samm:property :listOfQualityTasksCreationDate; samm:payloadName "listOfQualityTasks_creationDate" ] [ samm:property :listOfQualityTasksTitle; samm:payloadName "listOfQualityTasks_title" ] [ samm:property :listOfQualityTasksDataDeletion; samm:payloadName "listOfQualityTasks_dataDeletion" ] [ samm:property :listOfQualityTasksStatus; samm:payloadName "listOfQualityTasks_status" ] ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:metaInformationSelectionEnd a samm:Property ;
+   samm:preferredName "metaInformation_selectionEnd"@en ;
+   samm:description "Describes the selection criteria a Catena-X data provider has applied to create this data set."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "2023-12-31T23:59:59" .
+
+:metaInformationselectionStart a samm:Property ;
+   samm:preferredName "metaInformation_selectionStart"@en ;
+   samm:description "Describes the starting point for providing records in this data set."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "2023-01-01T00:00:00" .
+
+:metaInformationSelectionCriteria a samm:Property ;
+   samm:preferredName "metaInformation_selectionCriteria"@en ;
+   samm:description "Describes the selection criteria a Catena-X data provider has applied to create this data set."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A list of all open quality tasks between company A and company B" .
+
+:listOfQualityTasksComponent a samm:Property ;
+   samm:preferredName "listOfQualityTasks_component"@en ;
+   samm:description "The component that should be investigated in this qTask."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "componentA" .
+
+:listOfQualityTasksRecordStatus a samm:Property ;
+   samm:preferredName "listOfQualityTasks_recordStatus"@en ;
+   samm:description "The record operation enumeration can be used to realize delta update concept.\nDelta update concept means:\n- You transfer an initial load of data\n- After the first week only the delta to the initial load is transferred\n\n\nThe record status describes whether this record is:\n- new=>This record is transferred the first time\n- update=> Some properties of this record have changed compared to a previous transfer\n- delete=> This record was transferred in the initial load or in a previous delta update, but is not \nused any more and therefore it should be deleted on data consumer side\n- same=> This record was transferred in the initial load or in a previous delta update"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "new" .
+
+:listOfQualityTasksListOfCompaniesName a samm:Property ;
+   samm:preferredName "listOfQualityTasks_listOfCompanies_name"@en ;
+   samm:description "Name of the company"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "copmanyA" .
+
+:listOfQualityTasksListOfCompaniesEmail a samm:Property ;
+   samm:preferredName "listOfQualityTasks_listOfCompanies_email"@en ;
+   samm:description "An email address."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "test.mail@example.com" .
+
+:listOfQualityTasksListOfCompaniesCxBusinessPartnerNumber a samm:Property ;
+   samm:preferredName "listOfQualityTasks_listOfCompanies_cxBusinessPartnerNumber"@en ;
+   samm:description "The Catena-X business partner number for this company."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BPNL000000000123" .
+
+:listOfQualityTasksQualityTaskID a samm:Property ;
+   samm:preferredName "listOfQualityTasks_qualityTaskId"@en ;
+   samm:description "A unique quality task identifier within the Catena-X dataspace. The unique id uses the Catena-X UUID trait."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "430f556d3-1234-1234-1234-abc123456789" .
+
+:listOfQualityTasksDescription a samm:Property ;
+   samm:preferredName "listOfQualityTasks_description"@en ;
+   samm:description "Description what should be done in this qTask"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "please evaluate why there is high number of customer complaints with ComponentA if the vehicle is between 10000-30000km." .
+
+:listOfQualityTasksCreationDate a samm:Property ;
+   samm:preferredName "listOfQualityTasks_creationDate"@en ;
+   samm:description "Timestamp when this qTask was created"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "2022-11-11" .
+
+:listOfQualityTasksTitle a samm:Property ;
+   samm:preferredName "listOfQualityTasks_title"@en ;
+   samm:description "Working title for this qTask"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Evaluation of ComponentA in CarmodelB in country DE." .
+
+:listOfQualityTasksDataDeletion a samm:Property ;
+   samm:preferredName "listOfQualityTasks_dataDeletion"@en ;
+   samm:description "What should be done with the data after this qTask is closed"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "delete-data-after-closing" .
+
+:listOfQualityTasksStatus a samm:Property ;
+   samm:preferredName "listOfQualityTasks_status"@en ;
+   samm:description "Status of this quality task"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "new" .
+

--- a/io.catenax.quality_task/RELEASE_NOTES.md
+++ b/io.catenax.quality_task/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ This aspect model was created in the Catena-X use case quality. The purpose of t
 - integration of the shared BPNL trait
 - integration of shared e-Mail trait
 - using of Catena-X UUID as qualityTaskId
+- Added FlattenedQualityTask model. This model is nothing but a flattened view of QualityTask aspect model. No business or any kind of changes introduced in this model. This flattened model is referenced in the Industry core KITS documentation for Parquet file transfer.
 
 ### Changed
 - qTask aspect model is now able to held also lists of qTasks


### PR DESCRIPTION
## Description
Added FlattenedQualityTask model. This model is nothing but a flattened view of QualityTask aspect model. No business or any kind of changes introduced in this model. This flattened model is referenced in the Industry core KITS documentation for Parquet file transfer.

 -->

Closes #762 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
