### PR TITLE
[New Model] Warranty Data Model - Warranty Claim Request

### DIFF
--- a/io.catenax.warranty_claim_request/1.0.0/WarrantyClaimRequest.ttl
+++ b/io.catenax.warranty_claim_request/1.0.0/WarrantyClaimRequest.ttl
@@ -1,0 +1,191 @@
+#######################################################################
+# Copyright (c) 2025 Robert Bosch GmbH
+# Copyright (c) 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2025 Volkswagen AG
+# Copyright (c) 2025 ZF Friedrichshafen AG
+# Copyright (c) 2025 SAP SE
+# Copyright (c) 2025 Siemens AG
+# Copyright (c) 2025 DENSO AUTOMOTIVE Deutschland GmbH
+# Copyright (c) 2025 WITTE Automotive GmbH
+# Copyright (c) 2025 Schaeffler Technologies AG & Co. KG
+# Copyright (c) 2025 Ford Werke GmbH
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.warranty_claim_request:1.0.0#> .
+@prefix ext-bpn: <urn:samm:io.catenax.shared.business_partner_number:2.0.0#> .
+@prefix ext-core: <urn:samm:io.catenax.shared.quality_core:1.0.0#> .
+
+:WarrantyClaimRequest a samm:Aspect ;
+   samm:preferredName "Warranty Claim Request"@en ;
+   samm:description "The focus of the data model is on standardizing the exchange of warranty information within the Catena-X network. This issue primarily affects suppliers who do not receive quality data from their customers (OEMs) and do not exchange data with their own suppliers (Tier 2 - n). These suppliers receive warranty claims from their customers (OEMs) at regular or irregular intervals. Due to a lack of “real” quality data, these claims are used to derive a quality analysis of the faulty components. "@en ;
+   samm:properties ( :claimId :billingId :billingDate :repairIndicator [ samm:property :recoveryType; samm:optional true ] [ samm:property :warrantyType; samm:optional true ] [ samm:property :recoveryGroupCode; samm:optional true ] [ samm:property :recoveryGroupName; samm:optional true ] :billedCurrency :billedAmount :billedTF [ samm:property :repairCostsTF100; samm:optional true ] [ samm:property :materialCosts; samm:optional true ] [ samm:property :laborCosts; samm:optional true ] [ samm:property :otherCosts; samm:optional true ] [ samm:property :hourlyRate; samm:optional true ] [ samm:property :globalLaborCode; samm:optional true ] [ samm:property :globalLaborCodeDesc; samm:optional true ] [ samm:property :baseLaborTime; samm:optional true ] [ samm:property :otherLaborTime; samm:optional true ] [ samm:property :supplementalLaborTime; samm:optional true ] [ samm:property :diagnosticLaborTime; samm:optional true ] [ samm:property :totalTime; samm:optional true ] ext-core:qualityTaskId [ samm:property ext-core:vehicleId; samm:optional true ] ext-core:anonymizedVIN [ samm:property ext-bpn:bpnsProperty; samm:optional true ] ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:claimId a samm:Property ;
+   samm:preferredName "Claim Identifier"@en ;
+   samm:description "Each claim from this data provider has a unique claim ID. If you combine the BPNL of the data provider with this claim ID you get a unique claim ID in the data space."@en ;
+   samm:characteristic ext-core:UniqueID ;
+   samm:exampleValue "a214-13d6" .
+
+:billingId a samm:Property ;
+   samm:preferredName "Billing ID"@en ;
+   samm:description "A unique identifier for one billing. It is data provider individual."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "B123456789" .
+
+:billingDate a samm:Property ;
+   samm:preferredName "Billing date"@en ;
+   samm:description "References the date when the claim was billed. Date format: ISO (JJJJ-MM-DD)"@en ;
+   samm:characteristic ext-core:ISO8601LocalDate ;
+   samm:exampleValue "2025-01-15" .
+
+:repairIndicator a samm:Property ;
+   samm:preferredName "Repair Indicator"@en ;
+   samm:description "A unique identifier for one type of activity. It is data provider individual."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Regular" .
+
+:recoveryType a samm:Property ;
+   samm:preferredName "Recovery type"@en ;
+   samm:description "A unique identifier for one type of recovery. It is data provider individual."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Standard" .
+
+:warrantyType a samm:Property ;
+   samm:preferredName "Warranty type"@en ;
+   samm:description "A unique identifier for one type of warranty. It is data provider individual."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Vehicle warranty" .
+
+:recoveryGroupCode a samm:Property ;
+   samm:preferredName "Recovery group code"@en ;
+   samm:description "A unique code for one specific part family (technically similar to Product Groups)."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A258" .
+
+:recoveryGroupName a samm:Property ;
+   samm:preferredName "Recovery group name"@en ;
+   samm:description "A name for one specific part family (technically similar to Product Groups)."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Part family A" .
+
+:billedCurrency a samm:Property ;
+   samm:preferredName "Billed currency"@en ;
+   samm:description "Billing currency according to ISO 4217 (latest version)"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "EUR" .
+
+:billedAmount a samm:Property ;
+   samm:preferredName "billed Amount"@en ;
+   samm:description "Billing amount for the specific repair."@en ;
+   samm:characteristic :CurrencyCharacteristic ;
+   samm:exampleValue "1000.00"^^xsd:float .
+
+:billedTF a samm:Property ;
+   samm:preferredName "Billed technical factor"@en ;
+   samm:description "Technical Factor which is charged"@en ;
+   samm:characteristic :CurrencyCharacteristic ;
+   samm:exampleValue "100.00"^^xsd:float .
+
+:repairCostsTF100 a samm:Property ;
+   samm:preferredName "Repair costs technical factor 100"@en ;
+   samm:description "Cost for the repair - overall"@en ;
+   samm:characteristic :CurrencyCharacteristic ;
+   samm:exampleValue "1000.00"^^xsd:float .
+
+:materialCosts a samm:Property ;
+   samm:preferredName "Material costs"@en ;
+   samm:description "Cost for the repair - parts"@en ;
+   samm:characteristic :CurrencyCharacteristic ;
+   samm:exampleValue "200.00"^^xsd:float .
+
+:laborCosts a samm:Property ;
+   samm:preferredName "Labor costs"@en ;
+   samm:description "Labor costs for the repair"@en ;
+   samm:characteristic :CurrencyCharacteristic ;
+   samm:exampleValue "700.00"^^xsd:float .
+
+:otherCosts a samm:Property ;
+   samm:preferredName "Other costs"@en ;
+   samm:description "Cost for the repair - others (consumables, handling fees, etc.)"@en ;
+   samm:characteristic :CurrencyCharacteristic ;
+   samm:exampleValue "100.00"^^xsd:float .
+
+:hourlyRate a samm:Property ;
+   samm:preferredName "Hourly rate"@en ;
+   samm:description "Individual hourly rate per OEM / per country"@en ;
+   samm:characteristic :CurrencyCharacteristic ;
+   samm:exampleValue "100.00"^^xsd:float .
+
+:globalLaborCode a samm:Property ;
+   samm:preferredName "Global labor code"@en ;
+   samm:description "Code for OEM specific definition of the repair performed / billed"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "L968574" .
+
+:globalLaborCodeDesc a samm:Property ;
+   samm:preferredName "Global labor code description"@en ;
+   samm:description "Description for OEM specific definition of the repair performed / billed"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Replacement of Mickey Mouse" .
+
+:baseLaborTime a samm:Property ;
+   samm:preferredName "Base labor time"@en ;
+   samm:description "Labor time (minutes) - base labor"@en ;
+   samm:characteristic :BillableMinutesCharacteristic ;
+   samm:exampleValue "300"^^xsd:positiveInteger .
+
+:otherLaborTime a samm:Property ;
+   samm:preferredName "Other labor time"@en ;
+   samm:description "Labor time (minutes) - other"@en ;
+   samm:characteristic :BillableMinutesCharacteristic ;
+   samm:exampleValue "60"^^xsd:positiveInteger .
+
+:supplementalLaborTime a samm:Property ;
+   samm:preferredName "Supplemental labor time"@en ;
+   samm:description "Labor time (minutes) - supplemental"@en ;
+   samm:characteristic :BillableMinutesCharacteristic ;
+   samm:exampleValue "30"^^xsd:positiveInteger .
+
+:diagnosticLaborTime a samm:Property ;
+   samm:preferredName "Diagnostic labor time"@en ;
+   samm:description "Labor time (minutes) - diagnostic"@en ;
+   samm:characteristic :BillableMinutesCharacteristic ;
+   samm:exampleValue "30"^^xsd:positiveInteger .
+
+:totalTime a samm:Property ;
+   samm:preferredName "Total time"@en ;
+   samm:description "Labor time (minutes) - total"@en ;
+   samm:characteristic :BillableMinutesCharacteristic ;
+   samm:exampleValue "420"^^xsd:positiveInteger .
+
+:CurrencyCharacteristic a samm:Characteristic ;
+   samm:preferredName "Currency characteristic"@en ;
+   samm:description "Currency Characteristic is used for all currency related aspects having a positive float values"@en ;
+   samm:dataType xsd:float .
+
+:BillableMinutesCharacteristic a samm:Characteristic ;
+   samm:preferredName "Billable minutes characteristic"@en ;
+   samm:description "Characteristic used for time related values (minutes)"@en ;
+   samm:dataType xsd:positiveInteger .
+

--- a/io.catenax.warranty_claim_request/1.0.0/WarrantyClaimRequest.ttl
+++ b/io.catenax.warranty_claim_request/1.0.0/WarrantyClaimRequest.ttl
@@ -48,7 +48,7 @@
    samm:exampleValue "a214-13d6" .
 
 :billingId a samm:Property ;
-   samm:preferredName "Billing ID"@en ;
+   samm:preferredName "Billing Identifier"@en ;
    samm:description "A unique identifier for one billing. It is data provider individual."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "B123456789" .
@@ -96,7 +96,7 @@
    samm:exampleValue "EUR" .
 
 :billedAmount a samm:Property ;
-   samm:preferredName "billed Amount"@en ;
+   samm:preferredName "Billed Amount"@en ;
    samm:description "Billing amount for the specific repair."@en ;
    samm:characteristic :CurrencyCharacteristic ;
    samm:exampleValue "1000.00"^^xsd:float .

--- a/io.catenax.warranty_claim_request/1.0.0/metadata.json
+++ b/io.catenax.warranty_claim_request/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.warranty_claim_request/RELEASE_NOTES.md
+++ b/io.catenax.warranty_claim_request/RELEASE_NOTES.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [1.0.0] - 2025-07-01
+### Added
+- initial version of model
+
+### Changed
+n/a
+
+### Removed
+


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

New model for exchange of warranty request data

 -->

Closes [#808](https://github.com/eclipse-tractusx/sldt-semantic-models/issues/808)

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
