### PR TITLE
[New Model] io.catenax.report_8d:1.0.0 for Saturn release 2509

### DIFF
--- a/io.catenax.report_8d/1.0.0/Report8D.ttl
+++ b/io.catenax.report_8d/1.0.0/Report8D.ttl
@@ -37,7 +37,7 @@
 
 :Report8D a samm:Aspect ;
    samm:preferredName "8D Report"@en ;
-   samm:description "Semantic Model for 8D Reports"@en ;
+   samm:description "Aspect Model for the Quality Management business case describing an 8D report. An 8D report (Eight Disciplines) is a structured problem-solving method used primarily in quality management to identify, correct, and eliminate recurring issues. It guides teams through eight steps, including root cause analysis and implementation of permanent corrective actions. The goal is to improve processes, prevent future problems, and ensure customer satisfaction."@en ;
    samm:properties ( :header [ samm:property :stepD1; samm:optional true ] [ samm:property :stepD2; samm:optional true ] [ samm:property :stepD3; samm:optional true ] [ samm:property :stepD4; samm:optional true ] [ samm:property :stepD5; samm:optional true ] [ samm:property :stepD6; samm:optional true ] [ samm:property :stepD7; samm:optional true ] [ samm:property :stepD8; samm:optional true ] [ samm:property :stepD0; samm:optional true ] ) ;
    samm:operations ( ) ;
    samm:events ( ) .
@@ -228,7 +228,7 @@
    samm:characteristic :ContactCharacteristic .
 
 :supplierContact a samm:Property ;
-   samm:preferredName "SupplierContact"@en ;
+   samm:preferredName "Supplier Contact"@en ;
    samm:description "The Contact of the supplier"@en ;
    samm:characteristic :ContactCharacteristic .
 
@@ -491,7 +491,7 @@
    samm:exampleValue "80"^^xsd:int .
 
 :introductionDate a samm:Property ;
-   samm:preferredName "IntroductionDate"@en ;
+   samm:preferredName "Introduction Date"@en ;
    samm:description "Definition of the date of introduction of the immediate measures - the date as yyyy-mm-dd"@en ;
    samm:characteristic ext-core:ISO8601LocalDate ;
    samm:exampleValue "2025-03-10" .
@@ -535,7 +535,7 @@
    samm:preferredName "Clarification Date"@en ;
    samm:description "Determination of the date of clarification of the cause - the date as yyyy-mm-dd"@en ;
    samm:characteristic ext-core:ISO8601LocalDate ;
-   samm:exampleValue "3/21/2025" .
+   samm:exampleValue "2025-03-21" .
 
 :result a samm:Property ;
    samm:preferredName "Result"@en ;

--- a/io.catenax.report_8d/1.0.0/Report8D.ttl
+++ b/io.catenax.report_8d/1.0.0/Report8D.ttl
@@ -1,0 +1,600 @@
+#######################################################################
+# Copyright (c) 2025 Robert Bosch GmbH
+# Copyright (c) 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2025 Volkswagen AG
+# Copyright (c) 2025 ZF Friedrichshafen AG
+# Copyright (c) 2025 SAP SE
+# Copyright (c) 2025 Siemens AG
+# Copyright (c) 2025 DENSO AUTOMOTIVE Deutschland GmbH
+# Copyright (c) 2025 WITTE Automotive GmbH
+# Copyright (c) 2025 Schaeffler Technologies AG & Co. KG
+# Copyright (c) 2025 Ford Werke GmbH
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.report_8d:1.0.0#> .
+@prefix ext-core: <urn:samm:io.catenax.shared.quality_core:1.0.0#> .
+@prefix ext-information: <urn:samm:io.catenax.shared.contact_information:4.0.0#> .
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:2.0.0#> .
+
+:Report8D a samm:Aspect ;
+   samm:preferredName "8D Report"@en ;
+   samm:description "Semantic Model for 8D Reports"@en ;
+   samm:properties ( :header [ samm:property :stepD1; samm:optional true ] [ samm:property :stepD2; samm:optional true ] [ samm:property :stepD3; samm:optional true ] [ samm:property :stepD4; samm:optional true ] [ samm:property :stepD5; samm:optional true ] [ samm:property :stepD6; samm:optional true ] [ samm:property :stepD7; samm:optional true ] [ samm:property :stepD8; samm:optional true ] [ samm:property :stepD0; samm:optional true ] ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:header a samm:Property ;
+   samm:preferredName "Header"@en ;
+   samm:description "The header of the 8D Report"@en ;
+   samm:characteristic :HeaderCharacteristic .
+
+:stepD1 a samm:Property ;
+   samm:preferredName "Step D1"@en ;
+   samm:description "First step of the 8D Report. Containing information about the team members working on the root cause analysis"@en ;
+   samm:characteristic :StepD1Characteristic .
+
+:stepD2 a samm:Property ;
+   samm:preferredName "Step D2"@en ;
+   samm:description "Second step of the 8D Report."@en ;
+   samm:characteristic :StepD2Characteristic .
+
+:stepD3 a samm:Property ;
+   samm:preferredName "Step D3"@en ;
+   samm:description "Third step of the 8D Report"@en ;
+   samm:characteristic :StepD3Characteristic .
+
+:stepD4 a samm:Property ;
+   samm:preferredName "Step D4"@en ;
+   samm:description "Fourth Step of the 8D Report"@en ;
+   samm:characteristic :StepD4Characteristic .
+
+:stepD5 a samm:Property ;
+   samm:preferredName "Step D5"@en ;
+   samm:description "Fifth step of the 8D Report"@en ;
+   samm:characteristic :StepD5Characteristic .
+
+:stepD6 a samm:Property ;
+   samm:preferredName "Step D6"@en ;
+   samm:description "Sixth step of the 8D Report"@en ;
+   samm:characteristic :StepD6Characteristic .
+
+:stepD7 a samm:Property ;
+   samm:preferredName "Step D7"@en ;
+   samm:description "Seventh step of the 8D Report"@en ;
+   samm:characteristic :StepD7Characteristic .
+
+:stepD8 a samm:Property ;
+   samm:preferredName "Step D8"@en ;
+   samm:description "Eighth step of the 8D Report"@en ;
+   samm:characteristic :StepD8Characteristic .
+
+:stepD0 a samm:Property ;
+   samm:preferredName "Step D0"@en ;
+   samm:description "Optional Step D0 used for the Global 8D Standard"@en ;
+   samm:characteristic :StepD0Characteristic .
+
+:HeaderCharacteristic a samm:Characteristic ;
+   samm:preferredName "Header characteristic"@en ;
+   samm:description "Characteristic for the property Header"@en ;
+   samm:dataType :HeaderEntity .
+
+:StepD1Characteristic a samm:Characteristic ;
+   samm:preferredName "Step D1 Characteristic"@en ;
+   samm:description "Characteristic for the step D1"@en ;
+   samm:dataType :StepD1Entity .
+
+:StepD2Characteristic a samm:Characteristic ;
+   samm:preferredName " Step D2 Characteristic"@en ;
+   samm:description "Characteristic for the step D2"@en ;
+   samm:dataType :StepD2Entity .
+
+:StepD3Characteristic a samm:Characteristic ;
+   samm:preferredName "Step D3 Characteristic"@en ;
+   samm:description "Characteristic for the step D3"@en ;
+   samm:dataType :StepD3Entity .
+
+:StepD4Characteristic a samm:Characteristic ;
+   samm:preferredName "Step D4 Characteristic"@en ;
+   samm:description "Characteristic for the Step D4"@en ;
+   samm:dataType :StepD4Entity .
+
+:StepD5Characteristic a samm:Characteristic ;
+   samm:preferredName "Step D5 Characteristic"@en ;
+   samm:description "Characteristic for the Step D5"@en ;
+   samm:dataType :StepD5Entity .
+
+:StepD6Characteristic a samm:Characteristic ;
+   samm:preferredName "Step D6 Characteristic"@en ;
+   samm:description "Characteristic for the Step D6"@en ;
+   samm:dataType :StepD6Entity .
+
+:StepD7Characteristic a samm:Characteristic ;
+   samm:preferredName "Step D7 Characteristic"@en ;
+   samm:description "Characteristic for the Step D8"@en ;
+   samm:dataType :StepD7Entity .
+
+:StepD8Characteristic a samm:Characteristic ;
+   samm:preferredName "Step D8 Characteristic"@en ;
+   samm:description "Characteristic for the Step D8"@en ;
+   samm:dataType :StepD8Entity .
+
+:StepD0Characteristic a samm:Characteristic ;
+   samm:preferredName "Step D0 Characteristic"@en ;
+   samm:description "Characteristic for the Step D0"@en ;
+   samm:dataType :StepD0Entity .
+
+:HeaderEntity a samm:Entity ;
+   samm:preferredName "Header entity"@en ;
+   samm:description "Entity for the property Header"@en ;
+   samm:properties ( :complaintDate :lastRevisionDate [ samm:property :title; samm:optional true ] :customerComplaintId [ samm:property :supplierComplaintId; samm:optional true ] :customerContact [ samm:property :supplierContact; samm:optional true ] :parts [ samm:property :complaintLocation; samm:optional true ] ext-core:supplierId [ samm:property ext-core:supplierName; samm:optional true ] [ samm:property ext-core:qualityTaskId; samm:optional true ] [ samm:property ext-core:additionalInformationList; samm:optional true ] ) .
+
+:StepD1Entity a samm:Entity ;
+   samm:preferredName "Step D1 Entity"@en ;
+   samm:description "Entity for the Characteristic Step D1"@en ;
+   samm:properties ( [ samm:property :sponsor; samm:optional true ] [ samm:property :teamLeader; samm:optional true ] :contactPerson [ samm:property :teamMembers; samm:optional true ] ) .
+
+:StepD2Entity a samm:Entity ;
+   samm:preferredName "Step D2 Entity"@en ;
+   samm:description "Entity for the Characteristic Step D2"@en ;
+   samm:properties ( :symptomDescription :problemDescription [ samm:property :errorType; samm:optional true ] :riskAssessmentStarted [ samm:property :riskAssessmentUpdated; samm:optional true ] [ samm:property :qualityTaskAttachmentId; samm:optional true ] [ samm:property :errorLocation; samm:optional true ] [ samm:property ext-core:additionalInformationList; samm:optional true ] ) .
+
+:StepD3Entity a samm:Entity ;
+   samm:preferredName "Step D3 Entity"@en ;
+   samm:description "Entity for the Characteristic Step D3"@en ;
+   samm:properties ( :descriptionOfInterimContainmentActions [ samm:property ext-core:additionalInformationList; samm:optional true ] ) .
+
+:StepD4Entity a samm:Entity ;
+   samm:preferredName "Step D4 Entity"@en ;
+   samm:description "Entity for the Characteristic Step D4"@en ;
+   samm:properties ( :causes [ samm:property ext-core:additionalInformationList; samm:optional true ] ) .
+
+:StepD5Entity a samm:Entity ;
+   samm:preferredName "Step D5 Entity"@en ;
+   samm:description "Entity for the Characteristic Step D5"@en ;
+   samm:properties ( :definePermanentCorrectiveActions [ samm:property ext-core:additionalInformationList; samm:optional true ] ) .
+
+:StepD6Entity a samm:Entity ;
+   samm:preferredName "Step D6 Entity"@en ;
+   samm:description "Entity for the Characteristic D6"@en ;
+   samm:properties ( :implementedCorrectiveMeasures [ samm:property ext-core:additionalInformationList; samm:optional true ] ) .
+
+:StepD7Entity a samm:Entity ;
+   samm:preferredName "Step D7 Entity"@en ;
+   samm:description "Entity for the Characteristic Step D7"@en ;
+   samm:properties ( :errorPreventiveMeasures [ samm:property ext-core:additionalInformationList; samm:optional true ] ) .
+
+:StepD8Entity a samm:Entity ;
+   samm:preferredName "Step D8 Entity"@en ;
+   samm:description "Entity for the Characteristic D8"@en ;
+   samm:properties ( [ samm:property :resultAssesment; samm:optional true ] :closingDate ) .
+
+:StepD0Entity a samm:Entity ;
+   samm:preferredName "Step D0 Entity"@en ;
+   samm:description "Entity for the Characteristic Step D0"@en ;
+   samm:properties ( :defineEmergencyResponseAction :customerComplaintId [ samm:property :supplierComplaintId; samm:optional true ] :problemDescription :complaintDate [ samm:property :complaintLocation; samm:optional true ] [ samm:property ext-core:additionalInformationList; samm:optional true ] ) .
+
+:complaintDate a samm:Property ;
+   samm:preferredName "Complaint date"@en ;
+   samm:description "The date of claim is the specific date on which the claim was filed."@en ;
+   samm:characteristic ext-core:ISO8601LocalDate ;
+   samm:exampleValue "2025-01-01" .
+
+:lastRevisionDate a samm:Property ;
+   samm:preferredName "Last revision date"@en ;
+   samm:description "The date of last revision refers to the most recent date on which the document was updated."@en ;
+   samm:characteristic ext-core:ISO8601LocalDate ;
+   samm:exampleValue "2025-01-01" .
+
+:title a samm:Property ;
+   samm:preferredName "Title"@en ;
+   samm:description "The title of the 8D report is the official title given to the 8D report."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Test Component 1 breakdown" .
+
+:customerComplaintId a samm:Property ;
+   samm:preferredName "CustomerComplaint ID"@en ;
+   samm:description "The customer specific ID of the complaint process is the identifier assigned to the complaint process by the customer."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "OE-123456789" .
+
+:supplierComplaintId a samm:Property ;
+   samm:preferredName "Supplier Complaint ID"@en ;
+   samm:description "The supplier specific ID of the complaint process is the identifier assigned to the complaint process by the supplier."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "SU-123456789" .
+
+:customerContact a samm:Property ;
+   samm:preferredName "Customer Contact"@en ;
+   samm:description "The Contact of the customer"@en ;
+   samm:characteristic :ContactCharacteristic .
+
+:supplierContact a samm:Property ;
+   samm:preferredName "SupplierContact"@en ;
+   samm:description "The Contact of the supplier"@en ;
+   samm:characteristic :ContactCharacteristic .
+
+:parts a samm:Property ;
+   samm:preferredName "Parts"@en ;
+   samm:description "Information about the effected parts"@en ;
+   samm:characteristic :PartCharacteristic .
+
+:complaintLocation a samm:Property ;
+   samm:preferredName "Complaint Location"@en ;
+   samm:description "Defines the location of the complaint"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Berlin Workshop Mustermann" .
+
+:sponsor a samm:Property ;
+   samm:preferredName "Sponsor"@en ;
+   samm:description "Sponsor of the 8D Report"@en ;
+   samm:characteristic :PersonCharacteristic .
+
+:teamLeader a samm:Property ;
+   samm:preferredName "Team leader"@en ;
+   samm:description "team leader"@en ;
+   samm:characteristic :PersonCharacteristic .
+
+:contactPerson a samm:Property ;
+   samm:preferredName "Contact person"@en ;
+   samm:description "contact person"@en ;
+   samm:characteristic :PersonCharacteristic .
+
+:teamMembers a samm:Property ;
+   samm:preferredName "Team members"@en ;
+   samm:description "Team members"@en ;
+   samm:characteristic :TeamMemberList .
+
+:symptomDescription a samm:Property ;
+   samm:preferredName "Symptom Description"@en ;
+   samm:description "Describes which symptoms lead to the claim"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A high percentage of the parts produced have scratches on the surface." .
+
+:problemDescription a samm:Property ;
+   samm:preferredName "Problem Description"@en ;
+   samm:description "Describes the problem of the complaint and the consequences that arise from it"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "The scratches on the parts lead to an increased scrap rate and affect product quality." .
+
+:errorType a samm:Property ;
+   samm:preferredName "Error Type"@en ;
+   samm:description "Describes the error type to be classified"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Surface defects" .
+
+:riskAssessmentStarted a samm:Property ;
+   samm:preferredName "Risk Assessment Started"@en ;
+   samm:description "Describes at what point the risk assessment was started - the date as yyyy-mm-dd"@en ;
+   samm:characteristic ext-core:ISO8601LocalDate ;
+   samm:exampleValue "2025-03-04" .
+
+:riskAssessmentUpdated a samm:Property ;
+   samm:preferredName "Risk Assessment Updated"@en ;
+   samm:description "Describes at what point the risk assessment was updated - the date as yyyy-mm-dd"@en ;
+   samm:characteristic ext-core:ISO8601LocalDate ;
+   samm:exampleValue "2025-03-10" .
+
+:qualityTaskAttachmentId a samm:Property ;
+   samm:preferredName "Quality Task Attachment ID"@en ;
+   samm:description "Allows to link an quality task attachment with added information about the complaint e.g. dimensions, photos, production data,…."@en ;
+   samm:characteristic ext-core:UniqueID ;
+   samm:exampleValue "12366548799" .
+
+:errorLocation a samm:Property ;
+   samm:preferredName "Error Location"@en ;
+   samm:description "Describes at which component or location the error occurred"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Cast housing" .
+
+:descriptionOfInterimContainmentActions a samm:Property ;
+   samm:preferredName "Description of Interim Containment Actions (ICA)"@en ;
+   samm:description "Describes interim containment action to resolve the quality problem in the short term"@en ;
+   samm:characteristic :DescriptionOfInterimContainmentActionList .
+
+:causes a samm:Property ;
+   samm:preferredName "Causes"@en ;
+   samm:description "Describes and lists the root cause(s)"@en ;
+   samm:characteristic :CauseList .
+
+:definePermanentCorrectiveActions a samm:Property ;
+   samm:preferredName "Define Permanent Corrective Actions (PCA)"@en ;
+   samm:description "Describes and lists planned permanent corrective measure(s)"@en ;
+   samm:characteristic :MeasuresList .
+
+:implementedCorrectiveMeasures a samm:Property ;
+   samm:preferredName "Implemented Corrective Measures"@en ;
+   samm:description "A List of implemented corrective measures"@en ;
+   samm:characteristic :MeasuresList .
+
+:errorPreventiveMeasures a samm:Property ;
+   samm:preferredName "Error Preventive Measures"@en ;
+   samm:description "Describes and lists error preventive measure(s)"@en ;
+   samm:characteristic :MeasuresList .
+
+:resultAssesment a samm:Property ;
+   samm:preferredName "Result Assesment"@en ;
+   samm:description "Allows a summary of the measure and a final statement on its effectiveness"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "The corrective measures are having an impact. The cause has been clearly identified and resolved." .
+
+:closingDate a samm:Property ;
+   samm:preferredName "Closing Date"@en ;
+   samm:description "Determining the time of 8D completion"@en ;
+   samm:characteristic ext-core:ISO8601LocalDate ;
+   samm:exampleValue "2025-05-02" .
+
+:defineEmergencyResponseAction a samm:Property ;
+   samm:preferredName "Define Emergency Response Action"@en ;
+   samm:description "Describes and lists planned permanent corrective measure(s)"@en ;
+   samm:characteristic :MeasuresList .
+
+:ContactCharacteristic a samm:Characteristic ;
+   samm:preferredName "Contact Characteristic"@en ;
+   samm:description "Characteristic for contacts"@en ;
+   samm:dataType :ContactEntity .
+
+:PartCharacteristic a samm-c:List ;
+   samm:preferredName "Part Characteristic"@en ;
+   samm:description "Characteristic of the property part"@en ;
+   samm:dataType :PartEntity .
+
+:PersonCharacteristic a samm:Characteristic ;
+   samm:preferredName "Person Characteristic"@en ;
+   samm:description "Information about one specific person"@en ;
+   samm:dataType :PersonEntity .
+
+:TeamMemberList a samm-c:List ;
+   samm:preferredName "Team Member List"@en ;
+   samm:description "TeamMemberList"@en ;
+   samm:dataType :PersonEntity .
+
+:DescriptionOfInterimContainmentActionList a samm-c:List ;
+   samm:preferredName "Description of Interim Containment Action List"@en ;
+   samm:description "A list of Descriptions of Interim Containment Actions"@en ;
+   samm:dataType :DescriptionofInterimContainmentAction .
+
+:CauseList a samm-c:List ;
+   samm:preferredName "Cause List"@en ;
+   samm:description "The Characteristic to describe a list of causes"@en ;
+   samm:dataType :Cause .
+
+:MeasuresList a samm-c:List ;
+   samm:preferredName "Planned Corrective "@en ;
+   samm:description "A List of measures"@en ;
+   samm:dataType :Measure .
+
+:ContactEntity a samm:Entity ;
+   samm:preferredName "Contact Entity"@en ;
+   samm:description "Entity describing contacts"@en ;
+   samm:properties ( :companyName [ samm:property :street; samm:optional true ] :city [ samm:property :postalCode; samm:optional true ] :country ext-number:bpnlProperty ext-information:email [ samm:property ext-information:phoneNumber; samm:optional true ] ) .
+
+:PartEntity a samm:Entity ;
+   samm:preferredName "Part Entity"@en ;
+   samm:description "Entity of the Characteristic PartCharacteristic"@en ;
+   samm:properties ( [ samm:property :supplierPartNumber; samm:optional true ] :customerPartNumber :orderNumber [ samm:property ext-core:serialNumber; samm:optional true ] [ samm:property ext-core:batchNumber; samm:optional true ] [ samm:property ext-core:partName; samm:optional true ] [ samm:property ext-core:hwVersion; samm:optional true ] [ samm:property ext-core:partId; samm:optional true ] ) .
+
+:PersonEntity a samm:Entity ;
+   samm:preferredName "Person Entity"@en ;
+   samm:description "Entity containing information of one specific person"@en ;
+   samm:properties ( :name [ samm:property :department; samm:optional true ] [ samm:property :role; samm:optional true ] [ samm:property ext-information:phoneNumber; samm:optional true ] ext-information:email ) .
+
+:DescriptionofInterimContainmentAction a samm:Entity ;
+   samm:preferredName "Description of Interim Containment Action"@en ;
+   samm:description "Describes the immediate technical measure to resolve the quality problem in the short term"@en ;
+   samm:properties ( :proofOfEffectiveness [ samm:property :effectivenessResult; samm:optional true ] :introductionDate [ samm:property :responsiblePerson; samm:optional true ] [ samm:property :riskOfImmediateMeasure; samm:optional true ] [ samm:property :methodForEffectivenessCheck; samm:optional true ] ) .
+
+:Cause a samm:Entity ;
+   samm:preferredName "Cause"@en ;
+   samm:description "Describes a cause for the 8D Report"@en ;
+   samm:properties ( :typeOfCauses :causeHypothesisDescription [ samm:property :verificationBy; samm:optional true ] :clarificationDate :result [ samm:property :method; samm:optional true ] [ samm:property :report; samm:optional true ] [ samm:property :errorCauseCategory; samm:optional true ] ) .
+
+:Measure a samm:Entity ;
+   samm:preferredName "Measure"@en ;
+   samm:description "Measure to resolve the quality problem permanently"@en ;
+   samm:properties ( :introductionDate [ samm:property :responsiblePerson; samm:optional true ] [ samm:property :causeAssignment; samm:optional true ] :proofOfEffectiveness [ samm:property :effectivenessResult; samm:optional true ] [ samm:property :status; samm:optional true ] :measure ) .
+
+:companyName a samm:Property ;
+   samm:preferredName "Company name"@en ;
+   samm:description "The name of the buyer company is the official registered name of the buyer's business."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Test Company" .
+
+:street a samm:Property ;
+   samm:preferredName "Street"@en ;
+   samm:description "The street of the contact refers to the street address where the contact's business is located."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Test Avenue" .
+
+:city a samm:Property ;
+   samm:preferredName "City"@en ;
+   samm:description "The location of the contact indicates the city or town where the contact operates."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Berlin" .
+
+:postalCode a samm:Property ;
+   samm:preferredName "Postal code"@en ;
+   samm:description "The postal code of the contact is the ZIP or postal code for the contact's address."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "012345" .
+
+:country a samm:Property ;
+   samm:preferredName "Country"@en ;
+   samm:description "The country of the contact specifies the nation where the contact's business is based."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Germany" .
+
+:supplierPartNumber a samm:Property ;
+   samm:preferredName "Supplier Part Number"@en ;
+   samm:description "The part number of the supplier is the identifier assigned to the part by the supplier."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "123456789" .
+
+:customerPartNumber a samm:Property ;
+   samm:preferredName "Customer Part Number"@en ;
+   samm:description "The part number of the customer is the identifier assigned to the part by the customer."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "987564321" .
+
+:orderNumber a samm:Property ;
+   samm:preferredName "Order number"@en ;
+   samm:description "The order number of the part is the number associated with the purchase order for the part."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "192837645" .
+
+:name a samm:Property ;
+   samm:preferredName "Name"@en ;
+   samm:description "The name of the person working on the 8D-report"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Max Muster" .
+
+:department a samm:Property ;
+   samm:preferredName "Department"@en ;
+   samm:description "The department of the person working on the 8D-report"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "QualityManagement" .
+
+:role a samm:Property ;
+   samm:preferredName "Role"@en ;
+   samm:description "The role in the company of the person working on the 8D-report"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "QualityExpert" .
+
+:proofOfEffectiveness a samm:Property ;
+   samm:preferredName "Proof Of Effectiveness"@en ;
+   samm:description "Explain how the effectiveness of this measure has been validated"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Daily inspection of the produced parts for scratches" .
+
+:effectivenessResult a samm:Property ;
+   samm:preferredName "Effectiveness Result"@en ;
+   samm:description "Explain to which extend / percentage the measure is effective"@en ;
+   samm:characteristic :Percentage ;
+   samm:exampleValue "80"^^xsd:int .
+
+:introductionDate a samm:Property ;
+   samm:preferredName "IntroductionDate"@en ;
+   samm:description "Definition of the date of introduction of the immediate measures - the date as yyyy-mm-dd"@en ;
+   samm:characteristic ext-core:ISO8601LocalDate ;
+   samm:exampleValue "2025-03-10" .
+
+:responsiblePerson a samm:Property ;
+   samm:preferredName "Responsible Person"@en ;
+   samm:description "Person responsible for the implementation of the planned corrective measure"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Max Mustermann" .
+
+:riskOfImmediateMeasure a samm:Property ;
+   samm:preferredName "Risk Of Immediate Measure"@en ;
+   samm:description "Describes the risk of introduction an immediate measure"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Possible delays in the production process due to the additional controls" .
+
+:methodForEffectivenessCheck a samm:Property ;
+   samm:preferredName "Method For Effectiveness Check"@en ;
+   samm:description "Describes the method for testing and demonstrating effectiveness"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "FMEA (Failure Mode and Effects Analysis)" .
+
+:typeOfCauses a samm:Property ;
+   samm:preferredName "Type Of Causes"@en ;
+   samm:description "There are different types of causes which are defined in 4 different categories."@en ;
+   samm:characteristic :TypeOfCausesEnumeration ;
+   samm:exampleValue "TUA" .
+
+:causeHypothesisDescription a samm:Property ;
+   samm:preferredName "Cause Hypothesis Description"@en ;
+   samm:description "Describes the causal hypothesis"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Insufficient lubrication of the brake components." .
+
+:verificationBy a samm:Property ;
+   samm:preferredName "Verification By"@en ;
+   samm:description "Name the person responsible for investigating the hypothesis"@en ;
+   samm:characteristic samm-c:Text .
+
+:clarificationDate a samm:Property ;
+   samm:preferredName "Clarification Date"@en ;
+   samm:description "Determination of the date of clarification of the cause - the date as yyyy-mm-dd"@en ;
+   samm:characteristic ext-core:ISO8601LocalDate ;
+   samm:exampleValue "3/21/2025" .
+
+:result a samm:Property ;
+   samm:preferredName "Result"@en ;
+   samm:description "The result describes the outcome of a causal hypothesis"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Lubrication investigation showed insufficient lubrication in some cases." .
+
+:method a samm:Property ;
+   samm:preferredName "Method"@en ;
+   samm:description "Describes the method for forming the causal hypothesis"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "5why" .
+
+:report a samm:Property ;
+   samm:preferredName "Report"@en ;
+   samm:description "Describes in detail the result of the investigated root cause hypothesis"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A detailed report was prepared documenting the analysis, the hypotheses tested, and the root cause identified." .
+
+:errorCauseCategory a samm:Property ;
+   samm:preferredName "Error Cause Category"@en ;
+   samm:description "Describes the error cause category (ID) according to the VDA error catalog"@en ;
+   samm:see <https://view.officeapps.live.com/op/view.aspx?src=https%3A%2F%2Fvda-qmc.de%2Fwp-content%2Fuploads%2F2023%2F01%2FVDA_8D_Fehlerursachenkategorien_V2.1_15112019-englisch.xlsx&wdOrigin=BROWSELINK> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "10030012" .
+
+:causeAssignment a samm:Property ;
+   samm:preferredName "Cause Assignment"@en ;
+   samm:description "Define for which root cause the measure is relevant"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Root cause 1" .
+
+:status a samm:Property ;
+   samm:preferredName "Status"@en ;
+   samm:description "Implementation status"@en ;
+   samm:characteristic :StatusEnumeration ;
+   samm:exampleValue "Closed" .
+
+:measure a samm:Property ;
+   samm:preferredName "Measure"@en ;
+   samm:description "Plan technical measure to resolve the quality problem permanently"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Introduction of camera inspection with automatic OK/nOK separation" .
+
+:Percentage a samm-c:Measurement ;
+   samm:preferredName "Percentage"@en ;
+   samm:description "A number between 0 and 100"@en ;
+   samm:dataType xsd:int ;
+   samm-c:unit unit:percent .
+
+:TypeOfCausesEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Type Of Causes Enumeration"@en ;
+   samm:description "Describes the valid inputs for the aspect typeOfCausesEnumeration"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "TUA" "TUN" "SUA" "SUN" ) .
+
+:StatusEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Status Enumeration"@en ;
+   samm:description "Defines valid values for the field Status"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "closed" "open" "in progress" ) .
+

--- a/io.catenax.report_8d/1.0.0/metadata.json
+++ b/io.catenax.report_8d/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.report_8d/RELEASE_NOTES.md
+++ b/io.catenax.report_8d/RELEASE_NOTES.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [Unreleased]
+
+## [1.0.0] - 2025-07-01
+### Added
+- initial version of this model
+
+### Changed
+
+
+### Removed


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

This model enables the implement of the 8D process via the Catena-X network.
This model supports the VDA-QDX standard of the 8D as well as the Global 8D standard

 -->

Closes [855](https://github.com/eclipse-tractusx/sldt-semantic-models/issues/855)

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
