### PR TITLE
Add "set -e" to generate.sh

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -63,6 +63,7 @@ commands=(aas aas schema json openapi html)
 endings=(-aas.xml .aasx -schema.json .json .yml .html)
 toggles=("-f xml" "-f aasx" "" "" "-b=catenax.io" "-c $CATENAXCSS")
 
+set -e
 for i in ${!commands[@]}; do
     echo "generate ${commands[$i]} into $PATHTEMPLATE${endings[$i]}"
     java -jar $SAMMCLI aspect "$1" to ${commands[$i]} ${toggles[$i]} -o $PATHTEMPLATE${endings[$i]}


### PR DESCRIPTION
This PR adds the setting "set -e" to the .sh automation scripts which generates the artefacts. Currently this script has a minor inconvenience: If the model is not valid, the script still tries to generate all 7 artefacts. In this case, all of them will fail, but this unnecessary consumes build time. The -e setting immediately stops the script, if it causes an error.

> set -e tells bash that it should exit the script if any statement returns a non-true return value. 