### PR TITLE
[New Model] Warranty Claim Request Verification

### DIFF
--- a/io.catenax.warranty_request_varification/1.0.0/WarrantyClaimRequestVerification.ttl
+++ b/io.catenax.warranty_request_varification/1.0.0/WarrantyClaimRequestVerification.ttl
@@ -1,0 +1,138 @@
+#######################################################################
+# Copyright (c) 2025 Robert Bosch GmbH
+# Copyright (c) 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2025 Volkswagen AG
+# Copyright (c) 2025 ZF Friedrichshafen AG
+# Copyright (c) 2025 SAP SE
+# Copyright (c) 2025 Siemens AG
+# Copyright (c) 2025 DENSO AUTOMOTIVE Deutschland GmbH
+# Copyright (c) 2025 WITTE Automotive GmbH
+# Copyright (c) 2025 Schaeffler Technologies AG & Co. KG
+# Copyright (c) 2025 Ford Werke GmbH
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.warranty_claim_request_verification:1.0.0#> .
+@prefix ext-core: <urn:samm:io.catenax.shared.quality_core:1.0.0#> .
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:2.0.0#> .
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
+
+:WarrantyClaimRequestVerification a samm:Aspect ;
+   samm:preferredName "Warranty Claim Request"@en ;
+   samm:description "For Catena-X business case Quality Management. This model is used to send back the answer for a WarrantyClaimRequest from a component manufacturer to a vehicle manufacturer (OEM). "@en ;
+   samm:properties ( :claimId ext-core:qualityTaskId ext-number:bpnlProperty [ samm:property ext-core:vehicleId; samm:optional true ] ext-core:anonymizedVIN :billingId :billingDate :agreedTechnicalFactor :debitValueJustified :billedCurrency :claimPlausible :claimImplausible :billingStatus :statementDate :statementReason ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:claimId a samm:Property ;
+   samm:preferredName "Claim ID"@en ;
+   samm:description "Each claim from this data provider has a unique claim ID.If you combine the BPNL of the data provider with this claim ID you get a unique claim ID in the data space."@en ;
+   samm:characteristic ext-core:UniqueID ;
+   samm:exampleValue "a214-13d6" .
+
+:billingId a samm:Property ;
+   samm:preferredName "Billing Identifier"@en ;
+   samm:description "A unique identifier for one billing. It is data provider individual."@en ;
+   samm:characteristic ext-core:UniqueID ;
+   samm:exampleValue "B123456789" .
+
+:billingDate a samm:Property ;
+   samm:preferredName "Billing Date"@en ;
+   samm:description "References the date when the claim was billed. Date format: ISO (YYYY-MM-DD)"@en ;
+   samm:characteristic ext-core:ISO8601LocalDate ;
+   samm:exampleValue "2025-02-13" .
+
+:agreedTechnicalFactor a samm:Property ;
+   samm:preferredName "Agreed Technical Factor"@en ;
+   samm:description "Technical factor which was agreed upon."@en ;
+   samm:characteristic :PositiveInteger ;
+   samm:exampleValue "50"^^xsd:positiveInteger .
+
+:debitValueJustified a samm:Property ;
+   samm:preferredName "Debit Value Justified"@en ;
+   samm:description "Check between billed technical factor & agreed technical factor; other plausibility checks"@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:billedCurrency a samm:Property ;
+   samm:preferredName "Billed Currency"@en ;
+   samm:description "Billing currency"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "EUR" .
+
+:claimPlausible a samm:Property ;
+   samm:preferredName "Claim Plausible"@en ;
+   samm:description "Check between billed technical factor & agreed technical factor"@en ;
+   samm:characteristic :PositiveFloatNumber ;
+   samm:exampleValue "500.00"^^xsd:float .
+
+:claimImplausible a samm:Property ;
+   samm:preferredName "Claim Implausible"@en ;
+   samm:description "Check between billed technical factor & agreed technical factor"@en ;
+   samm:characteristic :PositiveFloatNumber ;
+   samm:exampleValue "500.00"^^xsd:float .
+
+:billingStatus a samm:Property ;
+   samm:preferredName "Billing Status"@en ;
+   samm:description "Status of the bill based on claim_request_verification assessment (approved / disputed / …)"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "approved" .
+
+:statementDate a samm:Property ;
+   samm:preferredName "Statement Date"@en ;
+   samm:description "Due date for the claim_request_verification to approve / dispute the bill"@en ;
+   samm:characteristic ext-core:ISO8601LocalDate ;
+   samm:exampleValue "2025-02-13" .
+
+:statementReason a samm:Property ;
+   samm:preferredName "Statement Reason"@en ;
+   samm:description "Reason give by the claim_request_verification, why the bill / claim was disputed"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Technical factor too high" .
+
+:PositiveInteger a samm:Characteristic ;
+   samm:preferredName "Positive Integer"@en ;
+   samm:description "Defines a positive integer number."@en ;
+   samm:dataType xsd:positiveInteger .
+
+:PositiveFloatNumber a samm-c:Trait ;
+   samm:preferredName "Positive Float Number"@en ;
+   samm:description "Represents a positive float number."@en ;
+   samm-c:baseCharacteristic :Float ;
+   samm-c:constraint :GreaterZero .
+
+:Float a samm:Characteristic ;
+   samm:preferredName "Float"@en ;
+   samm:description "Defines a float number."@en ;
+   samm:dataType xsd:float .
+
+:GreaterZero a samm-c:RangeConstraint ;
+   samm:preferredName "Greatere Zero"@en ;
+   samm:description "Range constraint for numbers including or bigger than 0."@en ;
+   samm-c:minValue "0"^^xsd:float ;
+   samm-c:lowerBoundDefinition samm-c:AT_LEAST ;
+   samm-c:upperBoundDefinition samm-c:LESS_THAN .
+
+:BillableMinutesCharacteristic a samm:Characteristic ;
+   samm:dataType xsd:positiveInteger .
+

--- a/io.catenax.warranty_request_varification/1.0.0/metadata.json
+++ b/io.catenax.warranty_request_varification/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.warranty_request_varification/RELEASE_NOTES.md
+++ b/io.catenax.warranty_request_varification/RELEASE_NOTES.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this model will be documented in this file.
+
+## [Unreleased]
+
+
+## [1.0.0] - 2025-07-01
+### Added
+- initial version of model
+
+### Changed
+n/a
+
+### Removed
+


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

New semantic model for exchanging warranty request verifications

 -->

Closes [#839](https://github.com/eclipse-tractusx/sldt-semantic-models/issues/839)

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
