### PR TITLE
[Model Update] QualityTaskAttachment to 3.0.0 for Saturn release 2509

### DIFF
--- a/io.catenax.quality_task_attachment/3.0.0/QualityTaskAttachment.ttl
+++ b/io.catenax.quality_task_attachment/3.0.0/QualityTaskAttachment.ttl
@@ -68,7 +68,7 @@
    samm:exampleValue "Histogramm_data.csv" .
 
 :schema a samm:Property ;
-   samm:preferredName "schema"@en ;
+   samm:preferredName "Schema"@en ;
    samm:description "schema definition for file"@en ;
    samm:characteristic :schemaCharacteristic .
 

--- a/io.catenax.quality_task_attachment/3.0.0/QualityTaskAttachment.ttl
+++ b/io.catenax.quality_task_attachment/3.0.0/QualityTaskAttachment.ttl
@@ -41,7 +41,7 @@
    samm:events ( ) .
 
 :files a samm:Property ;
-   samm:preferredName "files"@en ;
+   samm:preferredName "Files"@en ;
    samm:description "A list of files within the ZIP-folder, which are needed for a specific quality task"@en ;
    samm:characteristic :ListOfFiles .
 

--- a/io.catenax.quality_task_attachment/3.0.0/QualityTaskAttachment.ttl
+++ b/io.catenax.quality_task_attachment/3.0.0/QualityTaskAttachment.ttl
@@ -1,0 +1,221 @@
+#######################################################################
+# Copyright (c) 2023 Robert Bosch GmbH
+# Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2023 Volkswagen AG
+# Copyright (c) 2023 ZF Friedrichshafen AG
+# Copyright (c) 2023 SAP SE
+# Copyright (c) 2023 Siemens AG
+# Copyright (c) 2025 DENSO AUTOMOTIVE Deutschland GmbH
+# Copyright (c) 2025 WITTE Automotive GmbH
+# Copyright (c) 2025 Schaeffler Technologies AG & Co. KG
+# Copyright (c) 2025 Ford Werke GmbH
+#
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.quality_task_attachment:3.0.0#> .
+@prefix ext-core: <urn:samm:io.catenax.shared.quality_core:1.0.0#> .
+
+:QualityTaskAttachment a samm:Aspect ;
+   samm:preferredName "Quality task attachment"@en ;
+   samm:description "Additional data for quality task"@en ;
+   samm:properties ( :files :qualityTaskAttachmentId ext-core:qualityTaskId ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:files a samm:Property ;
+   samm:preferredName "files"@en ;
+   samm:description "A list of files within the ZIP-folder, which are needed for a specific quality task"@en ;
+   samm:characteristic :ListOfFiles .
+
+:qualityTaskAttachmentId a samm:Property ;
+   samm:preferredName "Quality Task Attachment ID"@en ;
+   samm:description "A unique identifier for a specific Quality Task Attachment"@en ;
+   samm:characteristic ext-core:UniqueID ;
+   samm:exampleValue "123456789" .
+
+:ListOfFiles a samm-c:List ;
+   samm:preferredName "List of files"@en ;
+   samm:description "List of files attached to a quality task"@en ;
+   samm:dataType :File .
+
+:File a samm:Entity ;
+   samm:preferredName "File"@en ;
+   samm:description "One file attached to the quality task"@en ;
+   samm:properties ( :fileName [ samm:property :schema; samm:optional true ] :filePath :sizeInKbProperty :fileDescription :fileExtension [ samm:property :relatedModelType; samm:optional true ] ) .
+
+:fileName a samm:Property ;
+   samm:preferredName "file name"@en ;
+   samm:description "The name of the described file"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Histogramm_data.csv" .
+
+:schema a samm:Property ;
+   samm:preferredName "schema"@en ;
+   samm:description "schema definition for file"@en ;
+   samm:characteristic :schemaCharacteristic .
+
+:filePath a samm:Property ;
+   samm:preferredName "File Path"@en ;
+   samm:description "Indicates where the file is located within the ZIP-folder"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "/subfolder/Histogramm_data.csv" .
+
+:sizeInKbProperty a samm:Property ;
+   samm:preferredName "Size in Kilobyte"@en ;
+   samm:description "Indicates the size of the file"@en ;
+   samm:characteristic :SizeInKb ;
+   samm:exampleValue "615"^^xsd:positiveInteger .
+
+:fileDescription a samm:Property ;
+   samm:preferredName "File Description"@en ;
+   samm:description "A description of the file content"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Price list for various components" .
+
+:fileExtension a samm:Property ;
+   samm:preferredName "File Extension"@en ;
+   samm:description "Indicates which file format the file has"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "csv" .
+
+:relatedModelType a samm:Property ;
+   samm:preferredName "Related Model Type"@en ;
+   samm:description "Indicates which aspect model these additional files are to be added to"@en ;
+   samm:characteristic :RelatedModelTypeCharacteristic .
+
+:schemaCharacteristic a samm:Characteristic ;
+   samm:preferredName "SchemaCharacteristic"@en ;
+   samm:description "Describes the schema of the values contained in the file"@en ;
+   samm:dataType :SchemaDefinition .
+
+:SizeInKb a samm-c:Measurement ;
+   samm:preferredName "Size in Kilobyte"@en ;
+   samm:description "Indicates the size of the file"@en ;
+   samm:dataType xsd:positiveInteger ;
+   samm-c:unit unit:kilobyte .
+
+:RelatedModelTypeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Related Model Type Characteristic"@en ;
+   samm:description "This characteristic groups all necessary properties to refer to an existing Catena-X semantic model."@en ;
+   samm:dataType :SemanticModel .
+
+:SchemaDefinition a samm:Entity ;
+   samm:preferredName "Schema"@en ;
+   samm:description "Schema for the file entities"@en ;
+   samm:properties ( [ samm:property :decimalSeperator; samm:optional true ] [ samm:property :delimiter; samm:optional true ] :variablesProperty ) .
+
+:SemanticModel a samm:Entity ;
+   samm:preferredName "Semantic Model"@en ;
+   samm:description "One existing Catena-X semantic model"@en ;
+   samm:properties ( :namespace :ttlFile [ samm:property :modelVersion; samm:optional true ] ) .
+
+:decimalSeperator a samm:Property ;
+   samm:preferredName "Decimal Separator Enumeration"@en ;
+   samm:description "Enumeration types to be used for the decimal separators"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "\"comma\", \"dot\"" .
+
+:delimiter a samm:Property ;
+   samm:preferredName "Delimiter"@en ;
+   samm:description "Indicates whether a semicolon, comma or tab is used as a delimiter between data points"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "semicolon" .
+
+:variablesProperty a samm:Property ;
+   samm:preferredName "VariablesProperty"@en ;
+   samm:description "A list describing the variables contained in the file"@en ;
+   samm:characteristic :Variables .
+
+:namespace a samm:Property ;
+   samm:preferredName "Namespace"@en ;
+   samm:description "The namespace of a Catena-X semantic model"@en ;
+   samm:characteristic :NamespaceTrait ;
+   samm:exampleValue "io.catenax.fleet.vehicles" .
+
+:ttlFile a samm:Property ;
+   samm:preferredName "TTL File"@en ;
+   samm:description "The name of the .ttl-file of the Catena-X semantic model"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Vehicles.ttl" .
+
+:modelVersion a samm:Property ;
+   samm:preferredName "Model Version"@en ;
+   samm:description "The version of a Catena-X semantic model"@en ;
+   samm:characteristic :ModelVersionTrait ;
+   samm:exampleValue "2.0.0" .
+
+:Variables a samm-c:List ;
+   samm:preferredName "Variables"@en ;
+   samm:description "A list describing the variables contained in the file"@en ;
+   samm:dataType :VariableAttribute .
+
+:NamespaceTrait a samm-c:Trait ;
+   samm:preferredName "Namespace Trait"@en ;
+   samm:description "This trait ensures proper namespaces of Catena-X semantic models"@en ;
+   samm-c:baseCharacteristic samm-c:Text ;
+   samm-c:constraint :NamespaceConstraint .
+
+:ModelVersionTrait a samm-c:Trait ;
+   samm:preferredName "Model Version Trait"@en ;
+   samm:description "This trait ensures proper versioning of a Catena-X semantic model."@en ;
+   samm-c:baseCharacteristic samm-c:Text ;
+   samm-c:constraint :VersionConstraint .
+
+:VariableAttribute a samm:Entity ;
+   samm:preferredName "VariableAttribute"@en ;
+   samm:description "A list describing the variables contained in the file"@en ;
+   samm:properties ( :variableName :dataType :unit [ samm:property :variableDescription; samm:optional true ] ) .
+
+:NamespaceConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Namespace Constraint"@en ;
+   samm:description "This constraint ensures that the namespace of the Catena-X semantic model is following the regulare expression ^io\\.catenax\\.[a-z]+([._][a-z]+)*$"@en ;
+   samm:value "^io\\.catenax\\.[a-z]+([._][a-z]+)*$" .
+
+:VersionConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Version Constraint"@en ;
+   samm:description "This constraint ensures that the version of the Catena-X semantic model is following the regular expression ^[1-9].[0-9].[0-9]$"@en ;
+   samm:value "^[1-9].[0-9].[0-9]$" .
+
+:variableName a samm:Property ;
+   samm:preferredName "Variable name"@en ;
+   samm:description "The name of the column"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Price" .
+
+:dataType a samm:Property ;
+   samm:preferredName "Variable data type"@en ;
+   samm:description "The data type of the data contained in the column"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "double" .
+
+:unit a samm:Property ;
+   samm:preferredName "Unit"@en ;
+   samm:description "The unit of the data contained in the column (used for numeric values)"@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/appendix/unitcatalog.html> ;
+   samm:characteristic samm-c:UnitReference ;
+   samm:exampleValue "unit:degreeCelsiusPerHour"^^samm:curie .
+
+:variableDescription a samm:Property ;
+   samm:preferredName "Variable description"@en ;
+   samm:description "A description of the data contained in the column"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "This column contains the hourly temperature of a part" .
+

--- a/io.catenax.quality_task_attachment/3.0.0/QualityTaskAttachment.ttl
+++ b/io.catenax.quality_task_attachment/3.0.0/QualityTaskAttachment.ttl
@@ -62,7 +62,7 @@
    samm:properties ( :fileName [ samm:property :schema; samm:optional true ] :filePath :sizeInKbProperty :fileDescription :fileExtension [ samm:property :relatedModelType; samm:optional true ] ) .
 
 :fileName a samm:Property ;
-   samm:preferredName "file name"@en ;
+   samm:preferredName "File name"@en ;
    samm:description "The name of the described file"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Histogramm_data.csv" .

--- a/io.catenax.quality_task_attachment/3.0.0/metadata.json
+++ b/io.catenax.quality_task_attachment/3.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.quality_task_attachment/RELEASE_NOTES.md
+++ b/io.catenax.quality_task_attachment/RELEASE_NOTES.md
@@ -21,3 +21,15 @@ n/a
 - updated SAMM Version from 2.0.0 to 2.1.0
 
 ### Removed
+
+## [3.0.0] - 2025-07-01
+### Added
+- added qualityTaskAttachmentId to identify attachments
+
+### Changed
+- changed referenced model description from enumeration to definition via namespace, ttl file name and version
+- moved model reference to file level instead of top level
+- usage of quality core model (e.g., for the qualityTaskId)
+
+
+### Removed


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

Adding a new version of the QualityTaskAttachment model.
Newest version uses the QualityCore model, added a new identifier for the attachment and changed the way of referencing to other semantic models.

 -->

Closes [#805](https://github.com/eclipse-tractusx/sldt-semantic-models/issues/805)

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
