### PR TITLE
[Update Model] io.catenax.generic.digital_product_passport:6.0.0#

### DIFF
--- a/io.catenax.generic.digital_product_passport/6.0.0/DigitalProductPassport.ttl
+++ b/io.catenax.generic.digital_product_passport/6.0.0/DigitalProductPassport.ttl
@@ -1,0 +1,1206 @@
+#######################################################################
+# Copyright (c) 2023 BASF Coatings GmbH
+# Copyright (c) 2023 BMW AG
+# Copyright (c) 2023 CGI Deutschland B.V. & Co. KG
+# Copyright (c) 2023 Henkel AG & Co. KGaA
+# Copyright (c) 2023 SAP Deutschland SE & Co.KG
+# Copyright (c) 2023 T-Systems International GmbH
+# Copyright (c) 2023 ZF Friedrichshafen AG
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.generic.digital_product_passport:6.0.0#> .
+@prefix ext-batch: <urn:samm:io.catenax.batch:3.0.0#> .
+@prefix ext-classification: <urn:samm:io.catenax.shared.part_classification:1.0.0#> .
+@prefix ext-information: <urn:samm:io.catenax.part_type_information:1.0.0#> .
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:2.0.0#> .
+@prefix ext-part: <urn:samm:io.catenax.serial_part:3.0.0#> .
+@prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:2.0.0#> .
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
+
+:DigitalProductPassport a samm:Aspect ;
+   samm:preferredName "Digital Product Passport"@en ;
+   samm:description "The Digital Product Passport (DPP) allows to share process and product-related information amongst supply chain businesses, authorities and consumers. The DPP allows for efficient information flows following best practices; and the possibility of accompanying the measures under this Regulation with mitigating measures so that impacts are expected to remain proportionate for SMEs.This is expected to increase transparency, both for supply chain businesses and for the general public, and increase efficiencies in terms of information transfer to support the data exchange between economic actors in integrating circularity in product design and manufacturing.\nIn particular, it is likely to help facilitate and streamline the monitoring and enforcement of the regulation carried out by EU and Member State authorities. It is also likely to provide a market-intelligence tool that may be used for revising and refining obligations in the future.\nThe DPP includes data about components, materials and chemical substances, information on reparability, spare parts, environmental impact and professional disposal for a product.\nThe data model will be updated, as newer versions of the regulation will be published.\nThe main basis is provided by the document \"Proposal for a REGULATION OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL establishing a framework for setting ecodesign requirements for sustainable products and repealing Directive 2009/125/EC\" from March 30th, 2022. The latest version of the document was the provisional agreement between the EU Council and the Parliament from January 9th, 2024. The text is informal, but the content of the final regulation was agreed between these two institutions.\nThe Title of Ecodesign Regulation has been changed to: Proposal for a REGULATION OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL establishing a framework for setting ecodesign requirements for sustainable products, amending Regulation (EU) 2023/1542 and repealing Directive 2009/125/EC."@en ;
+   samm:see <https://data.consilium.europa.eu/doc/document/ST-9014-2023-INIT/en/pdf> ;
+   samm:see <https://commission.europa.eu/energy-climate-change-environment/standards-tools-and-labels/products-labelling-rules-and-requirements/sustainable-products/ecodesign-sustainable-products_en> ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52022PC0142> ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CONSIL:ST_5147_2024_INIT> ;
+   samm:properties ( :metadata :identification :operation :handling :characteristics :commercial :materials :sustainability :sources [ samm:property :additionalData; samm:optional true ] ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:metadata a samm:Property ;
+   samm:preferredName "Metadata"@en ;
+   samm:description "Metadata of the product passport. These are mentioned in the ESPR proposal from March 30th, 2022 and some changed by the provisional agreement from January 9th, 2024."@en ;
+   samm:characteristic :MetadataCharacteristic .
+
+:identification a samm:Property ;
+   samm:preferredName "Identification"@en ;
+   samm:description "Identification information of the product, especially identifiers and codes. These are mentioned in the ESPR provisional agreement from January 9th, 2024 ANNEX III:\n(b) the unique product identifier at the level indicated in the applicable delegated act adopted pursuant to Article 4.\nAdditionally in Article 9 regarding general requirements for the product passport is stated that:\nA product passport shall meet the following conditions:\n(a) it shall be connected through a data carrier to a persistent unique product identifier;\n(e) the information included in the product passport shall refer to the product model, batch, or item as specified in the delegated act adopted pursuant to Article 4.\nArticle 2 Definitions: \n(31) 'unique product identifier' means a unique string of characters for the identification of products that also enables a web link to the product passport;\nRecital (27): A 'model' usually means a version of a product of which all units share the same technical characteristics relevant for the ecodesign requirements and the same model identifier, a 'batch' usually means a subset of a specific model composed of all products produced in a specific manufacturing plant at a specific moment in time and an 'item' usually means a single unit of a model."@en ;
+   samm:characteristic :IdentificationCharacteristic .
+
+:operation a samm:Property ;
+   samm:preferredName "Operation"@en ;
+   samm:description "Operational information of the product."@en ;
+   samm:characteristic :OperationCharacteristic .
+
+:handling a samm:Property ;
+   samm:preferredName "handling"@en ;
+   samm:description "Properties connected with the handling of the product."@en ;
+   samm:characteristic :HandlingCharacteristic .
+
+:characteristics a samm:Property ;
+   samm:preferredName "Characteristics"@en ;
+   samm:description "Defines specific characteristics of a product."@en ;
+   samm:characteristic :ProductCharacteristics .
+
+:commercial a samm:Property ;
+   samm:preferredName "Commercial"@en ;
+   samm:description "Commercial information of the product."@en ;
+   samm:characteristic :CommercialCharacteristic .
+
+:materials a samm:Property ;
+   samm:preferredName "Materials"@en ;
+   samm:description "Properties which are relevant for the materials of the product."@en ;
+   samm:characteristic :MaterialsCharacteristic .
+
+:sustainability a samm:Property ;
+   samm:preferredName "Sustainability"@en ;
+   samm:description "Sustainability related attributes."@en ;
+   samm:characteristic :SustainabilityCharacteristic .
+
+:sources a samm:Property ;
+   samm:preferredName "Sources"@en ;
+   samm:description "Documents that are mandatory if applicable for the product. These are mentioned in the ESPR provisional agreement from January 9th, 2024 ANNEX III:\n(e) compliance documentation and information required under this Regulation or other Union law applicable to the product, such as the declaration of conformity, technical documentation or conformity certificates;\n(f) user manuals, instructions, warnings or safety information, as required by other Union legislation applicable to the product.\nAdditionally requirements are mentioned in Article 21:\n7. Manufacturers shall ensure that a product covered by a delegated act adopted pursuant to Article 4 is accompanied by instructions in digital format that enable customers and other relevant actors to assemble, install, operate, store, maintain, repair and dispose of the product in a language that can be easily understood, as determined by the Member State concerned. Such instructions shall be clear, understandable and legible and include at least the information set out in Article 7(2), point (b), point (ii) specified in the delegated acts adopted pursuant to Article 4.\nArticle 7 states additionally:\n(ii) information for customers and other actors on how to install, use, maintain and repair the product, in order to minimise its impact on the environment and to ensure optimum durability, on how to install third-party operating systems where relevant, as well as on collection for refurbishment or remanufacture, and on how to return or handle the product at the end of its life;\n(2) (b) (iii) information for treatment facilities on disassembly, reuse, refurbishment, recycling, or disposal at end-of-life;\n(2) (b) (iv) other information that may influence sustainable product choices for customers and the way the product is handled by parties other than the manufacturer in order to facilitate appropriate use, value retaining operations and correct treatment at end-of-life.\n(5) (d) relevant instructions for the safe use of the product.\n(5) (e) information relevant for disassembly, preparation for reuse, reuse, recycling and the environmentally sound management of the product at the end of its life.\nAnnex I:\n(b) [...] availability of repair and maintenance instructions, number of materials and components used, use of standard components,[...] number and complexity of processes and whether specialised toolsare needed, ease of non-destructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed;\n(c) ease of upgrading, re-use, remanufacturing and refurbishment as expressed through: [...] number and complexity of processes and tools needed, ease of non-destructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed, conditions of access to test protocols or not commonly available testing equipment, availability of guarantees specific to remanufactured or refurbished products, conditions for access to or use of technologies protected by intellectual property rights, modularity;\n(d) design for recycling, ease and quality of recycling as expressed through: use of easily recyclable materials, safe, easy and non-destructive access to recyclable components and materials or components and materials containing hazardous substances and material composition and homogeneity, possibility for high-purity sorting, [...] number and complexity of processes and tools needed, ease of nondestructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed;\n(q) functional performance and conditions for use including as expressed through ability in performing its intended use, precautions of use, skills required, compatibility with other products or systems.\nAdditionally to consider are guidelines and instructions regarding the proper management and disposal of packaging materials after use. This can include instructions for separation, reuse, and recycling."@en ;
+   samm:characteristic :SourceList .
+
+:additionalData a samm:Property ;
+   samm:preferredName "Additional Data"@en ;
+   samm:description "Data in form of open fields which need to be transferred in addition. The regulation is still under development and may change in the future. To accommodate this, additional data allows the option to include additional data required by future changes to the regulation. In addition, the DPP can be easily updated and adapted to the new requirements. \nThe ESPR provisional agreement from January 9th, 2024 Article 9 mentions:\n2. Where other Union legislation requires or allows the inclusion of specific information in the product passport, that information may be included in the product passport pursuant to the applicable delegated act adopted pursuant to Article 4."@en ;
+   samm:characteristic :AdditionalDataList .
+
+:MetadataCharacteristic a samm:Characteristic ;
+   samm:preferredName "Metadata Characteristic"@en ;
+   samm:description "Characteristic for the passport metadata of the digital product passport."@en ;
+   samm:dataType :MetadataEntity .
+
+:IdentificationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Identification Characteristic"@en ;
+   samm:description "Identification information of the product."@en ;
+   samm:dataType :IdentificationEntity .
+
+:OperationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Operation Characteristic"@en ;
+   samm:description "Operational information of the product."@en ;
+   samm:dataType :OperationEntity .
+
+:HandlingCharacteristic a samm:Characteristic ;
+   samm:preferredName "Handling Characteristic"@en ;
+   samm:description "Characteristic to describe aspects which are connected with the handling of the product."@en ;
+   samm:dataType :HandlingEntity .
+
+:ProductCharacteristics a samm:Characteristic ;
+   samm:preferredName "Product Characteristics"@en ;
+   samm:description "Defines a set of specific characteristics of a product."@en ;
+   samm:dataType :CharacteristicsEntity .
+
+:CommercialCharacteristic a samm:Characteristic ;
+   samm:preferredName "Commercial Characteristic"@en ;
+   samm:description "Commercial information of the product."@en ;
+   samm:dataType :CommercialEntity .
+
+:MaterialsCharacteristic a samm:Characteristic ;
+   samm:preferredName "Materials Characteristic"@en ;
+   samm:description "Materials Characteristic on product level."@en ;
+   samm:dataType :MaterialsEntity .
+
+:SustainabilityCharacteristic a samm:Characteristic ;
+   samm:preferredName "Sustainability Characteristic"@en ;
+   samm:description "Characteristic which describes relevant information for the sustainability of the product."@en ;
+   samm:dataType :SustainabilityEntity .
+
+:SourceList a samm-c:List ;
+   samm:preferredName "Source List"@en ;
+   samm:description "A list of documents."@en ;
+   samm:dataType :DocumentEntity .
+
+:AdditionalDataList a samm-c:List ;
+   samm:preferredName "Additional Data List"@en ;
+   samm:description "List of additional data."@en ;
+   samm:dataType :AdditionalDataEntity .
+
+:MetadataEntity a samm:Entity ;
+   samm:preferredName "Metadata Entity"@en ;
+   samm:description "Passport Entity to describe version, status, end and issue date."@en ;
+   samm:properties ( :version [ samm:property :status; samm:optional true ] :expirationDate :issueDate :economicOperatorId :passportIdentifier :predecessor :backupReference [ samm:property :registrationIdentifier; samm:optional true ] [ samm:property :lastModification; samm:optional true ] :language ) .
+
+:IdentificationEntity a samm:Entity ;
+   samm:preferredName "Identification Entity"@en ;
+   samm:description "Entity with identification information of the product with part type information, local identifiers, other codes and the data carrier."@en ;
+   samm:properties ( [ samm:property :serialInformation; samm:optional true; samm:payloadName "serial" ] [ samm:property :batchInformation; samm:optional true; samm:payloadName "batch" ] [ samm:property :partTypeInformation; samm:payloadName "type" ] :codes :dataCarrier [ samm:property ext-classification:partClassification; samm:payloadName "classification" ] ) .
+
+:OperationEntity a samm:Entity ;
+   samm:preferredName "Operation Entity"@en ;
+   samm:description "Operational information of the product such as the owner, manufacturer and importer."@en ;
+   samm:properties ( :manufacturer :import [ samm:property :otherOperators; samm:optional true; samm:payloadName "other" ] ) .
+
+:HandlingEntity a samm:Entity ;
+   samm:preferredName "Handling Entity"@en ;
+   samm:description "Entity to describe different aspects in relation with the handling of the product with attributes if applicable to the product."@en ;
+   samm:properties ( [ samm:property :spareParts; samm:payloadName "content" ] :applicable ) .
+
+:CharacteristicsEntity a samm:Entity ;
+   samm:preferredName "Characteristics Entity"@en ;
+   samm:description "Entity which defines specific characteristics of a product such as different life spans and physical dimensions."@en ;
+   samm:properties ( :lifespan :physicalDimension [ samm:property :physicalState; samm:optional true ] [ samm:property :generalPerformanceClass; samm:optional true ] ) .
+
+:CommercialEntity a samm:Entity ;
+   samm:preferredName "Commercial Entity"@en ;
+   samm:description "Commercial information."@en ;
+   samm:properties ( [ samm:property :placedOnMarket; samm:optional true ] :purpose [ samm:property :purchaseOrder; samm:optional true ] :recallInformation ) .
+
+:MaterialsEntity a samm:Entity ;
+   samm:preferredName "Materials Entity"@en ;
+   samm:description "Entity with materials on the level of the product."@en ;
+   samm:properties ( :substancesOfConcern :materialComposition ) .
+
+:SustainabilityEntity a samm:Entity ;
+   samm:preferredName "Sustainability Entity"@en ;
+   samm:description "Entity with the properties regarding the sustainability of the product."@en ;
+   samm:properties ( [ samm:property :state; samm:payloadName "status" ] :productFootprint [ samm:property :reparabilityScore; samm:optional true ] [ samm:property :durabilityScore; samm:optional true ] ) .
+
+:DocumentEntity a samm:Entity ;
+   samm:preferredName "Document Entity"@en ;
+   samm:description "Document entity with header, content, category and type."@en ;
+   samm:properties ( :content :category [ samm:property :contentType; samm:payloadName "type" ] :header ) .
+
+:AdditionalDataEntity a samm:Entity ;
+   samm:preferredName "Additional Data Entity"@en ;
+   samm:description "Entity with additional data. Properties are label, description, type, data and children. Either the fields data or children filled. Children constructs a hierarchy with the same attributes. Data is filled as the end of an path/leaf."@en ;
+   samm:properties ( :label :description :type [ samm:property :data; samm:optional true ] [ samm:property :children; samm:optional true ] ) .
+
+:version a samm:Property ;
+   samm:preferredName "Version"@en ;
+   samm:description "The current version of the product passport. The possibility of modification/ updating the product passport needs to include versioning of the dataset. This attribute is an internal versioning from the passport issuer. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(1) [...] The information in the product passport shall be accurate, complete, and up to date."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "1.0.0" .
+
+:status a samm:Property ;
+   samm:preferredName "Status"@en ;
+   samm:description "The current status of the product passport declared through either: draft, approved, invalid or expired."@en ;
+   samm:characteristic :StatusEnumeration ;
+   samm:exampleValue "draft" .
+
+:expirationDate a samm:Property ;
+   samm:preferredName "Expiration Date"@en ;
+   samm:description "The timestamp in the format (yyyy-mm-dd) for the product passport until when it is available or a comment describing this period. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(2) (h) the period during which the product passport is to remain available, which shall correspond to at least the expected lifetime of a specific product."@en ;
+   samm:characteristic :DateTrait ;
+   samm:exampleValue "2030-01-01" .
+
+:issueDate a samm:Property ;
+   samm:preferredName "Issue Date"@en ;
+   samm:description "The timestamp in the format (yyyy-mm-dd) since when the product passport is available."@en ;
+   samm:characteristic :DateTrait ;
+   samm:exampleValue "2000-01-01" .
+
+:economicOperatorId a samm:Property ;
+   samm:preferredName "Economic Operator Id"@en ;
+   samm:description "The identification of the owner/economic operator of the passport. Proposed, according to ISO 15459, is the CIN (company identification code). Other identification numbers like the tax identification number, value added tax identification number, commercial register number and the like are also valid entries. In the Catena-X network, the BPNL is used for the identification of companies and the information stored like contact information and addresses. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex III:\n(k) the [...] unique operator identifier code of the economic operator established in the Union responsible for carrying out the tasks set out in Article 4 of Regulation (EU) 2019/1020, or Article 15 of Regulation (EU) on general product safety, or similar tasks pursuant to other EU legislation applicable to the product."@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL0123456789ZZ" .
+
+:passportIdentifier a samm:Property ;
+   samm:preferredName "Passport Identifier"@en ;
+   samm:description "The identifier of the product passport, which is an uuidv4."@en ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
+   samm:exampleValue "urn:uuid:550e8400-e29b-41d4-a716-446655440000" .
+
+:predecessor a samm:Property ;
+   samm:preferredName "Predecessor"@en ;
+   samm:description "Identification of the preceding product passport. If there is no preceding passport, input a dummy value. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(2)(g) [...] Any new product passport shall be linked to the product passport or passports of the original product whenever appropriate."@en ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
+   samm:exampleValue "urn:uuid:00000000-0000-0000-0000-000000000000" .
+
+:backupReference a samm:Property ;
+   samm:preferredName "Backup Reference"@en ;
+   samm:description "A reference to the data backup of the passport. This mandatory attribute will be further defined in the future. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex III:\n(kb) the reference of the certified independent third-party product passport service provider hosting the back-up copy of the product passport.\nArticle 10 also mentions:\n(c) the data included in the product passport shall be stored by the economic operator responsible for its creation or by certified independent third-party product passport service providers authorised to act on their behalf."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "https://dummy.link" .
+
+:registrationIdentifier a samm:Property ;
+   samm:preferredName "Registration Identifier"@en ;
+   samm:description "Identifier in the respective registry. This will be further defined in the future. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 in Article 12:\nBy [2 years from entering into force of this Regulation], the Commission shall set up and manage a digital registry (\"the registry\") storing in a secure manner at least the unique product identifier, the unique operator identifier, the unique facility identifiers. In case of products intended to be placed under the customs procedure 'release for free circulation', the registry shall also store the product commodity code. The registry shall also store the batteries' unique identifiers referred to in Article 77(3) of Regulation (EU) 2023/1542."@en ;
+   samm:characteristic :IdentifierCharacteristic ;
+   samm:exampleValue "https://dummy.link/ID8283746239078" .
+
+:lastModification a samm:Property ;
+   samm:preferredName "Last Modification"@en ;
+   samm:description "Date of the latest modification."@en ;
+   samm:characteristic :DateTrait ;
+   samm:exampleValue "2000-01-01" .
+
+:language a samm:Property ;
+   samm:preferredName "Language"@en ;
+   samm:description "Specific language in which the passport content is created. Language code is based on the ISO 639-1."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "EN" .
+
+:serialInformation a samm:Property ;
+   samm:preferredName "Serial Information"@en ;
+   samm:description "Identifier for a serial part if available. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Recital (27):\n[...] an 'item' usually means a single unit of a model."@en ;
+   samm:characteristic ext-part:LocalIdentifierCharacteristic .
+
+:batchInformation a samm:Property ;
+   samm:preferredName "Batch Information"@en ;
+   samm:description "Identifier for a batch part if available. Identifier for a serial part if available. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Recital (27):\n[...] a 'batch' usually means a subset of a specific model composed of all products produced in a specific manufacturing plant at a specific moment in time [...]."@en ;
+   samm:characteristic ext-batch:LocalIdentifierCharacteristic .
+
+:partTypeInformation a samm:Property ;
+   samm:preferredName "Part Type Information"@en ;
+   samm:description "Identifier on the level of a part model or type. Identifier for a serial part if available. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Recital (27):\n[...] A 'model' usually means a version of a product of which all units share the same technical characteristics relevant for the ecodesign requirements and the same model identifier [...]."@en ;
+   samm:characteristic :PartTypeCharacteristic .
+
+:codes a samm:Property ;
+   samm:preferredName "Codes"@en ;
+   samm:description "Codes for identification."@en ;
+   samm:characteristic :CodeList .
+
+:dataCarrier a samm:Property ;
+   samm:preferredName "Data Carrier"@en ;
+   samm:description "The type and layout of the data carrier on the product. These are mentioned in the ESPR proposal from March 30th, 2022 Article 8:\n(b) the types of data carrier to be used;\n(c) the layout in which the data carrier shall be presented and its positioning;\nArticle 2 defines:\n(30) 'data carrier' means a linear bar code symbol, a two-dimensional symbol or other automatic identification data capture medium that can be read by a device."@en ;
+   samm:characteristic :DataCarrierCharacteristic .
+
+:manufacturer a samm:Property ;
+   samm:preferredName "Manufacturer"@en ;
+   samm:description "Manufacturing information of the product. In the CATENA-X use case, the BPNL and BPNA can be stated. These attributes are mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(h) unique operator identifiers other than that of the manufacturer;\n(k) the name, contact details and unique operator identifier code of the economic operator established in the Union responsible for carrying out the tasks set out in Article 4 of Regulation (EU) 2019/1020, or Article 15 of Regulation (EU) [.../...] on general product safety, or similar tasks pursuant to other EU legislation applicable to the product."@en ;
+   samm:characteristic :ManufacturerCharacteristic .
+
+:import a samm:Property ;
+   samm:preferredName "Import"@en ;
+   samm:description "Importer details such as the identification."@en ;
+   samm:characteristic :ImportCharacteristic .
+
+:otherOperators a samm:Property ;
+   samm:preferredName "Other Operators"@en ;
+   samm:description "Other operators relevant for the product."@en ;
+   samm:characteristic :OperatorCharacteristic .
+
+:spareParts a samm:Property ;
+   samm:preferredName "spareParts"@en ;
+   samm:description "The list of spare parts available for the product from various suppliers."@en ;
+   samm:characteristic :SparePart .
+
+:applicable a samm:Property ;
+   samm:preferredName "Applicable"@en ;
+   samm:description "Check whether the connected attributes are applicable to the product. If it is not applicable (false), dummy data can be delivered."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:lifespan a samm:Property ;
+   samm:preferredName "Lifespan"@en ;
+   samm:description "The type of lifespan represented with the values guaranteed lifetime, technical lifetime and mean time between failures. Both can be described through the attributes: type, which defines the type such as guaranteed lifetime or technical lifetime, the unit for the lifetime, and the value represented by an integer. These attributes are mentioned in the ESPR proposal from March 30th, 2022 ANNEX I:\n(a) durability and reliability of the product or its components as expressed through the products guaranteed lifetime, technical lifetime [or] mean time between failures [...]."@en ;
+   samm:characteristic :LifespanList .
+
+:physicalDimension a samm:Property ;
+   samm:preferredName "Physical Dimension"@en ;
+   samm:description "Physical dimensions are properties  associated with physical quantities for purposes of classification or differentiation. These attributes are mentioned in the ESPR provisional agreement from January 9th, Article 7:\n(2) (b) (i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I;\nAnnex I (i) weight and volume of the product and its packaging, and the product-to-packaging ratio."@en ;
+   samm:characteristic :PhysicalDimensionCharacteristic .
+
+:physicalState a samm:Property ;
+   samm:preferredName "Physical State"@en ;
+   samm:description "The physical state of the item. There are four states of matter solid, liquid, gas and plasma which can be chosen from an enumeration."@en ;
+   samm:characteristic :PhysicalStateEnumeration ;
+   samm:exampleValue "solid" .
+
+:generalPerformanceClass a samm:Property ;
+   samm:preferredName "General Performance Class"@en ;
+   samm:description "The performance class of the product. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n4. When establishing the information requirements referred to in paragraph 2, point (b), point (i), the Commission shall, as appropriate in view of the specificity of the product group, determine classes of performance. Classes of performance may be based on single parameters, on aggregated scores, in absolute terms or in any other form that enables potential customers to choose the best performing products. Those classes of performance shall correspond to significant improvements in performance levels. Where classes of performance are based on parameters in relation to which performance requirements are established, they shall use as the minimum level the minimum performance required at the time when the classes of performance start to apply.\nDefinition:\n'class of performance': means a range of performance levels in relation to one or more product parameters referred to in Annex I, based on a common methodology for the product or product group, ordered into successive steps to allow for product differentiation."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A" .
+
+:placedOnMarket a samm:Property ;
+   samm:preferredName "Placed on Market"@en ;
+   samm:description "The timestamp in the format (yyyy-mm-dd) with or without time zone when the product was put in the market."@en ;
+   samm:characteristic :DateTrait ;
+   samm:exampleValue "2000-01-01" .
+
+:purpose a samm:Property ;
+   samm:preferredName "Purpose"@en ;
+   samm:description "One or more intended industry/industries of the product described by the digital product passport. If exchanged via Catena-X, 'automotive ' is a must choice included in the list."@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "automotive" .
+
+:purchaseOrder a samm:Property ;
+   samm:preferredName "Purchase Order"@en ;
+   samm:description "A unique identifier assigned to the order of the product for tracking purposes between supplier and customer."@en ;
+   samm:characteristic samm-c:Text .
+
+:recallInformation a samm:Property ;
+   samm:preferredName "Recall Information"@en ;
+   samm:description "Information regarding the recall of the product.\nRegulation (EU) 2023/988 of the European Parliament and of the Council of 10 May 2023 on general product safety, amending Regulation (EU) No 1025/2012 of the European Parliament and of the Council and Directive (EU) 2020/1828 of the European Parliament and the Council, and repealing Directive 2001/95/EC of the European Parliament and of the Council and Council Directive 87/357/EEC\n\nArticle 9 (Obligations of manufacturers)\n8.   Where a manufacturer considers or has reason to believe, on the basis of the information in that manufacturer’s possession, that a product which it has placed on the market is a dangerous product, the manufacturer shall immediately:\n(a) take the corrective measures necessary to bring in an effective manner the product into conformity, including a withdrawal or recall, as appropriate;\n(b) inform consumers thereof, in accordance with Article 35 or 36, or both; and\n(c) inform, through the Safety Business Gateway, the market surveillance authorities of the Member States in which the product has been made available on the market thereof.\nFor the purposes of points (b) and (c) of the first subparagraph, the manufacturer shall give details, in particular, of the risk to the health and safety of consumers and of any corrective measure already taken, and, if available, of the quantity, by Member State, of products still circulating on the market."@en ;
+   samm:characteristic :RecallInformationCharacteristic .
+
+:substancesOfConcern a samm:Property ;
+   samm:preferredName "Substances of Concern"@en ;
+   samm:description "Information regarding substances of concern in the product. The ESPR provisional agreement from January 9th, 2024 defines:\n(52) 'hazardous substance' means a substance classified as hazardous pursuant to Article 3 of Regulation (EC) No 1272/2008."@en ;
+   samm:characteristic :SubstanceOfConcernCharacteristic .
+
+:materialComposition a samm:Property ;
+   samm:preferredName "Material Composition"@en ;
+   samm:description "Material composition of the product with information on recycled and renewable materials."@en ;
+   samm:characteristic :MaterialCharacteristic .
+
+:state a samm:Property ;
+   samm:preferredName "State"@en ;
+   samm:description "The status of the product (original, repurposed, re-used, remanufactured or waste) to indicated, whether it is a used product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(j) incorporation of used components."@en ;
+   samm:characteristic :StateEnumeration ;
+   samm:exampleValue "original" .
+
+:productFootprint a samm:Property ;
+   samm:preferredName "Product Footprint"@en ;
+   samm:description "The carbon and environmental footprint or material footprint of the product. These attributes are mentioned in the ESPR provisional agreement from January 9th 2024 Annex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories;\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product;\nAll are defined by Article 2:\n(23) 'environmental footprint' means a quantification of product environmental impacts throughout its life cycle, whether in relation to a single environmental impact category or an aggregated set of impact categories based on the Product Environmental Footprint method or other scientific methods developed by international organisations and widely tested in collaboration with different industry sectors and adopted or implemented by the Commission in other Union \nlegislation;\n(25) 'carbon footprint' means the sum of greenhouse gas (GHG) emissions and GHG removals in a product system, expressed as CO2 equivalents and based on a life cycle assessment using the single impact category of climate change.\n(25a) 'material footprint' refers to the total amount of raw materials extracted to meet final consumption demands;"@en ;
+   samm:characteristic :ProductFootprintCharacteristic .
+
+:reparabilityScore a samm:Property ;
+   samm:preferredName "Reparability Score"@en ;
+   samm:description "The reparability score. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n(b) as appropriate, also require products to be accompanied by:\n(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability [...]."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "B" .
+
+:durabilityScore a samm:Property ;
+   samm:preferredName "Durability Score"@en ;
+   samm:description "The durability score. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n(b) as appropriate, also require products to be accompanied by:\n(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability [...]."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A" .
+
+:content a samm:Property ;
+   samm:preferredName "Content"@en ;
+   samm:description "The content of the document e.g a link."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "https://dummy.link" .
+
+:category a samm:Property ;
+   samm:preferredName "Category"@en ;
+   samm:description "The category in which the document can be sorted. These are mentioned in the ESPR proposal from March 30th, 2022 ANNEX III:\n(e) compliance documentation and information required under this Regulation or other Union law applicable to the product, such as the declaration of conformity, technical documentation or conformity certificates;\nANNEX IV states additional information regarding the content of the technical documentation\nFurther information on documents are mentioned in the proposal from March 30th, 2022 ANNEX III:\n(f) user manuals, instructions, warnings or safety information, as required by other Union legislation applicable to the product.\nAdditionally requirements are mentioned in Article 21:\n(7) Manufacturers shall ensure that that a product covered by a delegated act adopted pursuant to Article 4 is accompanied by instructions that enable consumers and other end-users to safely assemble, install, operate, store, maintain, repair and dispose of the product in a language that can be easily understood by consumers and other end-users, as determined by the Member State concerned. Such instructions shall be clear, understandable and legible and include at least the information specified in the delegated acts adopted pursuant to Article 4 and pursuant to Article 7(2)(b), point (ii).\nArticle 7 states additionally:\n(2) (b) (ii) information for consumers and other end-users on how to install, use, maintain and repair the product in order to minimize its impact on the environment and to ensure optimum durability, as well as on how to return or dispose of the product at end-of-life;\n(2) (b) (iii) information for treatment facilities on disassembly, recycling, or disposal at end-of-life;\n(2) (b) (iv) other information that may influence the way the product is handled by parties other than the manufacturer in order to improve performance in relation to product parameters referred to in Annex I.\n(5) (d) relevant instructions for the safe use of the product."@en ;
+   samm:characteristic :SourceCategoryEnumeration ;
+   samm:exampleValue "Legal Information" .
+
+:contentType a samm:Property ;
+   samm:preferredName "Content Type"@en ;
+   samm:description "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "URL" .
+
+:header a samm:Property ;
+   samm:preferredName "Header"@en ;
+   samm:description "The header as a short description of the document with a maximum of 100 characters."@en ;
+   samm:characteristic :HeaderTrait ;
+   samm:exampleValue "Example Document XYZ" .
+
+:label a samm:Property ;
+   samm:preferredName "Label"@en ;
+   samm:description "The human readable name of the attribute."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Maximum permitted battery power" .
+
+:description a samm:Property ;
+   samm:preferredName "Description"@en ;
+   samm:description "The description of the attribute context."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Description of an attribute" .
+
+:type a samm:Property ;
+   samm:preferredName "Type"@en ;
+   samm:description "The complex description of the type."@en ;
+   samm:characteristic :TypeCharacteristic .
+
+:data a samm:Property ;
+   samm:preferredName "Data"@en ;
+   samm:description "The content from the attribute which is a depended of the data type and typeUnit."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "23" .
+
+:children a samm:Property ;
+   samm:preferredName "children"@en ;
+   samm:description "Children of the hierarchy."@en ;
+   samm:characteristic :AdditionalDataList .
+
+:StatusEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Status Enumeration"@en ;
+   samm:description "The current status of the product passport declared through either: draft, approved, invalid or expired."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "draft" "approved" "invalid" "expired" ) .
+
+:DateTrait a samm-c:Trait ;
+   samm:preferredName "Date Trait"@en ;
+   samm:description "Trait for valid traits.."@en ;
+   samm-c:baseCharacteristic samm-c:Text ;
+   samm-c:constraint :DateConstraint .
+
+:IdentifierCharacteristic a samm:Characteristic ;
+   samm:preferredName "Identifier Characteristic"@en ;
+   samm:description "Characteristic for Identifiers."@en ;
+   samm:dataType xsd:string .
+
+:PartTypeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Part Type Characteristic"@en ;
+   samm:description "Characteristic for the part type."@en ;
+   samm:dataType :PartTypeEntity .
+
+:CodeList a samm-c:List ;
+   samm:preferredName "Code List"@en ;
+   samm:description "A list of additional codes."@en ;
+   samm:dataType :CodeEntity .
+
+:DataCarrierCharacteristic a samm:Characteristic ;
+   samm:preferredName "Data Carrier Characteristic"@en ;
+   samm:description "Data Carrier Characteristic for the product."@en ;
+   samm:dataType :DataCarrierEntity .
+
+:ManufacturerCharacteristic a samm:Characteristic ;
+   samm:preferredName "Manufacturer Characteristic"@en ;
+   samm:description "Manufacturing information."@en ;
+   samm:dataType :ManufacturerEntity .
+
+:ImportCharacteristic a samm:Characteristic ;
+   samm:preferredName "Import Characteristic"@en ;
+   samm:description "Import Characteristic for the product."@en ;
+   samm:dataType :ImportEntity .
+
+:OperatorCharacteristic a samm:Characteristic ;
+   samm:preferredName "Operator Characteristic"@en ;
+   samm:description "Other operators characteristic."@en ;
+   samm:dataType :OperatorEntity .
+
+:SparePart a samm:Characteristic ;
+   samm:preferredName "Spare Part"@en ;
+   samm:description "Characteristic describing sources and spare parts."@en ;
+   samm:dataType :SparePartEntity .
+
+:LifespanList a samm-c:List ;
+   samm:preferredName "Lifespan List"@en ;
+   samm:description "List of different life spans of a product."@en ;
+   samm:dataType :LifespanEntity .
+
+:PhysicalDimensionCharacteristic a samm:Characteristic ;
+   samm:preferredName "Physical Dimension Characteristic"@en ;
+   samm:description "Characteristic for physical dimensions with linear, mass and capacity attributes."@en ;
+   samm:dataType :PhysicalDimensionEntity .
+
+:PhysicalStateEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Physical State Enumeration"@en ;
+   samm:description "Enumeration with the values solid, liquid, gas and plasma."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "solid" "liquid" "gas" "plasma" ) .
+
+:StringList a samm-c:List ;
+   samm:preferredName "String List"@en ;
+   samm:description "List of strings."@en ;
+   samm:dataType xsd:string .
+
+:RecallInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Recall Information Characteristic"@en ;
+   samm:description "Recall information characteristic for the product."@en ;
+   samm:dataType :RecallInformationEntity .
+
+:SubstanceOfConcernCharacteristic a samm:Characteristic ;
+   samm:preferredName "Substance Of Concern Characteristic"@en ;
+   samm:description "Substance of concern Characteristic of the product."@en ;
+   samm:dataType :SubstanceOfConcernEntity .
+
+:MaterialCharacteristic a samm:Characteristic ;
+   samm:preferredName "Material Characteristic"@en ;
+   samm:description "Material Characteristic with information on the materials."@en ;
+   samm:dataType :ChemicalMaterialEntity .
+
+:StateEnumeration a samm-c:Enumeration ;
+   samm:preferredName "State Enumeration"@en ;
+   samm:description "Enumeration defined as original, repurposed, re-used, remanufactured or waste."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "original" "repurposed" "re-used" "remanufactured" "waste" ) .
+
+:ProductFootprintCharacteristic a samm:Characteristic ;
+   samm:preferredName "Product Footprint Characteristic"@en ;
+   samm:description "The Product Footprint Characteristic with sustainability information."@en ;
+   samm:dataType :ProductFootprintEntity .
+
+:SourceCategoryEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Source Category Enumeration"@en ;
+   samm:description "The types of sources that can be linked in a digital product passport can vary depending on the nature of the product and the information that needs to be included. This is an enumeration of possible sources."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Product Specifications" "Manufacturer Information" "User Manuals and Guides" "Certifications and Compliance" "Product Images and Videos" "Warranty Information" "Reviews and Ratings" "Product Variations" "Supply Chain Information" "Environmental Impact" "Compatibility and Accessories" "FAQs and Support" "Purchase and Retail Information" "Privacy and Data Handling" "Third-Party Integrations" "Legal Information" "Safety Information" "Repair and Installation" "Waste Generation and Prevention" "Specific Voluntary Labels" "Product Packaging" "Return and Disposal" "End of Life" "Material and Substance Information" "Technical Documentation" "Treatment facilities" "Other" ) .
+
+:HeaderTrait a samm-c:Trait ;
+   samm:preferredName "Header Trait"@en ;
+   samm:description "Trait for a restrictive header."@en ;
+   samm-c:baseCharacteristic samm-c:Text ;
+   samm-c:constraint :HeaderConstraint .
+
+:TypeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Type Characteristic"@en ;
+   samm:description "Characteristic for the data type."@en ;
+   samm:dataType :TypeEntity .
+
+:DateConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Date Constraint"@en ;
+   samm:description "Constraint fo a timestamp in the format (yyyy-mm-dd)."@en ;
+   samm:value "^\\d{4}-\\d{2}-\\d{2}$" .
+
+:PartTypeEntity a samm:Entity ;
+   samm:preferredName "Part Type Entity"@en ;
+   samm:description "Entity for the part type with manufacturer id and name."@en ;
+   samm:properties ( ext-information:manufacturerPartId ext-information:nameAtManufacturer ) .
+
+:CodeEntity a samm:Entity ;
+   samm:preferredName "Code Entity"@en ;
+   samm:description "Code entity with code key and value."@en ;
+   samm:properties ( [ samm:property :codeKey; samm:payloadName "key" ] [ samm:property :codeValue; samm:payloadName "value" ] ) .
+
+:DataCarrierEntity a samm:Entity ;
+   samm:preferredName "Data Carrier Entity"@en ;
+   samm:description "Data Carrier Entity with type and layout of the data carrier."@en ;
+   samm:properties ( :carrierType :carrierLayout ) .
+
+:ManufacturerEntity a samm:Entity ;
+   samm:preferredName "Manufacturer Entity"@en ;
+   samm:description "Manufacturing Entity with the identification of the main manufacturer and the facility location as well as the manufacturing date."@en ;
+   samm:properties ( [ samm:property :facilityIdentification; samm:payloadName "facility" ] [ samm:property :manufacturerIdentification; samm:payloadName "manufacturer" ] [ samm:property :manufacturingDate; samm:optional true ] ) .
+
+:ImportEntity a samm:Entity ;
+   samm:preferredName "Import Entity"@en ;
+   samm:description "Import entity with attributes if applicable to the product."@en ;
+   samm:properties ( [ samm:property :importer; samm:payloadName "content" ] :applicable ) .
+
+:OperatorEntity a samm:Entity ;
+   samm:preferredName "Operator Entity"@en ;
+   samm:description "Operator with role and identification. "@en ;
+   samm:properties ( [ samm:property :otherOperatorId; samm:payloadName "id" ] [ samm:property :otherOperatorRole; samm:payloadName "role" ] ) .
+
+:SparePartEntity a samm:Entity ;
+   samm:preferredName "Spare Part Entity"@en ;
+   samm:description "Information regarding  possible spare parts. This is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(b) ease of repair and maintenance as expressed through: characteristics, availability and delivery time of spare parts, modularity, compatibility with commonly available spare parts, availability of repair and maintenance instructions, number of materials and components used, use of standard components, use of component and material coding standards for the identification of components and materials, number and complexity of processes and tools needed,  ease of non-destructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed;\n(c) the Global Trade Identification Number as provided for in standard ISO/IEC 15459-6 or equivalent of products or their parts."@en ;
+   samm:properties ( [ samm:property :sparePartSources; samm:payloadName "producer" ] :sparePart ) .
+
+:LifespanEntity a samm:Entity ;
+   samm:preferredName "Lifespan Entity"@en ;
+   samm:description "Entity for the lifespan of a product with type, unit and value."@en ;
+   samm:properties ( [ samm:property :lifeUnit; samm:payloadName "unit" ] [ samm:property :lifeValue; samm:payloadName "value" ] [ samm:property :lifeType; samm:payloadName "key" ] ) .
+
+:PhysicalDimensionEntity a samm:Entity ;
+   samm:preferredName "Physical Dimension Entity"@en ;
+   samm:description "Entity for physical dimensions with linear, mass and capacity attributes. Either weight or volume is mandatory."@en ;
+   samm:properties ( [ samm:property :width; samm:optional true ] [ samm:property :length; samm:optional true ] [ samm:property :diameter; samm:optional true ] [ samm:property :height; samm:optional true ] :grossWeight :grossVolume :weight :volume ) .
+
+:RecallInformationEntity a samm:Entity ;
+   samm:preferredName "Recall Information Entity"@en ;
+   samm:description "Recall information entity with attributes if applicabe to the product."@en ;
+   samm:properties ( :applicable [ samm:property :recallInformationDocumentation; samm:optional true ] ) .
+
+:SubstanceOfConcernEntity a samm:Entity ;
+   samm:preferredName "Substance Of Concern Entity"@en ;
+   samm:description "Substance of Concern entity with attributes if applicable to the product."@en ;
+   samm:properties ( :applicable [ samm:property :substanceOfConcern; samm:payloadName "content" ] ) .
+
+:ChemicalMaterialEntity a samm:Entity ;
+   samm:preferredName "Chemical Material Entity"@en ;
+   samm:description "Material entity with attributes if applicable to the product."@en ;
+   samm:properties ( :applicable [ samm:property :chemicalMaterial; samm:payloadName "content" ] ) .
+
+:ProductFootprintEntity a samm:Entity ;
+   samm:preferredName "Product Footprint Entity"@en ;
+   samm:description "The Product Footprint Entity with sustainability information such as the different environmental footprint types, the carbon and material footprint explicitly, applicable rules and lifecycle stages."@en ;
+   samm:properties ( [ samm:property :environmentalFootprint; samm:optional true; samm:payloadName "environmental" ] [ samm:property :carbonFootprint; samm:payloadName "carbon" ] [ samm:property :materialFootprint; samm:optional true; samm:payloadName "material" ] ) .
+
+:HeaderConstraint a samm-c:LengthConstraint ;
+   samm:preferredName "Header Constraint"@en ;
+   samm:description "Constraint for a maximum of 100 characters."@en ;
+   samm-c:maxValue "100"^^xsd:nonNegativeInteger .
+
+:TypeEntity a samm:Entity ;
+   samm:preferredName "Type Entity"@en ;
+   samm:description "Entity for type with unit and data type."@en ;
+   samm:properties ( [ samm:property :typeUnit; samm:optional true ] :dataType ) .
+
+:codeKey a samm:Property ;
+   samm:preferredName "Code Key"@en ;
+   samm:description "The code key for the identification of the product. Examples are GTIN, hash, DID, ISBN, TARIC. This attribute is mentioned in the ESPR proposal from March 30th, 2022 ANNEX III:\n(b) the unique product identifier at the level indicated in the applicable delegated act adopted pursuant to Article 4;\n(c) the Global Trade Identification Number as provided for in standard ISO/IEC 15459-6 or equivalent of products or their parts;\n(d) relevant commodity codes, such as a TARIC code as defined in Council Regulation (EEC) No 2658/87."@en ;
+   samm:characteristic :IdentifierCharacteristic ;
+   samm:exampleValue "TARIC" .
+
+:codeValue a samm:Property ;
+   samm:preferredName "Code Value"@en ;
+   samm:description "The code value for the identification of the product in regard to the chosen code name."@en ;
+   samm:characteristic :IdentifierCharacteristic ;
+   samm:exampleValue "8703 24 10 00" .
+
+:carrierType a samm:Property ;
+   samm:preferredName "Carrier Type"@en ;
+   samm:description "The type of data carrier such as a QR code on the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 8:\n(2) (b) the types of data carrier to be used."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "QR" .
+
+:carrierLayout a samm:Property ;
+   samm:preferredName "Carrier Layout"@en ;
+   samm:description "The positioning of data carrier on the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 8:\n(2) (c) the layout in which the data carrier shall be presented and its positioning."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "upper-left side" .
+
+:facilityIdentification a samm:Property ;
+   samm:preferredName "Facility Identification"@en ;
+   samm:description "The identifier used for a location.  In the CATENA-X use case, the BPNA can be stated. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product."@en ;
+   samm:characteristic :FacilityList .
+
+:manufacturerIdentification a samm:Property ;
+   samm:preferredName "Manufacturer Identification"@en ;
+   samm:description "The main manufacturer, if different from the passport owner, represented by an identification number. In the Catena-X use case, the BPNL can be stated. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(h) unique operator identifiers other than that of the manufacturer;\n(k) the name, contact details and unique operator identifier code of the economic operator established in the Union responsible for carrying out the tasks set out in Article 4 of Regulation (EU) 2019/1020, or Article 15 of Regulation (EU) [.../...] on general product safety, or similar tasks pursuant to other EU legislation applicable to the product."@en ;
+   samm:characteristic ext-number:BpnlTrait .
+
+:manufacturingDate a samm:Property ;
+   samm:preferredName "Manufacturing Date"@en ;
+   samm:description "The timestamp in the format (yyyy-mm-dd) of the manufacturing date as the final step in production process (e.g. final quality check, ready-for-shipment event)."@en ;
+   samm:characteristic :DateTrait ;
+   samm:exampleValue "2000-01-31" .
+
+:importer a samm:Property ;
+   samm:preferredName "Importer"@en ;
+   samm:description "Information regarding the importer of the product, if different from the owner of the passport. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex III:\n(j) information related to the importer, including the information referred to in Article 23(3) and its EORI number;\nArticle 23 states:\n(3) Importers shall, for products covered by a delegated act adopted pursuant to Article 4, indicate their name, registered trade name or registered trade mark and the postal address and electronic means of communication, where they can be contacted:  (a) on the public part of the product passport, when applicable, and\n(b) on the product or, where this is not possible, on the packaging, or in a document accompanying the product."@en ;
+   samm:characteristic :ImporterCharacteristic .
+
+:otherOperatorId a samm:Property ;
+   samm:preferredName "Other Operator Id"@en ;
+   samm:description "Identifier of the other operator. This can be a BPN."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BPNL0123456789XX" .
+
+:otherOperatorRole a samm:Property ;
+   samm:preferredName "Other Operator Role"@en ;
+   samm:description "Role of the other operator."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "distributor" .
+
+:sparePartSources a samm:Property ;
+   samm:preferredName "Spare Part Sources"@en ;
+   samm:description "Sources of possible spare parts."@en ;
+   samm:characteristic :SourcesList .
+
+:sparePart a samm:Property ;
+   samm:preferredName "Spare Part"@en ;
+   samm:description "Possible spare parts of the product."@en ;
+   samm:characteristic :PartList .
+
+:lifeUnit a samm:Property ;
+   samm:preferredName "Life Unit"@en ;
+   samm:description "The unit of the respective lifespan expressed through the possible units day, month, cycle, year and runningOrOperatingHour."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:characteristic :LifeEnumeration ;
+   samm:exampleValue "unit:month" .
+
+:lifeValue a samm:Property ;
+   samm:preferredName "Life Value"@en ;
+   samm:description "The value as an integer for the respective lifespan."@en ;
+   samm:characteristic :LifeValueCharacteristic ;
+   samm:exampleValue 36 .
+
+:lifeType a samm:Property ;
+   samm:preferredName "Life Type"@en ;
+   samm:description "The type of lifespan represented with the values guaranteed lifetime, technical lifetime and mean time between failures. This attribute is mentioned in the ESPR proposal from March 30th, 2022 ANNEX I:\n(a) durability and reliability of the product or its components as expressed through the product's guaranteed lifetime, technical lifetime [or] mean time between failures [...]."@en ;
+   samm:characteristic :LifeTypeEnumeration ;
+   samm:exampleValue "guaranteed lifetime" .
+
+:width a samm:Property ;
+   samm:preferredName "Width"@en ;
+   samm:description "The width of the item measured in a specific linear unit which can be declared in the corresponding unit attribute."@en ;
+   samm:characteristic ext-quantity:LinearCharacteristic .
+
+:length a samm:Property ;
+   samm:preferredName "Length"@en ;
+   samm:description "The length of the item measured in a specific linear unit which can be declared in the corresponding unit attribute."@en ;
+   samm:characteristic ext-quantity:LinearCharacteristic .
+
+:diameter a samm:Property ;
+   samm:preferredName "Diameter"@en ;
+   samm:description "The diameter of the item, if applicable, measured in a specific linear unit which can be declared in the corresponding unit attribute."@en ;
+   samm:characteristic ext-quantity:LinearCharacteristic .
+
+:height a samm:Property ;
+   samm:preferredName "Height"@en ;
+   samm:description "The height of the item measured in a specific linear unit which can be declared in the corresponding unit attribute."@en ;
+   samm:characteristic ext-quantity:LinearCharacteristic .
+
+:grossWeight a samm:Property ;
+   samm:preferredName "Gross Weight"@en ;
+   samm:description "The gross weight of the item measured in a specific mass unit which can be declared in the corresponding unit attribute. Gross weight refers to the total weight of a product, including the weight of the packaging. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(2) (b) (i) information on the performance of the product in relation to the product parameters referred to in Annex I;\nAnnex I (i) weight and volume of the product and its packaging, and the product-to-packaging ratio."@en ;
+   samm:characteristic ext-quantity:MassCharacteristic .
+
+:grossVolume a samm:Property ;
+   samm:preferredName "Gross Volume"@en ;
+   samm:description "The gross volume of the item, if possible, measured in a specific capacity unit which can be declared in the corresponding unit attribute. If there is no separate packing, the volume of the product shall be given. Gross volume refers to the total volume of a product, including the volume of the packaging. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(2) (b) (i) information on the performance of the product in relation to the product parameters referred to in Annex I;\nAnnex I (i) weight and volume of the product and its packaging, and the product-to-packaging ratio."@en ;
+   samm:characteristic ext-quantity:VolumeCharacteristic .
+
+:weight a samm:Property ;
+   samm:preferredName "Weight"@en ;
+   samm:description "Weight of the product measured in a specific mass unit which can be declared in the corresponding unit attribute.  This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(2) (b) (i) information on the performance of the product in relation to the product parameters referred to in Annex I;\nAnnex I (i) weight and volume of the product [...]."@en ;
+   samm:characteristic ext-quantity:MassCharacteristic .
+
+:volume a samm:Property ;
+   samm:preferredName "Volume"@en ;
+   samm:description "Volume of the product, if possible, measured in a specific capacity unit which can be declared in the corresponding unit attribute. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(2) (b) (i) information on the performance of the product in relation to the product parameters referred to in Annex I;\nAnnex I (i) weight and volume of the product [...]."@en ;
+   samm:characteristic ext-quantity:VolumeCharacteristic .
+
+:recallInformationDocumentation a samm:Property ;
+   samm:preferredName "Recall Information Documentation"@en ;
+   samm:description "Documentation of the recall information of the product."@en ;
+   samm:characteristic :DocumentList .
+
+:substanceOfConcern a samm:Property ;
+   samm:preferredName "Substance of Concern"@en ;
+   samm:description "Information regarding substances of concern in the product. Attributes are among others substance names, ids, concentration, location and hazard class. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 7:\n(5) (a) the name of the substances of concern present in the product, as follows:\n- name(s) in the International Union of Pure and Applied Chemistry (IUPAC) nomenclature, or another international name when IUPAC name is not available; \n- other names (usual name, trade name, abbreviation);\n- European Community (EC) number, as indicated in the European Inventory of Existing Commercial Chemical Substances (EINECS), the European List of Notified Chemical Substances (ELINCS) or the No Longer Polymer (NLP) list or assigned by the European Chemicals Agency (ECHA), if available;\n- the Chemical Abstract Service (CAS) name(s) and number(s), if available;\n(5) (b) the location of the substances of concern within the product.\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product its relevant components, or spare parts;\n(d) relevant instructions for the safe use of the product;\n(e) information relevant for disassembly, preparation for reuse, reuse, recycling and the environmentally sound management of the product at the end of its life.\nAnd in the next paragraph:\n(c) provide duly justified exemptions for substances of concern or information elements from the information requirements referred to in the first subparagraph."@en ;
+   samm:characteristic :SubstanceList .
+
+:chemicalMaterial a samm:Property ;
+   samm:preferredName "Material"@en ;
+   samm:description "Information on different materials in the product."@en ;
+   samm:characteristic :MaterialList .
+
+:environmentalFootprint a samm:Property ;
+   samm:preferredName "Environmental Footprint"@en ;
+   samm:description "The environmental footprint of the product. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\nThe following parameters shall, as appropriate, and where necessary supplemented by others, be used, individually or combined, as a basis for improving the product aspects referred to in Article 5(1):\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories.\nand Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nand defined by Article 2:\n(23) 'environmental footprint' means a quantification of product environmental impacts throughout its life cycle, whether in relation to a single environmental impact category or an aggregated set of impact categories based on the Product Environmental Footprint method or other scientific methods developed by international organisations and widely tested in collaboration with different industry sectors and adopted or implemented by the Commission in other Union legislation;\n(24) 'Product Environmental Footprint method' means the life cycle assessment method to quantify the environmental impacts of products established by Recommendation (EU) 2021/2279."@en ;
+   samm:characteristic :FootprintList .
+
+:carbonFootprint a samm:Property ;
+   samm:preferredName "Carbon Footprint"@en ;
+   samm:description "The carbon footprint of the product. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\nThe following parameters shall, as appropriate, and where necessary supplemented by others, be used, individually or combined, as a basis for improving the product aspects referred to in Article 5(1):\n(m) the carbon footprint of the product;\nand Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nand defined by Article 2:\n(25) 'carbon footprint' means the sum of greenhouse gas (GHG) emissions and GHG removals in a product system, expressed as CO2 equivalents and based on a life cycle assessment using the single impact category of climate change."@en ;
+   samm:characteristic :FootprintList .
+
+:materialFootprint a samm:Property ;
+   samm:preferredName "Material Footprint"@en ;
+   samm:description "The material footprint of the product. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(ma) the material footprint of the product;\nand defined by Article 2:\n(25a) 'material footprint' refers to the total amount of raw materials extracted to meet final consumption demands."@en ;
+   samm:characteristic :FootprintList .
+
+:typeUnit a samm:Property ;
+   samm:preferredName "Type Unit"@en ;
+   samm:description "Choose a unit type from the unit catalog, or if the property \"children\" is filled, leave empty."@en ;
+   samm:characteristic :UnitCatalog ;
+   samm:exampleValue "unit:volume" .
+
+:dataType a samm:Property ;
+   samm:preferredName "Data Type"@en ;
+   samm:description "Data type that describe the content of the attributes children and data. In case \"object\" is selected in the enumeration, the children field will be used in the AdditionalDataEntity instead of the \"data\" property. If it is an other type, the content will be specified in \"data\" as a string."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:characteristic :DataTypeEnumeration ;
+   samm:exampleValue "xsd:integer" .
+
+:FacilityList a samm-c:List ;
+   samm:preferredName "Facility List"@en ;
+   samm:description "List of facilities."@en ;
+   samm:dataType :FacilityEntity .
+
+:ImporterCharacteristic a samm:Characteristic ;
+   samm:preferredName "Importer Characteristic"@en ;
+   samm:description "Characteristic with information regarding the importer."@en ;
+   samm:dataType :ImporterEntity .
+
+:SourcesList a samm-c:List ;
+   samm:preferredName "Sources List"@en ;
+   samm:description "List of possible spare part sources."@en ;
+   samm:dataType :SourcesEntity .
+
+:PartList a samm-c:List ;
+   samm:preferredName "Part List"@en ;
+   samm:description "A list of possible spare parts of the product."@en ;
+   samm:dataType :PartsEntity .
+
+:LifeEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Life Enumeration"@en ;
+   samm:description "Enumeration with the possible units day, month, cycle, year and runningOrOperatingHour."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "unit:day" "unit:month" "unit:year" "unit:cycle" "unit:runningOrOperatingHour" ) .
+
+:LifeValueCharacteristic a samm-c:Quantifiable ;
+   samm:preferredName "Life Value Characteristic"@en ;
+   samm:description "Characteristic for the life span value as an integer."@en ;
+   samm:dataType xsd:integer .
+
+:LifeTypeEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Life Type Enumeration"@en ;
+   samm:description "Enumeration with the values guaranteed lifetime, technical lifetime and mean time between failures."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "guaranteed lifetime" "technical lifetime" "mean time between failures" ) .
+
+:DocumentList a samm-c:List ;
+   samm:preferredName "Document List"@en ;
+   samm:description "List of documents."@en ;
+   samm:dataType :DocumentationEntity .
+
+:SubstanceList a samm-c:List ;
+   samm:preferredName "Substance List"@en ;
+   samm:description "Characteristic for a list of substances of concern."@en ;
+   samm:dataType :SubstanceEntity .
+
+:MaterialList a samm-c:List ;
+   samm:preferredName "Material List"@en ;
+   samm:description "A list of different materials in the product."@en ;
+   samm:dataType :MaterialEntity .
+
+:FootprintList a samm-c:List ;
+   samm:preferredName "Footprint List"@en ;
+   samm:description "Footprint List for the environmental footprint."@en ;
+   samm:dataType :FootprintEntity .
+
+:UnitCatalog a samm:Characteristic ;
+   samm:preferredName "Unit Catalog"@en ;
+   samm:description "Link to the unit catalog with all possible units in the format \"unit:xxx\"."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:dataType xsd:string .
+
+:DataTypeEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Data Type Enumeration"@en ;
+   samm:description "Data type that describe the content of the attributes children and data. In case \"object\" is selected in the enumeration, the children field will be used in the AdditionalDataEntity instead of the \"data\" property. If it is an other type, the content will be specified in \"data\" as a string."@en ;
+   samm:see <https://www.w3.org/2001/XMLSchema> ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "array" "object" "xsd:string" "xsd:integer" "xsd:boolean" "xsd:double" "xsd:float" "xsd:byte" ) .
+
+:FacilityEntity a samm:Entity ;
+   samm:preferredName "Facility Entity"@en ;
+   samm:description "The entity for a facility with the BPNA identifier."@en ;
+   samm:properties ( :facility ) .
+
+:ImporterEntity a samm:Entity ;
+   samm:preferredName "Importer Entity"@en ;
+   samm:description "Entity with information regarding the importer such as the identification and the EORI."@en ;
+   samm:properties ( :eori [ samm:property :importerIdentification; samm:payloadName "id" ] ) .
+
+:SourcesEntity a samm:Entity ;
+   samm:preferredName "Sources Entity"@en ;
+   samm:description "Entity for a possible spare part sources."@en ;
+   samm:properties ( [ samm:property :sourcesIdentification; samm:payloadName "id" ] ) .
+
+:PartsEntity a samm:Entity ;
+   samm:preferredName "Parts Entity"@en ;
+   samm:description "Possible spare parts of the product with identifiers and names."@en ;
+   samm:properties ( ext-information:manufacturerPartId ext-information:nameAtManufacturer ) .
+
+:DocumentationEntity a samm:Entity ;
+   samm:preferredName "Documentation Entity"@en ;
+   samm:description "Entity for a document with a header, type and content."@en ;
+   samm:properties ( :content :contentType :header ) .
+
+:SubstanceEntity a samm:Entity ;
+   samm:preferredName "Substance Entity"@en ;
+   samm:description "Information regarding substances of concern in the product."@en ;
+   samm:properties ( :location [ samm:property :materialUnit; samm:payloadName "unit" ] :concentration :exemption :hazardClassification :concentrationRange [ samm:property :materialIdentification; samm:payloadName "id" ] :documentation ) .
+
+:MaterialEntity a samm:Entity ;
+   samm:preferredName "Material Entity"@en ;
+   samm:description "Information regarding recycled and/or renewable materials in the product."@en ;
+   samm:properties ( :recycled :renewable [ samm:property :materialUnit; samm:payloadName "unit" ] [ samm:property :materialIdentification; samm:payloadName "id" ] :critical :concentration :documentation ) .
+
+:FootprintEntity a samm:Entity ;
+   samm:preferredName "Footprint Entity"@en ;
+   samm:description "Footprint Entity for the carbon and environmental footprint with the total value, unit, impact category type, lifecycle, rulebook, declaration, performance class and the facility."@en ;
+   samm:properties ( [ samm:property :footprintValue; samm:payloadName "value" ] [ samm:property :footprintRulebook; samm:payloadName "rulebook" ] [ samm:property :footprintLifecycle; samm:payloadName "lifecycle" ] [ samm:property :footprintUnit; samm:payloadName "unit" ] [ samm:property :footprintType; samm:payloadName "type" ] [ samm:property :performanceClass; samm:optional true ] :manufacturingPlant :declaration ) .
+
+:facility a samm:Property ;
+   samm:preferredName "Facility"@en ;
+   samm:description "The identifier used for a location. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product."@en ;
+   samm:characteristic ext-number:BpnaTrait ;
+   samm:exampleValue "BPNA1234567890AA" .
+
+:eori a samm:Property ;
+   samm:preferredName "EORI"@en ;
+   samm:description "An economic operator established in the customs territory of the Union needs, for customs purposes, an EORI number. EORI stands for economic operators registration and identification number. In this case, the importer's EORI must be provided. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex III:\n(j) information related to the importer, including the information referred to in Article 23(3) and its EORI number."@en ;
+   samm:see <https://taxation-customs.ec.europa.eu/customs-4/customs-procedures-import-and-export-0/customs-procedures/economic-operators-registration-and-identification-number-eori_en> ;
+   samm:characteristic :EoriTrait ;
+   samm:exampleValue "GB123456789000" .
+
+:importerIdentification a samm:Property ;
+   samm:preferredName "Importer Identification"@en ;
+   samm:description "The importer of the product, if different from the owner of the passport. In the Catena-X network, the BPNL is used for the identification of companies and the information stored for this like contact information and addresses.\nThis attribute is mentioned in the ESPR provisional agreement from January 9th, 2024  Annex III:\n(j) information related to the importer, including the information referred to in Article 23(3) and its EORI number;\nArticle 23 states:\n(3) Importers shall, for products covered by a delegated act adopted pursuant to Article 4, indicate their name, registered trade name or registered trade mark and the postal address and electronic means of communication, where they can be contacted:  (a) on the public part of the product passport, when applicable, and\n(b) on the product or, where this is not possible, on the packaging, or in a document accompanying the product."@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL0123456789ZZ" .
+
+:sourcesIdentification a samm:Property ;
+   samm:preferredName "Sources Identification"@en ;
+   samm:description "The identifier of a spare part producer of the product. In the Catena-X network, the BPNL is used for the identification of companies and the information stored for this like contact information and addresses."@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL0123456789ZZ" .
+
+:location a samm:Property ;
+   samm:preferredName "Location"@en ;
+   samm:description "The location of the substances of concern within the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (b) the location of the substances of concern within the product."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Housing" .
+
+:materialUnit a samm:Property ;
+   samm:preferredName "Material Unit"@en ;
+   samm:description "The unit of concentration chosen from an enumeration: mass percent, volume percent, parts per thousand, parts per million, parts per billion and  parts per trillion."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:characteristic :ConcentrationEnumeration ;
+   samm:exampleValue "unit:percent" .
+
+:concentration a samm:Property ;
+   samm:preferredName "Concentration"@en ;
+   samm:description "Concentration of the material at the level of the product. This attribute is specially mentioned for substances of concern mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product [...].\nOther substances are mentioned for the purpose of recycling in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(d) design for recycling, ease and quality of recycling as expressed through: use of easily recyclable materials, safe, easy and non-destructive access to recyclable components and materials or components and materials containing hazardous substances and material composition and homogeneity, possibility for high-purity sorting, number of materials and components used, use of standard components, use of component and material coding standards for the identification of components and materials, number and complexity of processes and tools needed, ease of nondestructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed.\n"@en ;
+   samm:characteristic :PositiveTrait ;
+   samm:exampleValue "5.3"^^xsd:float .
+
+:exemption a samm:Property ;
+   samm:preferredName "Exemption"@en ;
+   samm:description "Exemptions to the substance of concern. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 7:\n(5) (c) provide duly justified exemptions for substances of concern or information elements from the information requirements referred to in the first subparagraph based on the technical feasibility or relevance of tracking substances of concern, the existence of analytical methods to detect and quantify them, the need to protect confidential business information or in other duly justified cases. Substances of concern within the meaning of Article 2(28), point a), shall not be exempted if they are present in products, their relevant components or spare parts in a concentration above 0,1 % weight by weight."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "shall not apply to product x containing not more than 1,5 ml of liquid" .
+
+:hazardClassification a samm:Property ;
+   samm:preferredName "Hazard Classification"@en ;
+   samm:description "The specification of the hazard class. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(f) use of substances, and in particular the use of substances of concern, on their own, as constituents of substances or in mixtures, during the production process of products, or leading to their presence in products, including once these products become waste, and their impacts on human health and the environment;\nFurther defined is this by Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006.\nDefined in Article 2:\n1. 'hazard class' means the nature of the physical, health or environmental hazard;\n2. 'hazard category' means the division of criteria within each hazard class, specifying hazard severity;\n5. 'hazard statement' means a phrase assigned to a hazard class and category that describes the nature of the hazards of a hazardous substance or mixture, including, where appropriate, the degree of hazard;"@en ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02008R1272-20231201> ;
+   samm:characteristic :HazardCharacteristic .
+
+:concentrationRange a samm:Property ;
+   samm:preferredName "Concentration Range"@en ;
+   samm:description "The concentration range for the substance of concern. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) [...] concentration range of the substances of concern, at the level of the product [...]."@en ;
+   samm:characteristic :RangeCharacteristic .
+
+:materialIdentification a samm:Property ;
+   samm:preferredName "Material Identification"@en ;
+   samm:description "The chemical material name and identification, in accordance with the specification in the attribute for the list type. Preference is given to the IUPAC name. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 7:\n(5) (a) the name of the substances of concern present in the product, as follows:\n - name(s) in the International Union of Pure and Applied Chemistry (IUPAC) nomenclature, or another international name when IUPAC name is not available; \n- other names (usual name, trade name, abbreviation);\n- European Community (EC) number, as indicated in the European Inventory of Existing Commercial Chemical Substances (EINECS), the European List of Notified Chemical Substances (ELINCS) or the No Longer Polymer (NLP) list or assigned by the European Chemicals Agency (ECHA), if available;\n- the Chemical Abstract Service (CAS) name(s) and number(s), if available; ."@en ;
+   samm:characteristic :MaterialIdList .
+
+:documentation a samm:Property ;
+   samm:preferredName "Documentation"@en ;
+   samm:description "Documentation accompanying the material."@en ;
+   samm:characteristic :DocumentList .
+
+:recycled a samm:Property ;
+   samm:preferredName "Recycled"@en ;
+   samm:description "The share of the material, which is recovered recycled content from the product. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(h) use or content of recycled materials and recovery of materials, including critical raw materials;"@en ;
+   samm:characteristic :PercentageTrait ;
+   samm:exampleValue "12.5"^^xsd:float .
+
+:renewable a samm:Property ;
+   samm:preferredName "Renewable"@en ;
+   samm:description "The share of the material, which is from a renewable resource that can be replenished. Renewable resources are those that can be reproduced by physical, chemical, or mechanical processes. These are the kind of resources that can be regenerated throughout time. Forest wood, for example, can be grown through reforestation. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(ha) use or content of sustainable renewable materials;\n"@en ;
+   samm:characteristic :PercentageTrait ;
+   samm:exampleValue "23.5"^^xsd:float .
+
+:critical a samm:Property ;
+   samm:preferredName "Critical"@en ;
+   samm:description "A flag, if the material is a critical raw material. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(h) use or content of recycled materials and recovery of materials, including critical raw materials;\nIn Annex II of the connected proposal Act of Critical Raw Materials, a list of critical raw materials can be found."@en ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=COM:2023:0160:FIN> ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:footprintValue a samm:Property ;
+   samm:preferredName "Footprint Value"@en ;
+   samm:description "The value of the footprint of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories;\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.\n"@en ;
+   samm:characteristic :PositiveTrait ;
+   samm:exampleValue "12.678"^^xsd:float .
+
+:footprintRulebook a samm:Property ;
+   samm:preferredName "Footprint Rulebook"@en ;
+   samm:description "The applied rulebook for the environmental footprint of the product."@en ;
+   samm:characteristic :DocumentList .
+
+:footprintLifecycle a samm:Property ;
+   samm:preferredName "Footprint Lifecycle"@en ;
+   samm:description "The lifecycle stage, to which the environmental footprint corresponds. These could be for example \"raw material acquisition and pre-processing\", \"main product production\", \"distribution\" or \"end of life and recycling\"."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "main product production" .
+
+:footprintUnit a samm:Property ;
+   samm:preferredName "Footprint Unit"@en ;
+   samm:description "The unit of measurement of the environmental impact category. For each impact category a specific unit is used. If an aggregation is used, utilize the normalization and weighting methods used in the referenced rulebook."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "kg CO2 / kWh" .
+
+:footprintType a samm:Property ;
+   samm:preferredName "Footprint Type"@en ;
+   samm:description "The type of the environmental footprint of the product. This could be one of the environmental impact categories. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nAnnex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories.\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product."@en ;
+   samm:characteristic :CategoryEnumeration ;
+   samm:exampleValue "Climate Change" .
+
+:performanceClass a samm:Property ;
+   samm:preferredName "Performance Class"@en ;
+   samm:description "The performance classification of the footprint."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A" .
+
+:manufacturingPlant a samm:Property ;
+   samm:preferredName "Manufacturing Plant"@en ;
+   samm:description "The manufacturing plant of the footprint in the specific lifecycle phase."@en ;
+   samm:characteristic :FacilityList .
+
+:declaration a samm:Property ;
+   samm:preferredName "Declaration"@en ;
+   samm:description "The footprint declaration in the format of a link "@en ;
+   samm:characteristic :DocumentList .
+
+:EoriTrait a samm-c:Trait ;
+   samm:preferredName "Eori Trait"@en ;
+   samm:description "Trait to limit the input to the specified format of an eori."@en ;
+   samm-c:baseCharacteristic :IdentifierCharacteristic ;
+   samm-c:constraint :EoriConstraint .
+
+:ConcentrationEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Concentration Enumeration"@en ;
+   samm:description "Enumeration of possible units of concentration with percent, volume percent, parts per thousand, parts per million, parts per billion and parts per trillion."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "unit:partPerMillion" "unit:percent" "unit:percentVolume" "unit:partPerThousand" "unit:partPerTrillionUs" "unit:partPerBillionUs" ) .
+
+:PositiveTrait a samm-c:Trait ;
+   samm:preferredName "Positive Trait"@en ;
+   samm:description "Trait for positive values."@en ;
+   samm-c:baseCharacteristic :FloatValue ;
+   samm-c:constraint :PositiveRangeConstraint .
+
+:HazardCharacteristic a samm:Characteristic ;
+   samm:preferredName "Hazard Characteristic"@en ;
+   samm:description "Characteristic for the hazardous classification."@en ;
+   samm:dataType :HazardEntity .
+
+:RangeCharacteristic a samm-c:List ;
+   samm:preferredName "Range Characteristic"@en ;
+   samm:description "Range characteristic with two values, the highest and the lowest of the concentration range. Only providing the maximum range is also possible."@en ;
+   samm:dataType :RangeEntity .
+
+:MaterialIdList a samm-c:List ;
+   samm:preferredName "Material Id List"@en ;
+   samm:description "List of ids for the identification."@en ;
+   samm:dataType :MaterialIdEntity .
+
+:PercentageTrait a samm-c:Trait ;
+   samm:preferredName "Percentage Trait"@en ;
+   samm:description "Trait for a positive percentage."@en ;
+   samm-c:baseCharacteristic :Share ;
+   samm-c:constraint :PercentageConstraint .
+
+:CategoryEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Category Enumeration"@en ;
+   samm:description "Enumeration of the 19 impact categories in accordance to EN15804+A2."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Climate Change Total" "Climate Change Fossil" "Climate Change Biogenic Removals and Emissions" "Climate Change Land Use and Land Use Change" "Ozone Depletion" "Acidification" "Eutrophication Aquatic Freshwater" "Eutrophication Fresh Marine" "Eutrophication Terrestrial" "Photochemical Ozone Formation" "Abiotic Depletion- Minerals and Metals" "Fossil Fuels" "Water Use" "Particulate Matter Emissions" "Ionizing Radiation, Human Health" "Eco-Toxicity" "Human Toxicity, Cancer Effects" "Human Toxicity, Non-Cancer Effects" "Land Use Related Impacts/Soil Quality" ) .
+
+:EoriConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "EORI Constraint"@en ;
+   samm:description "Constraint with a pattern which ensures that the EORI number starts with two alphanumeric characters, followed by two alphabetic characters, and ends with 2 to 15 alphanumeric characters."@en ;
+   samm:value "^[A-Z]{2}[A-Z0-9]{1,18}$" .
+
+:FloatValue a samm-c:Quantifiable ;
+   samm:preferredName "Float Value"@en ;
+   samm:description "Float number representing a positive value."@en ;
+   samm:dataType xsd:float .
+
+:PositiveRangeConstraint a samm-c:RangeConstraint ;
+   samm:preferredName "Positive Range Constraint"@en ;
+   samm:description "Constraint for only positive values."@en ;
+   samm-c:minValue "0.0"^^xsd:float ;
+   samm-c:lowerBoundDefinition samm-c:AT_LEAST ;
+   samm-c:upperBoundDefinition samm-c:LESS_THAN .
+
+:HazardEntity a samm:Entity ;
+   samm:preferredName "Hazard Entity"@en ;
+   samm:description "Entity for the hazardous classification."@en ;
+   samm:properties ( [ samm:property :hazardCategory; samm:payloadName "category" ] [ samm:property :hazardClass; samm:payloadName "class" ] [ samm:property :hazardStatement; samm:payloadName "statement" ] ) .
+
+:RangeEntity a samm:Entity ;
+   samm:preferredName "Range Entity"@en ;
+   samm:description "Entity for the concentration range with two values, the highest and the lowest of the concentration range."@en ;
+   samm:properties ( [ samm:property :minConcentration; samm:optional true; samm:payloadName "min" ] [ samm:property :maxConcentration; samm:payloadName "max" ] ) .
+
+:MaterialIdEntity a samm:Entity ;
+   samm:preferredName "Material Id Entity"@en ;
+   samm:description "Id Entity with identifier, name and list type."@en ;
+   samm:properties ( [ samm:property :chemicalId; samm:payloadName "id" ] [ samm:property :listTypeId; samm:payloadName "type" ] [ samm:property :chemicalName; samm:payloadName "name" ] ) .
+
+:Share a samm-c:Measurement ;
+   samm:preferredName "share"@en ;
+   samm:description "The share represented in a float number in the unit percent."@en ;
+   samm:dataType xsd:float ;
+   samm-c:unit unit:percent .
+
+:PercentageConstraint a samm-c:RangeConstraint ;
+   samm:preferredName "Percentage Constraint"@en ;
+   samm:description "Range constraint for a positive percentage value."@en ;
+   samm-c:minValue "0.0"^^xsd:float ;
+   samm-c:maxValue "100.0"^^xsd:float ;
+   samm-c:lowerBoundDefinition samm-c:AT_LEAST ;
+   samm-c:upperBoundDefinition samm-c:AT_MOST .
+
+:hazardCategory a samm:Property ;
+   samm:preferredName "Hazard Category"@en ;
+   samm:description "The hazard category of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n2. 'hazard category' means the division of criteria within each hazard class, specifying hazard severity."@en ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02008R1272-20231201> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "category 1A" .
+
+:hazardClass a samm:Property ;
+   samm:preferredName "Hazard Class"@en ;
+   samm:description "The hazard class of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n1. 'hazard class' means the nature of the physical, health or environmental hazard."@en ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02008R1272-20231201> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Skin corrosion" .
+
+:hazardStatement a samm:Property ;
+   samm:preferredName "Hazard Statement"@en ;
+   samm:description "The hazard statement of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n5. 'hazard statement' means a phrase assigned to a hazard class and category that describes the nature of the hazards of a hazardous substance or mixture, including, where appropriate, the degree of hazard."@en ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02008R1272-20231201> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Causes severe skin burns and eye damage." .
+
+:minConcentration a samm:Property ;
+   samm:preferredName "Minimum Concentration"@en ;
+   samm:description "The minimum concentration of the substance of concern at the level of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) [...] concentration range of the substances of concern, at the level of the product [...]."@en ;
+   samm:characteristic :PositiveTrait ;
+   samm:exampleValue "2.1"^^xsd:float .
+
+:maxConcentration a samm:Property ;
+   samm:preferredName "Maximum Concentration"@en ;
+   samm:description "The maximum concentration of the substance of concern at the level of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product [...]."@en ;
+   samm:characteristic :PositiveTrait ;
+   samm:exampleValue "2.6"^^xsd:float .
+
+:chemicalId a samm:Property ;
+   samm:preferredName "Chemical Id"@en ;
+   samm:description "The substance identification, in accordance with the specification in the attribute for the list type."@en ;
+   samm:characteristic :IdentifierCharacteristic ;
+   samm:exampleValue "201-004-7" .
+
+:listTypeId a samm:Property ;
+   samm:preferredName "List Type Id"@en ;
+   samm:description "The type of standard used for the identification of the substances. Selected can be for example CAS, IUPAC or EC."@en ;
+   samm:characteristic :ListTypeEnumerationId ;
+   samm:exampleValue "CAS" .
+
+:chemicalName a samm:Property ;
+   samm:preferredName "Chemical Name"@en ;
+   samm:description "The name of the material which is present in the product."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "phenolphthalein" .
+
+:ListTypeEnumerationId a samm-c:Enumeration ;
+   samm:preferredName "List Type Enumeration Id"@en ;
+   samm:description "Enumeration of different systems and organizations related to the identification and classification of chemical substances in the field of chemistry. The enumeration values are EC or CAS."@en ;
+   samm:see <https://www.cas.org/cas-data/cas-registry> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "CAS" "EC" "IUPAC" ) .
+

--- a/io.catenax.generic.digital_product_passport/6.0.0/metadata.json
+++ b/io.catenax.generic.digital_product_passport/6.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.generic.digital_product_passport/RELEASE_NOTES.md
+++ b/io.catenax.generic.digital_product_passport/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
+## [6.0.0] - 2025-04-08
+### Changed
+- new attribute added: language
+- new attribute added: purchaseOrder
+- new attribute added: recallInformation
+
 ## [5.0.0] - 2024-05-21
 ### Changed
 - structure and pattern below chemicalName and chemicalId changed for materials

--- a/io.catenax.generic.digital_product_passport/RELEASE_NOTES.md
+++ b/io.catenax.generic.digital_product_passport/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
-## [6.0.0] - 2025-04-08
+## [6.0.0] - 2025-04-24
 ### Changed
 - new attribute added: language
 - new attribute added: purchaseOrder


### PR DESCRIPTION
Closes #814 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
