### PR TITLE
hotfix: added unique aspect attribute

### DIFF
--- a/io.catenax.generic.digital_product_passport/6.0.0/gen/DigitalProductPassport-context.jsonld
+++ b/io.catenax.generic.digital_product_passport/6.0.0/gen/DigitalProductPassport-context.jsonld
@@ -2,15 +2,19 @@
   "@context": {
     "@version": 1.1,
     "schema": "https://schema.org/",
-    "DigitalProductPassport": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#",
+    "digitalproductpassport-aspect": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#",
+    "DigitalProductPassport": {
+      "@id": "digitalproductpassport-aspect:DigitalProductPassport",
+      "@type": "@id"
+    },
     "metadata": {
-      "@id": "DigitalProductPassport:metadata",
+      "@id": "digitalproductpassport-aspect:metadata",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "version": {
-          "@id": "DigitalProductPassport:version",
+          "@id": "digitalproductpassport-aspect:version",
           "@context": {
             "@definition": "The current version of the product passport. The possibility of modification/ updating the product passport needs to include versioning of the dataset. This attribute is an internal versioning from the passport issuer. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(1) [...] The information in the product passport shall be accurate, complete, and up to date.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#version"
@@ -18,7 +22,7 @@
           "@type": "schema:string"
         },
         "status": {
-          "@id": "DigitalProductPassport:status",
+          "@id": "digitalproductpassport-aspect:status",
           "@context": {
             "@definition": "The current status of the product passport declared through either: draft, approved, invalid or expired.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#status"
@@ -26,7 +30,7 @@
           "@type": "schema:string"
         },
         "expirationDate": {
-          "@id": "DigitalProductPassport:expirationDate",
+          "@id": "digitalproductpassport-aspect:expirationDate",
           "@context": {
             "@definition": "The timestamp in the format (yyyy-mm-dd) for the product passport until when it is available or a comment describing this period. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(2) (h) the period during which the product passport is to remain available, which shall correspond to at least the expected lifetime of a specific product.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#expirationDate"
@@ -34,7 +38,7 @@
           "@type": "schema:string"
         },
         "issueDate": {
-          "@id": "DigitalProductPassport:issueDate",
+          "@id": "digitalproductpassport-aspect:issueDate",
           "@context": {
             "@definition": "The timestamp in the format (yyyy-mm-dd) since when the product passport is available.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#issueDate"
@@ -42,7 +46,7 @@
           "@type": "schema:string"
         },
         "economicOperatorId": {
-          "@id": "DigitalProductPassport:economicOperatorId",
+          "@id": "digitalproductpassport-aspect:economicOperatorId",
           "@context": {
             "@definition": "The identification of the owner/economic operator of the passport. Proposed, according to ISO 15459, is the CIN (company identification code). Other identification numbers like the tax identification number, value added tax identification number, commercial register number and the like are also valid entries. In the Catena-X network, the BPNL is used for the identification of companies and the information stored like contact information and addresses. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex III:\n(k) the [...] unique operator identifier code of the economic operator established in the Union responsible for carrying out the tasks set out in Article 4 of Regulation (EU) 2019/1020, or Article 15 of Regulation (EU) on general product safety, or similar tasks pursuant to other EU legislation applicable to the product.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#economicOperatorId"
@@ -50,7 +54,7 @@
           "@type": "schema:string"
         },
         "passportIdentifier": {
-          "@id": "DigitalProductPassport:passportIdentifier",
+          "@id": "digitalproductpassport-aspect:passportIdentifier",
           "@context": {
             "@definition": "The identifier of the product passport, which is an uuidv4.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#passportIdentifier"
@@ -58,7 +62,7 @@
           "@type": "schema:string"
         },
         "predecessor": {
-          "@id": "DigitalProductPassport:predecessor",
+          "@id": "digitalproductpassport-aspect:predecessor",
           "@context": {
             "@definition": "Identification of the preceding product passport. If there is no preceding passport, input a dummy value. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(2)(g) [...] Any new product passport shall be linked to the product passport or passports of the original product whenever appropriate.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#predecessor"
@@ -66,7 +70,7 @@
           "@type": "schema:string"
         },
         "backupReference": {
-          "@id": "DigitalProductPassport:backupReference",
+          "@id": "digitalproductpassport-aspect:backupReference",
           "@context": {
             "@definition": "A reference to the data backup of the passport. This mandatory attribute will be further defined in the future. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex III:\n(kb) the reference of the certified independent third-party product passport service provider hosting the back-up copy of the product passport.\nArticle 10 also mentions:\n(c) the data included in the product passport shall be stored by the economic operator responsible for its creation or by certified independent third-party product passport service providers authorised to act on their behalf.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#backupReference"
@@ -74,7 +78,7 @@
           "@type": "schema:string"
         },
         "registrationIdentifier": {
-          "@id": "DigitalProductPassport:registrationIdentifier",
+          "@id": "digitalproductpassport-aspect:registrationIdentifier",
           "@context": {
             "@definition": "Identifier in the respective registry. This will be further defined in the future. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 in Article 12:\nBy [2 years from entering into force of this Regulation], the Commission shall set up and manage a digital registry (\"the registry\") storing in a secure manner at least the unique product identifier, the unique operator identifier, the unique facility identifiers. In case of products intended to be placed under the customs procedure 'release for free circulation', the registry shall also store the product commodity code. The registry shall also store the batteries' unique identifiers referred to in Article 77(3) of Regulation (EU) 2023/1542.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#registrationIdentifier"
@@ -82,7 +86,7 @@
           "@type": "schema:string"
         },
         "lastModification": {
-          "@id": "DigitalProductPassport:lastModification",
+          "@id": "digitalproductpassport-aspect:lastModification",
           "@context": {
             "@definition": "Date of the latest modification.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#lastModification"
@@ -90,7 +94,7 @@
           "@type": "schema:string"
         },
         "language": {
-          "@id": "DigitalProductPassport:language",
+          "@id": "digitalproductpassport-aspect:language",
           "@context": {
             "@definition": "Specific language in which the passport content is created. Language code is based on the ISO 639-1.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#language"
@@ -102,18 +106,18 @@
       }
     },
     "identification": {
-      "@id": "DigitalProductPassport:identification",
+      "@id": "digitalproductpassport-aspect:identification",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": {
-          "@id": "DigitalProductPassport:type",
+          "@id": "digitalproductpassport-aspect:type",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "manufacturerPartId": {
-              "@id": "DigitalProductPassport:manufacturerPartId",
+              "@id": "digitalproductpassport-aspect:manufacturerPartId",
               "@context": {
                 "@definition": "Part ID as assigned by the manufacturer of the part. The part ID identifies the part in the manufacturer`s dataspace. The part ID references a specific version of a part. The version number must be included in the part ID if it is available. The part ID does not reference a specific instance of a part and must not be confused with the serial number.",
                 "@samm-urn": "urn:samm:io.catenax.part_type_information:1.0.0#manufacturerPartId"
@@ -121,7 +125,7 @@
               "@type": "schema:string"
             },
             "nameAtManufacturer": {
-              "@id": "DigitalProductPassport:nameAtManufacturer",
+              "@id": "digitalproductpassport-aspect:nameAtManufacturer",
               "@context": {
                 "@definition": "Name of the part as assigned by the manufacturer.",
                 "@samm-urn": "urn:samm:io.catenax.part_type_information:1.0.0#nameAtManufacturer"
@@ -133,7 +137,7 @@
           }
         },
         "serial": {
-          "@id": "DigitalProductPassport:serial",
+          "@id": "digitalproductpassport-aspect:serial",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -143,7 +147,7 @@
               "id": "@id",
               "type": "@type",
               "key": {
-                "@id": "DigitalProductPassport:key",
+                "@id": "digitalproductpassport-aspect:key",
                 "@context": {
                   "@definition": "The key of a local identifier. ",
                   "@samm-urn": "urn:samm:io.catenax.serial_part:3.0.0#key"
@@ -151,7 +155,7 @@
                 "@type": "schema:string"
               },
               "value": {
-                "@id": "DigitalProductPassport:value",
+                "@id": "digitalproductpassport-aspect:value",
                 "@context": {
                   "@definition": "The value of an identifier.",
                   "@samm-urn": "urn:samm:io.catenax.serial_part:3.0.0#value"
@@ -165,7 +169,7 @@
           "@container": "@list"
         },
         "batch": {
-          "@id": "DigitalProductPassport:batch",
+          "@id": "digitalproductpassport-aspect:batch",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -175,7 +179,7 @@
               "id": "@id",
               "type": "@type",
               "key": {
-                "@id": "DigitalProductPassport:key",
+                "@id": "digitalproductpassport-aspect:key",
                 "@context": {
                   "@definition": "The key of a local identifier.",
                   "@samm-urn": "urn:samm:io.catenax.batch:3.0.0#key"
@@ -183,7 +187,7 @@
                 "@type": "schema:string"
               },
               "value": {
-                "@id": "DigitalProductPassport:value",
+                "@id": "digitalproductpassport-aspect:value",
                 "@context": {
                   "@definition": "The value of an identifier.",
                   "@samm-urn": "urn:samm:io.catenax.batch:3.0.0#value"
@@ -197,7 +201,7 @@
           "@container": "@list"
         },
         "codes": {
-          "@id": "DigitalProductPassport:codes",
+          "@id": "digitalproductpassport-aspect:codes",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -207,7 +211,7 @@
               "id": "@id",
               "type": "@type",
               "key": {
-                "@id": "DigitalProductPassport:key",
+                "@id": "digitalproductpassport-aspect:key",
                 "@context": {
                   "@definition": "The code key for the identification of the product. Examples are GTIN, hash, DID, ISBN, TARIC. This attribute is mentioned in the ESPR proposal from March 30th, 2022 ANNEX III:\n(b) the unique product identifier at the level indicated in the applicable delegated act adopted pursuant to Article 4;\n(c) the Global Trade Identification Number as provided for in standard ISO/IEC 15459-6 or equivalent of products or their parts;\n(d) relevant commodity codes, such as a TARIC code as defined in Council Regulation (EEC) No 2658/87.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#codeKey"
@@ -215,7 +219,7 @@
                 "@type": "schema:string"
               },
               "value": {
-                "@id": "DigitalProductPassport:value",
+                "@id": "digitalproductpassport-aspect:value",
                 "@context": {
                   "@definition": "The code value for the identification of the product in regard to the chosen code name.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#codeValue"
@@ -229,13 +233,13 @@
           "@container": "@list"
         },
         "dataCarrier": {
-          "@id": "DigitalProductPassport:dataCarrier",
+          "@id": "digitalproductpassport-aspect:dataCarrier",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "carrierType": {
-              "@id": "DigitalProductPassport:carrierType",
+              "@id": "digitalproductpassport-aspect:carrierType",
               "@context": {
                 "@definition": "The type of data carrier such as a QR code on the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 8:\n(2) (b) the types of data carrier to be used.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#carrierType"
@@ -243,7 +247,7 @@
               "@type": "schema:string"
             },
             "carrierLayout": {
-              "@id": "DigitalProductPassport:carrierLayout",
+              "@id": "digitalproductpassport-aspect:carrierLayout",
               "@context": {
                 "@definition": "The positioning of data carrier on the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 8:\n(2) (c) the layout in which the data carrier shall be presented and its positioning.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#carrierLayout"
@@ -255,7 +259,7 @@
           }
         },
         "classification": {
-          "@id": "DigitalProductPassport:classification",
+          "@id": "digitalproductpassport-aspect:classification",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -265,7 +269,7 @@
               "id": "@id",
               "type": "@type",
               "classificationStandard": {
-                "@id": "DigitalProductPassport:classificationStandard",
+                "@id": "digitalproductpassport-aspect:classificationStandard",
                 "@context": {
                   "@definition": "Identified classification standards that align to the Catena-X needs.",
                   "@samm-urn": "urn:samm:io.catenax.shared.part_classification:1.0.0#classificationStandard"
@@ -273,7 +277,7 @@
                 "@type": "schema:string"
               },
               "classificationID": {
-                "@id": "DigitalProductPassport:classificationID",
+                "@id": "digitalproductpassport-aspect:classificationID",
                 "@context": {
                   "@definition": "The classification ID of the part type according to the corresponding standard definition mentioned in the key value pair.",
                   "@samm-urn": "urn:samm:io.catenax.shared.part_classification:1.0.0#classificationID"
@@ -281,7 +285,7 @@
                 "@type": "schema:string"
               },
               "classificationDescription": {
-                "@id": "DigitalProductPassport:classificationDescription",
+                "@id": "digitalproductpassport-aspect:classificationDescription",
                 "@context": {
                   "@definition": "Optional property describing the classification standard.",
                   "@samm-urn": "urn:samm:io.catenax.shared.part_classification:1.0.0#classificationDescription"
@@ -299,19 +303,19 @@
       }
     },
     "operation": {
-      "@id": "DigitalProductPassport:operation",
+      "@id": "digitalproductpassport-aspect:operation",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "manufacturer": {
-          "@id": "DigitalProductPassport:manufacturer",
+          "@id": "digitalproductpassport-aspect:manufacturer",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "facility": {
-              "@id": "DigitalProductPassport:facility",
+              "@id": "digitalproductpassport-aspect:facility",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -321,7 +325,7 @@
                   "id": "@id",
                   "type": "@type",
                   "facility": {
-                    "@id": "DigitalProductPassport:facility",
+                    "@id": "digitalproductpassport-aspect:facility",
                     "@context": {
                       "@definition": "The identifier used for a location. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#facility"
@@ -335,7 +339,7 @@
               "@container": "@list"
             },
             "manufacturer": {
-              "@id": "DigitalProductPassport:manufacturer",
+              "@id": "digitalproductpassport-aspect:manufacturer",
               "@context": {
                 "@definition": "The main manufacturer, if different from the passport owner, represented by an identification number. In the Catena-X use case, the BPNL can be stated. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(h) unique operator identifiers other than that of the manufacturer;\n(k) the name, contact details and unique operator identifier code of the economic operator established in the Union responsible for carrying out the tasks set out in Article 4 of Regulation (EU) 2019/1020, or Article 15 of Regulation (EU) [.../...] on general product safety, or similar tasks pursuant to other EU legislation applicable to the product.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#manufacturerIdentification"
@@ -343,7 +347,7 @@
               "@type": "schema:string"
             },
             "manufacturingDate": {
-              "@id": "DigitalProductPassport:manufacturingDate",
+              "@id": "digitalproductpassport-aspect:manufacturingDate",
               "@context": {
                 "@definition": "The timestamp in the format (yyyy-mm-dd) of the manufacturing date as the final step in production process (e.g. final quality check, ready-for-shipment event).",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#manufacturingDate"
@@ -355,17 +359,17 @@
           }
         },
         "import": {
-          "@id": "DigitalProductPassport:import",
+          "@id": "digitalproductpassport-aspect:import",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "content": {
-              "@id": "DigitalProductPassport:content",
+              "@id": "digitalproductpassport-aspect:content",
               "@context": {
                 "@version": 1.1,
                 "id": {
-                  "@id": "DigitalProductPassport:id",
+                  "@id": "digitalproductpassport-aspect:id",
                   "@context": {
                     "@definition": "The importer of the product, if different from the owner of the passport. In the Catena-X network, the BPNL is used for the identification of companies and the information stored for this like contact information and addresses.\nThis attribute is mentioned in the ESPR provisional agreement from January 9th, 2024  Annex III:\n(j) information related to the importer, including the information referred to in Article 23(3) and its EORI number;\nArticle 23 states:\n(3) Importers shall, for products covered by a delegated act adopted pursuant to Article 4, indicate their name, registered trade name or registered trade mark and the postal address and electronic means of communication, where they can be contacted:  (a) on the public part of the product passport, when applicable, and\n(b) on the product or, where this is not possible, on the packaging, or in a document accompanying the product.",
                     "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#importerIdentification"
@@ -374,7 +378,7 @@
                 },
                 "type": "@type",
                 "eori": {
-                  "@id": "DigitalProductPassport:eori",
+                  "@id": "digitalproductpassport-aspect:eori",
                   "@context": {
                     "@definition": "An economic operator established in the customs territory of the Union needs, for customs purposes, an EORI number. EORI stands for economic operators registration and identification number. In this case, the importer's EORI must be provided. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex III:\n(j) information related to the importer, including the information referred to in Article 23(3) and its EORI number.",
                     "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#eori"
@@ -386,7 +390,7 @@
               }
             },
             "applicable": {
-              "@id": "DigitalProductPassport:applicable",
+              "@id": "digitalproductpassport-aspect:applicable",
               "@context": {
                 "@definition": "Check whether the connected attributes are applicable to the product. If it is not applicable (false), dummy data can be delivered.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#applicable"
@@ -398,11 +402,11 @@
           }
         },
         "other": {
-          "@id": "DigitalProductPassport:other",
+          "@id": "digitalproductpassport-aspect:other",
           "@context": {
             "@version": 1.1,
             "id": {
-              "@id": "DigitalProductPassport:id",
+              "@id": "digitalproductpassport-aspect:id",
               "@context": {
                 "@definition": "Identifier of the other operator. This can be a BPN.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#otherOperatorId"
@@ -411,7 +415,7 @@
             },
             "type": "@type",
             "role": {
-              "@id": "DigitalProductPassport:role",
+              "@id": "digitalproductpassport-aspect:role",
               "@context": {
                 "@definition": "Role of the other operator.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#otherOperatorRole"
@@ -427,19 +431,19 @@
       }
     },
     "handling": {
-      "@id": "DigitalProductPassport:handling",
+      "@id": "digitalproductpassport-aspect:handling",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "content": {
-          "@id": "DigitalProductPassport:content",
+          "@id": "digitalproductpassport-aspect:content",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "producer": {
-              "@id": "DigitalProductPassport:producer",
+              "@id": "digitalproductpassport-aspect:producer",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -447,7 +451,7 @@
                 "@context": {
                   "@version": 1.1,
                   "id": {
-                    "@id": "DigitalProductPassport:id",
+                    "@id": "digitalproductpassport-aspect:id",
                     "@context": {
                       "@definition": "The identifier of a spare part producer of the product. In the Catena-X network, the BPNL is used for the identification of companies and the information stored for this like contact information and addresses.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#sourcesIdentification"
@@ -462,7 +466,7 @@
               "@container": "@list"
             },
             "sparePart": {
-              "@id": "DigitalProductPassport:sparePart",
+              "@id": "digitalproductpassport-aspect:sparePart",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -472,7 +476,7 @@
                   "id": "@id",
                   "type": "@type",
                   "manufacturerPartId": {
-                    "@id": "DigitalProductPassport:manufacturerPartId",
+                    "@id": "digitalproductpassport-aspect:manufacturerPartId",
                     "@context": {
                       "@definition": "Part ID as assigned by the manufacturer of the part. The part ID identifies the part in the manufacturer`s dataspace. The part ID references a specific version of a part. The version number must be included in the part ID if it is available. The part ID does not reference a specific instance of a part and must not be confused with the serial number.",
                       "@samm-urn": "urn:samm:io.catenax.part_type_information:1.0.0#manufacturerPartId"
@@ -480,7 +484,7 @@
                     "@type": "schema:string"
                   },
                   "nameAtManufacturer": {
-                    "@id": "DigitalProductPassport:nameAtManufacturer",
+                    "@id": "digitalproductpassport-aspect:nameAtManufacturer",
                     "@context": {
                       "@definition": "Name of the part as assigned by the manufacturer.",
                       "@samm-urn": "urn:samm:io.catenax.part_type_information:1.0.0#nameAtManufacturer"
@@ -498,7 +502,7 @@
           }
         },
         "applicable": {
-          "@id": "DigitalProductPassport:applicable",
+          "@id": "digitalproductpassport-aspect:applicable",
           "@context": {
             "@definition": "Check whether the connected attributes are applicable to the product. If it is not applicable (false), dummy data can be delivered.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#applicable"
@@ -510,13 +514,13 @@
       }
     },
     "characteristics": {
-      "@id": "DigitalProductPassport:characteristics",
+      "@id": "digitalproductpassport-aspect:characteristics",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "lifespan": {
-          "@id": "DigitalProductPassport:lifespan",
+          "@id": "digitalproductpassport-aspect:lifespan",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -526,7 +530,7 @@
               "id": "@id",
               "type": "@type",
               "unit": {
-                "@id": "DigitalProductPassport:unit",
+                "@id": "digitalproductpassport-aspect:unit",
                 "@context": {
                   "@definition": "The unit of the respective lifespan expressed through the possible units day, month, cycle, year and runningOrOperatingHour.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#lifeUnit"
@@ -534,7 +538,7 @@
                 "@type": "schema:string"
               },
               "value": {
-                "@id": "DigitalProductPassport:value",
+                "@id": "digitalproductpassport-aspect:value",
                 "@context": {
                   "@definition": "The value as an integer for the respective lifespan.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#lifeValue"
@@ -542,7 +546,7 @@
                 "@type": "schema:number"
               },
               "key": {
-                "@id": "DigitalProductPassport:key",
+                "@id": "digitalproductpassport-aspect:key",
                 "@context": {
                   "@definition": "The type of lifespan represented with the values guaranteed lifetime, technical lifetime and mean time between failures. This attribute is mentioned in the ESPR proposal from March 30th, 2022 ANNEX I:\n(a) durability and reliability of the product or its components as expressed through the product's guaranteed lifetime, technical lifetime [or] mean time between failures [...].",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#lifeType"
@@ -556,19 +560,19 @@
           "@container": "@list"
         },
         "physicalDimension": {
-          "@id": "DigitalProductPassport:physicalDimension",
+          "@id": "digitalproductpassport-aspect:physicalDimension",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "width": {
-              "@id": "DigitalProductPassport:width",
+              "@id": "digitalproductpassport-aspect:width",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "DigitalProductPassport:value",
+                  "@id": "digitalproductpassport-aspect:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -576,7 +580,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "DigitalProductPassport:unit",
+                  "@id": "digitalproductpassport-aspect:unit",
                   "@context": {
                     "@definition": "The unit of a linear attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#linearUnit"
@@ -588,13 +592,13 @@
               }
             },
             "length": {
-              "@id": "DigitalProductPassport:length",
+              "@id": "digitalproductpassport-aspect:length",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "DigitalProductPassport:value",
+                  "@id": "digitalproductpassport-aspect:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -602,7 +606,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "DigitalProductPassport:unit",
+                  "@id": "digitalproductpassport-aspect:unit",
                   "@context": {
                     "@definition": "The unit of a linear attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#linearUnit"
@@ -614,13 +618,13 @@
               }
             },
             "diameter": {
-              "@id": "DigitalProductPassport:diameter",
+              "@id": "digitalproductpassport-aspect:diameter",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "DigitalProductPassport:value",
+                  "@id": "digitalproductpassport-aspect:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -628,7 +632,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "DigitalProductPassport:unit",
+                  "@id": "digitalproductpassport-aspect:unit",
                   "@context": {
                     "@definition": "The unit of a linear attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#linearUnit"
@@ -640,13 +644,13 @@
               }
             },
             "height": {
-              "@id": "DigitalProductPassport:height",
+              "@id": "digitalproductpassport-aspect:height",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "DigitalProductPassport:value",
+                  "@id": "digitalproductpassport-aspect:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -654,7 +658,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "DigitalProductPassport:unit",
+                  "@id": "digitalproductpassport-aspect:unit",
                   "@context": {
                     "@definition": "The unit of a linear attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#linearUnit"
@@ -666,13 +670,13 @@
               }
             },
             "grossWeight": {
-              "@id": "DigitalProductPassport:grossWeight",
+              "@id": "digitalproductpassport-aspect:grossWeight",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "DigitalProductPassport:value",
+                  "@id": "digitalproductpassport-aspect:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -680,7 +684,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "DigitalProductPassport:unit",
+                  "@id": "digitalproductpassport-aspect:unit",
                   "@context": {
                     "@definition": "The unit of a mass related attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#massUnit"
@@ -692,13 +696,13 @@
               }
             },
             "grossVolume": {
-              "@id": "DigitalProductPassport:grossVolume",
+              "@id": "digitalproductpassport-aspect:grossVolume",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "DigitalProductPassport:value",
+                  "@id": "digitalproductpassport-aspect:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -706,7 +710,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "DigitalProductPassport:unit",
+                  "@id": "digitalproductpassport-aspect:unit",
                   "@context": {
                     "@definition": "The unit of a volume related attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#volumeUnit"
@@ -718,13 +722,13 @@
               }
             },
             "weight": {
-              "@id": "DigitalProductPassport:weight",
+              "@id": "digitalproductpassport-aspect:weight",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "DigitalProductPassport:value",
+                  "@id": "digitalproductpassport-aspect:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -732,7 +736,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "DigitalProductPassport:unit",
+                  "@id": "digitalproductpassport-aspect:unit",
                   "@context": {
                     "@definition": "The unit of a mass related attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#massUnit"
@@ -744,13 +748,13 @@
               }
             },
             "volume": {
-              "@id": "DigitalProductPassport:volume",
+              "@id": "digitalproductpassport-aspect:volume",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "DigitalProductPassport:value",
+                  "@id": "digitalproductpassport-aspect:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -758,7 +762,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "DigitalProductPassport:unit",
+                  "@id": "digitalproductpassport-aspect:unit",
                   "@context": {
                     "@definition": "The unit of a volume related attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#volumeUnit"
@@ -774,7 +778,7 @@
           }
         },
         "physicalState": {
-          "@id": "DigitalProductPassport:physicalState",
+          "@id": "digitalproductpassport-aspect:physicalState",
           "@context": {
             "@definition": "The physical state of the item. There are four states of matter solid, liquid, gas and plasma which can be chosen from an enumeration.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#physicalState"
@@ -782,7 +786,7 @@
           "@type": "schema:string"
         },
         "generalPerformanceClass": {
-          "@id": "DigitalProductPassport:generalPerformanceClass",
+          "@id": "digitalproductpassport-aspect:generalPerformanceClass",
           "@context": {
             "@definition": "The performance class of the product. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n4. When establishing the information requirements referred to in paragraph 2, point (b), point (i), the Commission shall, as appropriate in view of the specificity of the product group, determine classes of performance. Classes of performance may be based on single parameters, on aggregated scores, in absolute terms or in any other form that enables potential customers to choose the best performing products. Those classes of performance shall correspond to significant improvements in performance levels. Where classes of performance are based on parameters in relation to which performance requirements are established, they shall use as the minimum level the minimum performance required at the time when the classes of performance start to apply.\nDefinition:\n'class of performance': means a range of performance levels in relation to one or more product parameters referred to in Annex I, based on a common methodology for the product or product group, ordered into successive steps to allow for product differentiation.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#generalPerformanceClass"
@@ -794,13 +798,13 @@
       }
     },
     "commercial": {
-      "@id": "DigitalProductPassport:commercial",
+      "@id": "digitalproductpassport-aspect:commercial",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "placedOnMarket": {
-          "@id": "DigitalProductPassport:placedOnMarket",
+          "@id": "digitalproductpassport-aspect:placedOnMarket",
           "@context": {
             "@definition": "The timestamp in the format (yyyy-mm-dd) with or without time zone when the product was put in the market.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#placedOnMarket"
@@ -808,7 +812,7 @@
           "@type": "schema:string"
         },
         "purpose": {
-          "@id": "DigitalProductPassport:purpose",
+          "@id": "digitalproductpassport-aspect:purpose",
           "@context": {
             "@definition": "One or more intended industry/industries of the product described by the digital product passport. If exchanged via Catena-X, 'automotive ' is a must choice included in the list.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#purpose"
@@ -817,7 +821,7 @@
           "@type": "schema:string"
         },
         "purchaseOrder": {
-          "@id": "DigitalProductPassport:purchaseOrder",
+          "@id": "digitalproductpassport-aspect:purchaseOrder",
           "@context": {
             "@definition": "A unique identifier assigned to the order of the product for tracking purposes between supplier and customer.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#purchaseOrder"
@@ -825,13 +829,13 @@
           "@type": "schema:string"
         },
         "recallInformation": {
-          "@id": "DigitalProductPassport:recallInformation",
+          "@id": "digitalproductpassport-aspect:recallInformation",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "applicable": {
-              "@id": "DigitalProductPassport:applicable",
+              "@id": "digitalproductpassport-aspect:applicable",
               "@context": {
                 "@definition": "Check whether the connected attributes are applicable to the product. If it is not applicable (false), dummy data can be delivered.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#applicable"
@@ -839,7 +843,7 @@
               "@type": "schema:boolean"
             },
             "recallInformationDocumentation": {
-              "@id": "DigitalProductPassport:recallInformationDocumentation",
+              "@id": "digitalproductpassport-aspect:recallInformationDocumentation",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -849,7 +853,7 @@
                   "id": "@id",
                   "type": "@type",
                   "content": {
-                    "@id": "DigitalProductPassport:content",
+                    "@id": "digitalproductpassport-aspect:content",
                     "@context": {
                       "@definition": "The content of the document e.g a link.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -857,7 +861,7 @@
                     "@type": "schema:string"
                   },
                   "contentType": {
-                    "@id": "DigitalProductPassport:contentType",
+                    "@id": "digitalproductpassport-aspect:contentType",
                     "@context": {
                       "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -865,7 +869,7 @@
                     "@type": "schema:string"
                   },
                   "header": {
-                    "@id": "DigitalProductPassport:header",
+                    "@id": "digitalproductpassport-aspect:header",
                     "@context": {
                       "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -887,19 +891,19 @@
       }
     },
     "materials": {
-      "@id": "DigitalProductPassport:materials",
+      "@id": "digitalproductpassport-aspect:materials",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "substancesOfConcern": {
-          "@id": "DigitalProductPassport:substancesOfConcern",
+          "@id": "digitalproductpassport-aspect:substancesOfConcern",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "applicable": {
-              "@id": "DigitalProductPassport:applicable",
+              "@id": "digitalproductpassport-aspect:applicable",
               "@context": {
                 "@definition": "Check whether the connected attributes are applicable to the product. If it is not applicable (false), dummy data can be delivered.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#applicable"
@@ -907,7 +911,7 @@
               "@type": "schema:boolean"
             },
             "content": {
-              "@id": "DigitalProductPassport:content",
+              "@id": "digitalproductpassport-aspect:content",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -915,7 +919,7 @@
                 "@context": {
                   "@version": 1.1,
                   "id": {
-                    "@id": "DigitalProductPassport:id",
+                    "@id": "digitalproductpassport-aspect:id",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -923,7 +927,7 @@
                       "@context": {
                         "@version": 1.1,
                         "id": {
-                          "@id": "DigitalProductPassport:id",
+                          "@id": "digitalproductpassport-aspect:id",
                           "@context": {
                             "@definition": "The substance identification, in accordance with the specification in the attribute for the list type.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#chemicalId"
@@ -931,7 +935,7 @@
                           "@type": "schema:string"
                         },
                         "type": {
-                          "@id": "DigitalProductPassport:type",
+                          "@id": "digitalproductpassport-aspect:type",
                           "@context": {
                             "@definition": "The type of standard used for the identification of the substances. Selected can be for example CAS, IUPAC or EC.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#listTypeId"
@@ -939,7 +943,7 @@
                           "@type": "schema:string"
                         },
                         "name": {
-                          "@id": "DigitalProductPassport:name",
+                          "@id": "digitalproductpassport-aspect:name",
                           "@context": {
                             "@definition": "The name of the material which is present in the product.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#chemicalName"
@@ -954,7 +958,7 @@
                   },
                   "type": "@type",
                   "location": {
-                    "@id": "DigitalProductPassport:location",
+                    "@id": "digitalproductpassport-aspect:location",
                     "@context": {
                       "@definition": "The location of the substances of concern within the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (b) the location of the substances of concern within the product.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#location"
@@ -962,7 +966,7 @@
                     "@type": "schema:string"
                   },
                   "unit": {
-                    "@id": "DigitalProductPassport:unit",
+                    "@id": "digitalproductpassport-aspect:unit",
                     "@context": {
                       "@definition": "The unit of concentration chosen from an enumeration: mass percent, volume percent, parts per thousand, parts per million, parts per billion and  parts per trillion.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#materialUnit"
@@ -970,7 +974,7 @@
                     "@type": "schema:string"
                   },
                   "concentration": {
-                    "@id": "DigitalProductPassport:concentration",
+                    "@id": "digitalproductpassport-aspect:concentration",
                     "@context": {
                       "@definition": "Concentration of the material at the level of the product. This attribute is specially mentioned for substances of concern mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product [...].\nOther substances are mentioned for the purpose of recycling in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(d) design for recycling, ease and quality of recycling as expressed through: use of easily recyclable materials, safe, easy and non-destructive access to recyclable components and materials or components and materials containing hazardous substances and material composition and homogeneity, possibility for high-purity sorting, number of materials and components used, use of standard components, use of component and material coding standards for the identification of components and materials, number and complexity of processes and tools needed, ease of nondestructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed.\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#concentration"
@@ -978,7 +982,7 @@
                     "@type": "schema:number"
                   },
                   "exemption": {
-                    "@id": "DigitalProductPassport:exemption",
+                    "@id": "digitalproductpassport-aspect:exemption",
                     "@context": {
                       "@definition": "Exemptions to the substance of concern. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 7:\n(5) (c) provide duly justified exemptions for substances of concern or information elements from the information requirements referred to in the first subparagraph based on the technical feasibility or relevance of tracking substances of concern, the existence of analytical methods to detect and quantify them, the need to protect confidential business information or in other duly justified cases. Substances of concern within the meaning of Article 2(28), point a), shall not be exempted if they are present in products, their relevant components or spare parts in a concentration above 0,1 % weight by weight.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#exemption"
@@ -986,13 +990,13 @@
                     "@type": "schema:string"
                   },
                   "hazardClassification": {
-                    "@id": "DigitalProductPassport:hazardClassification",
+                    "@id": "digitalproductpassport-aspect:hazardClassification",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
                       "type": "@type",
                       "category": {
-                        "@id": "DigitalProductPassport:category",
+                        "@id": "digitalproductpassport-aspect:category",
                         "@context": {
                           "@definition": "The hazard category of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n2. 'hazard category' means the division of criteria within each hazard class, specifying hazard severity.",
                           "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#hazardCategory"
@@ -1000,7 +1004,7 @@
                         "@type": "schema:string"
                       },
                       "class": {
-                        "@id": "DigitalProductPassport:class",
+                        "@id": "digitalproductpassport-aspect:class",
                         "@context": {
                           "@definition": "The hazard class of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n1. 'hazard class' means the nature of the physical, health or environmental hazard.",
                           "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#hazardClass"
@@ -1008,7 +1012,7 @@
                         "@type": "schema:string"
                       },
                       "statement": {
-                        "@id": "DigitalProductPassport:statement",
+                        "@id": "digitalproductpassport-aspect:statement",
                         "@context": {
                           "@definition": "The hazard statement of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n5. 'hazard statement' means a phrase assigned to a hazard class and category that describes the nature of the hazards of a hazardous substance or mixture, including, where appropriate, the degree of hazard.",
                           "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#hazardStatement"
@@ -1020,7 +1024,7 @@
                     }
                   },
                   "concentrationRange": {
-                    "@id": "DigitalProductPassport:concentrationRange",
+                    "@id": "digitalproductpassport-aspect:concentrationRange",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1030,7 +1034,7 @@
                         "id": "@id",
                         "type": "@type",
                         "min": {
-                          "@id": "DigitalProductPassport:min",
+                          "@id": "digitalproductpassport-aspect:min",
                           "@context": {
                             "@definition": "The minimum concentration of the substance of concern at the level of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) [...] concentration range of the substances of concern, at the level of the product [...].",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#minConcentration"
@@ -1038,7 +1042,7 @@
                           "@type": "schema:number"
                         },
                         "max": {
-                          "@id": "DigitalProductPassport:max",
+                          "@id": "digitalproductpassport-aspect:max",
                           "@context": {
                             "@definition": "The maximum concentration of the substance of concern at the level of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product [...].",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#maxConcentration"
@@ -1052,7 +1056,7 @@
                     "@container": "@list"
                   },
                   "documentation": {
-                    "@id": "DigitalProductPassport:documentation",
+                    "@id": "digitalproductpassport-aspect:documentation",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1062,7 +1066,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "DigitalProductPassport:content",
+                          "@id": "digitalproductpassport-aspect:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1070,7 +1074,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "DigitalProductPassport:contentType",
+                          "@id": "digitalproductpassport-aspect:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1078,7 +1082,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "DigitalProductPassport:header",
+                          "@id": "digitalproductpassport-aspect:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1102,13 +1106,13 @@
           }
         },
         "materialComposition": {
-          "@id": "DigitalProductPassport:materialComposition",
+          "@id": "digitalproductpassport-aspect:materialComposition",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "applicable": {
-              "@id": "DigitalProductPassport:applicable",
+              "@id": "digitalproductpassport-aspect:applicable",
               "@context": {
                 "@definition": "Check whether the connected attributes are applicable to the product. If it is not applicable (false), dummy data can be delivered.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#applicable"
@@ -1116,7 +1120,7 @@
               "@type": "schema:boolean"
             },
             "content": {
-              "@id": "DigitalProductPassport:content",
+              "@id": "digitalproductpassport-aspect:content",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -1124,7 +1128,7 @@
                 "@context": {
                   "@version": 1.1,
                   "id": {
-                    "@id": "DigitalProductPassport:id",
+                    "@id": "digitalproductpassport-aspect:id",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1132,7 +1136,7 @@
                       "@context": {
                         "@version": 1.1,
                         "id": {
-                          "@id": "DigitalProductPassport:id",
+                          "@id": "digitalproductpassport-aspect:id",
                           "@context": {
                             "@definition": "The substance identification, in accordance with the specification in the attribute for the list type.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#chemicalId"
@@ -1140,7 +1144,7 @@
                           "@type": "schema:string"
                         },
                         "type": {
-                          "@id": "DigitalProductPassport:type",
+                          "@id": "digitalproductpassport-aspect:type",
                           "@context": {
                             "@definition": "The type of standard used for the identification of the substances. Selected can be for example CAS, IUPAC or EC.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#listTypeId"
@@ -1148,7 +1152,7 @@
                           "@type": "schema:string"
                         },
                         "name": {
-                          "@id": "DigitalProductPassport:name",
+                          "@id": "digitalproductpassport-aspect:name",
                           "@context": {
                             "@definition": "The name of the material which is present in the product.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#chemicalName"
@@ -1163,7 +1167,7 @@
                   },
                   "type": "@type",
                   "recycled": {
-                    "@id": "DigitalProductPassport:recycled",
+                    "@id": "digitalproductpassport-aspect:recycled",
                     "@context": {
                       "@definition": "The share of the material, which is recovered recycled content from the product. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(h) use or content of recycled materials and recovery of materials, including critical raw materials;",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#recycled"
@@ -1171,7 +1175,7 @@
                     "@type": "schema:number"
                   },
                   "renewable": {
-                    "@id": "DigitalProductPassport:renewable",
+                    "@id": "digitalproductpassport-aspect:renewable",
                     "@context": {
                       "@definition": "The share of the material, which is from a renewable resource that can be replenished. Renewable resources are those that can be reproduced by physical, chemical, or mechanical processes. These are the kind of resources that can be regenerated throughout time. Forest wood, for example, can be grown through reforestation. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(ha) use or content of sustainable renewable materials;\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#renewable"
@@ -1179,7 +1183,7 @@
                     "@type": "schema:number"
                   },
                   "unit": {
-                    "@id": "DigitalProductPassport:unit",
+                    "@id": "digitalproductpassport-aspect:unit",
                     "@context": {
                       "@definition": "The unit of concentration chosen from an enumeration: mass percent, volume percent, parts per thousand, parts per million, parts per billion and  parts per trillion.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#materialUnit"
@@ -1187,7 +1191,7 @@
                     "@type": "schema:string"
                   },
                   "critical": {
-                    "@id": "DigitalProductPassport:critical",
+                    "@id": "digitalproductpassport-aspect:critical",
                     "@context": {
                       "@definition": "A flag, if the material is a critical raw material. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(h) use or content of recycled materials and recovery of materials, including critical raw materials;\nIn Annex II of the connected proposal Act of Critical Raw Materials, a list of critical raw materials can be found.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#critical"
@@ -1195,7 +1199,7 @@
                     "@type": "schema:boolean"
                   },
                   "concentration": {
-                    "@id": "DigitalProductPassport:concentration",
+                    "@id": "digitalproductpassport-aspect:concentration",
                     "@context": {
                       "@definition": "Concentration of the material at the level of the product. This attribute is specially mentioned for substances of concern mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product [...].\nOther substances are mentioned for the purpose of recycling in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(d) design for recycling, ease and quality of recycling as expressed through: use of easily recyclable materials, safe, easy and non-destructive access to recyclable components and materials or components and materials containing hazardous substances and material composition and homogeneity, possibility for high-purity sorting, number of materials and components used, use of standard components, use of component and material coding standards for the identification of components and materials, number and complexity of processes and tools needed, ease of nondestructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed.\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#concentration"
@@ -1203,7 +1207,7 @@
                     "@type": "schema:number"
                   },
                   "documentation": {
-                    "@id": "DigitalProductPassport:documentation",
+                    "@id": "digitalproductpassport-aspect:documentation",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1213,7 +1217,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "DigitalProductPassport:content",
+                          "@id": "digitalproductpassport-aspect:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1221,7 +1225,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "DigitalProductPassport:contentType",
+                          "@id": "digitalproductpassport-aspect:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1229,7 +1233,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "DigitalProductPassport:header",
+                          "@id": "digitalproductpassport-aspect:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1257,13 +1261,13 @@
       }
     },
     "sustainability": {
-      "@id": "DigitalProductPassport:sustainability",
+      "@id": "digitalproductpassport-aspect:sustainability",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "status": {
-          "@id": "DigitalProductPassport:status",
+          "@id": "digitalproductpassport-aspect:status",
           "@context": {
             "@definition": "The status of the product (original, repurposed, re-used, remanufactured or waste) to indicated, whether it is a used product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(j) incorporation of used components.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#state"
@@ -1271,13 +1275,13 @@
           "@type": "schema:string"
         },
         "productFootprint": {
-          "@id": "DigitalProductPassport:productFootprint",
+          "@id": "digitalproductpassport-aspect:productFootprint",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "environmental": {
-              "@id": "DigitalProductPassport:environmental",
+              "@id": "digitalproductpassport-aspect:environmental",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -1286,7 +1290,7 @@
                   "@version": 1.1,
                   "id": "@id",
                   "type": {
-                    "@id": "DigitalProductPassport:type",
+                    "@id": "digitalproductpassport-aspect:type",
                     "@context": {
                       "@definition": "The type of the environmental footprint of the product. This could be one of the environmental impact categories. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nAnnex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories.\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintType"
@@ -1294,7 +1298,7 @@
                     "@type": "schema:string"
                   },
                   "value": {
-                    "@id": "DigitalProductPassport:value",
+                    "@id": "digitalproductpassport-aspect:value",
                     "@context": {
                       "@definition": "The value of the footprint of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories;\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintValue"
@@ -1302,7 +1306,7 @@
                     "@type": "schema:number"
                   },
                   "rulebook": {
-                    "@id": "DigitalProductPassport:rulebook",
+                    "@id": "digitalproductpassport-aspect:rulebook",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1312,7 +1316,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "DigitalProductPassport:content",
+                          "@id": "digitalproductpassport-aspect:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1320,7 +1324,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "DigitalProductPassport:contentType",
+                          "@id": "digitalproductpassport-aspect:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1328,7 +1332,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "DigitalProductPassport:header",
+                          "@id": "digitalproductpassport-aspect:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1342,7 +1346,7 @@
                     "@container": "@list"
                   },
                   "lifecycle": {
-                    "@id": "DigitalProductPassport:lifecycle",
+                    "@id": "digitalproductpassport-aspect:lifecycle",
                     "@context": {
                       "@definition": "The lifecycle stage, to which the environmental footprint corresponds. These could be for example \"raw material acquisition and pre-processing\", \"main product production\", \"distribution\" or \"end of life and recycling\".",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintLifecycle"
@@ -1350,7 +1354,7 @@
                     "@type": "schema:string"
                   },
                   "unit": {
-                    "@id": "DigitalProductPassport:unit",
+                    "@id": "digitalproductpassport-aspect:unit",
                     "@context": {
                       "@definition": "The unit of measurement of the environmental impact category. For each impact category a specific unit is used. If an aggregation is used, utilize the normalization and weighting methods used in the referenced rulebook.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintUnit"
@@ -1358,7 +1362,7 @@
                     "@type": "schema:string"
                   },
                   "performanceClass": {
-                    "@id": "DigitalProductPassport:performanceClass",
+                    "@id": "digitalproductpassport-aspect:performanceClass",
                     "@context": {
                       "@definition": "The performance classification of the footprint.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#performanceClass"
@@ -1366,7 +1370,7 @@
                     "@type": "schema:string"
                   },
                   "manufacturingPlant": {
-                    "@id": "DigitalProductPassport:manufacturingPlant",
+                    "@id": "digitalproductpassport-aspect:manufacturingPlant",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1376,7 +1380,7 @@
                         "id": "@id",
                         "type": "@type",
                         "facility": {
-                          "@id": "DigitalProductPassport:facility",
+                          "@id": "digitalproductpassport-aspect:facility",
                           "@context": {
                             "@definition": "The identifier used for a location. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#facility"
@@ -1390,7 +1394,7 @@
                     "@container": "@list"
                   },
                   "declaration": {
-                    "@id": "DigitalProductPassport:declaration",
+                    "@id": "digitalproductpassport-aspect:declaration",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1400,7 +1404,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "DigitalProductPassport:content",
+                          "@id": "digitalproductpassport-aspect:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1408,7 +1412,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "DigitalProductPassport:contentType",
+                          "@id": "digitalproductpassport-aspect:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1416,7 +1420,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "DigitalProductPassport:header",
+                          "@id": "digitalproductpassport-aspect:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1436,7 +1440,7 @@
               "@container": "@list"
             },
             "carbon": {
-              "@id": "DigitalProductPassport:carbon",
+              "@id": "digitalproductpassport-aspect:carbon",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -1445,7 +1449,7 @@
                   "@version": 1.1,
                   "id": "@id",
                   "type": {
-                    "@id": "DigitalProductPassport:type",
+                    "@id": "digitalproductpassport-aspect:type",
                     "@context": {
                       "@definition": "The type of the environmental footprint of the product. This could be one of the environmental impact categories. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nAnnex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories.\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintType"
@@ -1453,7 +1457,7 @@
                     "@type": "schema:string"
                   },
                   "value": {
-                    "@id": "DigitalProductPassport:value",
+                    "@id": "digitalproductpassport-aspect:value",
                     "@context": {
                       "@definition": "The value of the footprint of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories;\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintValue"
@@ -1461,7 +1465,7 @@
                     "@type": "schema:number"
                   },
                   "rulebook": {
-                    "@id": "DigitalProductPassport:rulebook",
+                    "@id": "digitalproductpassport-aspect:rulebook",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1471,7 +1475,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "DigitalProductPassport:content",
+                          "@id": "digitalproductpassport-aspect:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1479,7 +1483,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "DigitalProductPassport:contentType",
+                          "@id": "digitalproductpassport-aspect:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1487,7 +1491,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "DigitalProductPassport:header",
+                          "@id": "digitalproductpassport-aspect:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1501,7 +1505,7 @@
                     "@container": "@list"
                   },
                   "lifecycle": {
-                    "@id": "DigitalProductPassport:lifecycle",
+                    "@id": "digitalproductpassport-aspect:lifecycle",
                     "@context": {
                       "@definition": "The lifecycle stage, to which the environmental footprint corresponds. These could be for example \"raw material acquisition and pre-processing\", \"main product production\", \"distribution\" or \"end of life and recycling\".",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintLifecycle"
@@ -1509,7 +1513,7 @@
                     "@type": "schema:string"
                   },
                   "unit": {
-                    "@id": "DigitalProductPassport:unit",
+                    "@id": "digitalproductpassport-aspect:unit",
                     "@context": {
                       "@definition": "The unit of measurement of the environmental impact category. For each impact category a specific unit is used. If an aggregation is used, utilize the normalization and weighting methods used in the referenced rulebook.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintUnit"
@@ -1517,7 +1521,7 @@
                     "@type": "schema:string"
                   },
                   "performanceClass": {
-                    "@id": "DigitalProductPassport:performanceClass",
+                    "@id": "digitalproductpassport-aspect:performanceClass",
                     "@context": {
                       "@definition": "The performance classification of the footprint.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#performanceClass"
@@ -1525,7 +1529,7 @@
                     "@type": "schema:string"
                   },
                   "manufacturingPlant": {
-                    "@id": "DigitalProductPassport:manufacturingPlant",
+                    "@id": "digitalproductpassport-aspect:manufacturingPlant",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1535,7 +1539,7 @@
                         "id": "@id",
                         "type": "@type",
                         "facility": {
-                          "@id": "DigitalProductPassport:facility",
+                          "@id": "digitalproductpassport-aspect:facility",
                           "@context": {
                             "@definition": "The identifier used for a location. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#facility"
@@ -1549,7 +1553,7 @@
                     "@container": "@list"
                   },
                   "declaration": {
-                    "@id": "DigitalProductPassport:declaration",
+                    "@id": "digitalproductpassport-aspect:declaration",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1559,7 +1563,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "DigitalProductPassport:content",
+                          "@id": "digitalproductpassport-aspect:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1567,7 +1571,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "DigitalProductPassport:contentType",
+                          "@id": "digitalproductpassport-aspect:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1575,7 +1579,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "DigitalProductPassport:header",
+                          "@id": "digitalproductpassport-aspect:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1595,7 +1599,7 @@
               "@container": "@list"
             },
             "material": {
-              "@id": "DigitalProductPassport:material",
+              "@id": "digitalproductpassport-aspect:material",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -1604,7 +1608,7 @@
                   "@version": 1.1,
                   "id": "@id",
                   "type": {
-                    "@id": "DigitalProductPassport:type",
+                    "@id": "digitalproductpassport-aspect:type",
                     "@context": {
                       "@definition": "The type of the environmental footprint of the product. This could be one of the environmental impact categories. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nAnnex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories.\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintType"
@@ -1612,7 +1616,7 @@
                     "@type": "schema:string"
                   },
                   "value": {
-                    "@id": "DigitalProductPassport:value",
+                    "@id": "digitalproductpassport-aspect:value",
                     "@context": {
                       "@definition": "The value of the footprint of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories;\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintValue"
@@ -1620,7 +1624,7 @@
                     "@type": "schema:number"
                   },
                   "rulebook": {
-                    "@id": "DigitalProductPassport:rulebook",
+                    "@id": "digitalproductpassport-aspect:rulebook",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1630,7 +1634,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "DigitalProductPassport:content",
+                          "@id": "digitalproductpassport-aspect:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1638,7 +1642,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "DigitalProductPassport:contentType",
+                          "@id": "digitalproductpassport-aspect:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1646,7 +1650,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "DigitalProductPassport:header",
+                          "@id": "digitalproductpassport-aspect:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1660,7 +1664,7 @@
                     "@container": "@list"
                   },
                   "lifecycle": {
-                    "@id": "DigitalProductPassport:lifecycle",
+                    "@id": "digitalproductpassport-aspect:lifecycle",
                     "@context": {
                       "@definition": "The lifecycle stage, to which the environmental footprint corresponds. These could be for example \"raw material acquisition and pre-processing\", \"main product production\", \"distribution\" or \"end of life and recycling\".",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintLifecycle"
@@ -1668,7 +1672,7 @@
                     "@type": "schema:string"
                   },
                   "unit": {
-                    "@id": "DigitalProductPassport:unit",
+                    "@id": "digitalproductpassport-aspect:unit",
                     "@context": {
                       "@definition": "The unit of measurement of the environmental impact category. For each impact category a specific unit is used. If an aggregation is used, utilize the normalization and weighting methods used in the referenced rulebook.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintUnit"
@@ -1676,7 +1680,7 @@
                     "@type": "schema:string"
                   },
                   "performanceClass": {
-                    "@id": "DigitalProductPassport:performanceClass",
+                    "@id": "digitalproductpassport-aspect:performanceClass",
                     "@context": {
                       "@definition": "The performance classification of the footprint.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#performanceClass"
@@ -1684,7 +1688,7 @@
                     "@type": "schema:string"
                   },
                   "manufacturingPlant": {
-                    "@id": "DigitalProductPassport:manufacturingPlant",
+                    "@id": "digitalproductpassport-aspect:manufacturingPlant",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1694,7 +1698,7 @@
                         "id": "@id",
                         "type": "@type",
                         "facility": {
-                          "@id": "DigitalProductPassport:facility",
+                          "@id": "digitalproductpassport-aspect:facility",
                           "@context": {
                             "@definition": "The identifier used for a location. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#facility"
@@ -1708,7 +1712,7 @@
                     "@container": "@list"
                   },
                   "declaration": {
-                    "@id": "DigitalProductPassport:declaration",
+                    "@id": "digitalproductpassport-aspect:declaration",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1718,7 +1722,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "DigitalProductPassport:content",
+                          "@id": "digitalproductpassport-aspect:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1726,7 +1730,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "DigitalProductPassport:contentType",
+                          "@id": "digitalproductpassport-aspect:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1734,7 +1738,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "DigitalProductPassport:header",
+                          "@id": "digitalproductpassport-aspect:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1758,7 +1762,7 @@
           }
         },
         "reparabilityScore": {
-          "@id": "DigitalProductPassport:reparabilityScore",
+          "@id": "digitalproductpassport-aspect:reparabilityScore",
           "@context": {
             "@definition": "The reparability score. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n(b) as appropriate, also require products to be accompanied by:\n(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability [...].",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#reparabilityScore"
@@ -1766,7 +1770,7 @@
           "@type": "schema:string"
         },
         "durabilityScore": {
-          "@id": "DigitalProductPassport:durabilityScore",
+          "@id": "digitalproductpassport-aspect:durabilityScore",
           "@context": {
             "@definition": "The durability score. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n(b) as appropriate, also require products to be accompanied by:\n(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability [...].",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#durabilityScore"
@@ -1778,7 +1782,7 @@
       }
     },
     "sources": {
-      "@id": "DigitalProductPassport:sources",
+      "@id": "digitalproductpassport-aspect:sources",
       "@context": {
         "@version": 1.1,
         "id": "@id",
@@ -1787,7 +1791,7 @@
           "@version": 1.1,
           "id": "@id",
           "type": {
-            "@id": "DigitalProductPassport:type",
+            "@id": "digitalproductpassport-aspect:type",
             "@context": {
               "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1795,7 +1799,7 @@
             "@type": "schema:string"
           },
           "content": {
-            "@id": "DigitalProductPassport:content",
+            "@id": "digitalproductpassport-aspect:content",
             "@context": {
               "@definition": "The content of the document e.g a link.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1803,7 +1807,7 @@
             "@type": "schema:string"
           },
           "category": {
-            "@id": "DigitalProductPassport:category",
+            "@id": "digitalproductpassport-aspect:category",
             "@context": {
               "@definition": "The category in which the document can be sorted. These are mentioned in the ESPR proposal from March 30th, 2022 ANNEX III:\n(e) compliance documentation and information required under this Regulation or other Union law applicable to the product, such as the declaration of conformity, technical documentation or conformity certificates;\nANNEX IV states additional information regarding the content of the technical documentation\nFurther information on documents are mentioned in the proposal from March 30th, 2022 ANNEX III:\n(f) user manuals, instructions, warnings or safety information, as required by other Union legislation applicable to the product.\nAdditionally requirements are mentioned in Article 21:\n(7) Manufacturers shall ensure that that a product covered by a delegated act adopted pursuant to Article 4 is accompanied by instructions that enable consumers and other end-users to safely assemble, install, operate, store, maintain, repair and dispose of the product in a language that can be easily understood by consumers and other end-users, as determined by the Member State concerned. Such instructions shall be clear, understandable and legible and include at least the information specified in the delegated acts adopted pursuant to Article 4 and pursuant to Article 7(2)(b), point (ii).\nArticle 7 states additionally:\n(2) (b) (ii) information for consumers and other end-users on how to install, use, maintain and repair the product in order to minimize its impact on the environment and to ensure optimum durability, as well as on how to return or dispose of the product at end-of-life;\n(2) (b) (iii) information for treatment facilities on disassembly, recycling, or disposal at end-of-life;\n(2) (b) (iv) other information that may influence the way the product is handled by parties other than the manufacturer in order to improve performance in relation to product parameters referred to in Annex I.\n(5) (d) relevant instructions for the safe use of the product.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#category"
@@ -1811,7 +1815,7 @@
             "@type": "schema:string"
           },
           "header": {
-            "@id": "DigitalProductPassport:header",
+            "@id": "digitalproductpassport-aspect:header",
             "@context": {
               "@definition": "The header as a short description of the document with a maximum of 100 characters.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1825,7 +1829,7 @@
       "@container": "@list"
     },
     "additionalData": {
-      "@id": "DigitalProductPassport:additionalData",
+      "@id": "digitalproductpassport-aspect:additionalData",
       "@context": {
         "@version": 1.1,
         "id": "@id",
@@ -1834,13 +1838,13 @@
           "@version": 1.1,
           "id": "@id",
           "type": {
-            "@id": "DigitalProductPassport:type",
+            "@id": "digitalproductpassport-aspect:type",
             "@context": {
               "@version": 1.1,
               "id": "@id",
               "type": "@type",
               "typeUnit": {
-                "@id": "DigitalProductPassport:typeUnit",
+                "@id": "digitalproductpassport-aspect:typeUnit",
                 "@context": {
                   "@definition": "Choose a unit type from the unit catalog, or if the property \"children\" is filled, leave empty.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#typeUnit"
@@ -1848,7 +1852,7 @@
                 "@type": "schema:string"
               },
               "dataType": {
-                "@id": "DigitalProductPassport:dataType",
+                "@id": "digitalproductpassport-aspect:dataType",
                 "@context": {
                   "@definition": "Data type that describe the content of the attributes children and data. In case \"object\" is selected in the enumeration, the children field will be used in the AdditionalDataEntity instead of the \"data\" property. If it is an other type, the content will be specified in \"data\" as a string.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#dataType"
@@ -1860,7 +1864,7 @@
             }
           },
           "label": {
-            "@id": "DigitalProductPassport:label",
+            "@id": "digitalproductpassport-aspect:label",
             "@context": {
               "@definition": "The human readable name of the attribute.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#label"
@@ -1868,7 +1872,7 @@
             "@type": "schema:string"
           },
           "description": {
-            "@id": "DigitalProductPassport:description",
+            "@id": "digitalproductpassport-aspect:description",
             "@context": {
               "@definition": "The description of the attribute context.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#description"
@@ -1876,7 +1880,7 @@
             "@type": "schema:string"
           },
           "data": {
-            "@id": "DigitalProductPassport:data",
+            "@id": "digitalproductpassport-aspect:data",
             "@context": {
               "@definition": "The content from the attribute which is a depended of the data type and typeUnit.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#data"
@@ -1884,7 +1888,7 @@
             "@type": "schema:string"
           },
           "children": {
-            "@id": "DigitalProductPassport:children",
+            "@id": "digitalproductpassport-aspect:children",
             "@context": {
               "@version": 1.1,
               "id": "@id",
@@ -1893,13 +1897,13 @@
                 "@version": 1.1,
                 "id": "@id",
                 "type": {
-                  "@id": "DigitalProductPassport:type",
+                  "@id": "digitalproductpassport-aspect:type",
                   "@context": {
                     "@version": 1.1,
                     "id": "@id",
                     "type": "@type",
                     "typeUnit": {
-                      "@id": "DigitalProductPassport:typeUnit",
+                      "@id": "digitalproductpassport-aspect:typeUnit",
                       "@context": {
                         "@definition": "Choose a unit type from the unit catalog, or if the property \"children\" is filled, leave empty.",
                         "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#typeUnit"
@@ -1907,7 +1911,7 @@
                       "@type": "schema:string"
                     },
                     "dataType": {
-                      "@id": "DigitalProductPassport:dataType",
+                      "@id": "digitalproductpassport-aspect:dataType",
                       "@context": {
                         "@definition": "Data type that describe the content of the attributes children and data. In case \"object\" is selected in the enumeration, the children field will be used in the AdditionalDataEntity instead of the \"data\" property. If it is an other type, the content will be specified in \"data\" as a string.",
                         "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#dataType"
@@ -1919,7 +1923,7 @@
                   }
                 },
                 "label": {
-                  "@id": "DigitalProductPassport:label",
+                  "@id": "digitalproductpassport-aspect:label",
                   "@context": {
                     "@definition": "The human readable name of the attribute.",
                     "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#label"
@@ -1927,7 +1931,7 @@
                   "@type": "schema:string"
                 },
                 "description": {
-                  "@id": "DigitalProductPassport:description",
+                  "@id": "digitalproductpassport-aspect:description",
                   "@context": {
                     "@definition": "The description of the attribute context.",
                     "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#description"
@@ -1935,7 +1939,7 @@
                   "@type": "schema:string"
                 },
                 "data": {
-                  "@id": "DigitalProductPassport:data",
+                  "@id": "digitalproductpassport-aspect:data",
                   "@context": {
                     "@definition": "The content from the attribute which is a depended of the data type and typeUnit.",
                     "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#data"

--- a/io.catenax.pcf/7.0.0/gen/Pcf-context.jsonld
+++ b/io.catenax.pcf/7.0.0/gen/Pcf-context.jsonld
@@ -2,9 +2,13 @@
   "@context": {
     "@version": 1.1,
     "schema": "https://schema.org/",
-    "Pcf": "urn:samm:io.catenax.pcf:7.0.0#",
+    "pcf-aspect": "urn:samm:io.catenax.pcf:7.0.0#",
+    "Pcf": {
+      "@id": "pcf-aspect:Pcf",
+      "@type": "@id"
+    },
     "specVersion": {
-      "@id": "Pcf:specVersion",
+      "@id": "pcf-aspect:specVersion",
       "@context": {
         "@definition": "Mandatory: Version of the product footprint data specification as defined in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#specVersion"
@@ -12,7 +16,7 @@
       "@type": "schema:string"
     },
     "partialFullPcf": {
-      "@id": "Pcf:partialFullPcf",
+      "@id": "pcf-aspect:partialFullPcf",
       "@context": {
         "@definition": "Mandatory: Indicator for partial or full PCF (Product Carbon Footprint) declaration as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#partialFullPcf"
@@ -20,7 +24,7 @@
       "@type": "schema:string"
     },
     "precedingPfIds": {
-      "@id": "Pcf:precedingPfIds",
+      "@id": "pcf-aspect:precedingPfIds",
       "@context": {
         "@version": 1.1,
         "id": "@id",
@@ -28,7 +32,7 @@
         "@context": {
           "@version": 1.1,
           "id": {
-            "@id": "Pcf:id",
+            "@id": "pcf-aspect:id",
             "@context": {
               "@definition": "Mandatory: The product footprint identifier as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
               "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#id"
@@ -43,7 +47,7 @@
       "@container": "@list"
     },
     "version": {
-      "@id": "Pcf:version",
+      "@id": "pcf-aspect:version",
       "@context": {
         "@definition": "Mandatory: Version of the product (carbon) footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to \"0\" per default.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#version"
@@ -51,7 +55,7 @@
       "@type": "schema:number"
     },
     "created": {
-      "@id": "Pcf:created",
+      "@id": "pcf-aspect:created",
       "@context": {
         "@definition": "Mandatory: Timestamp of the creation of the Product (Carbon) Footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#created"
@@ -59,7 +63,7 @@
       "@type": "schema:string"
     },
     "extWBCSD_pfStatus": {
-      "@id": "Pcf:extWBCSD_pfStatus",
+      "@id": "pcf-aspect:extWBCSD_pfStatus",
       "@context": {
         "@definition": "Mandatory: Status indicator of a product (carbon) footprint as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example set to \"Active\" per default.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#status"
@@ -67,7 +71,7 @@
       "@type": "schema:string"
     },
     "validityPeriodStart": {
-      "@id": "Pcf:validityPeriodStart",
+      "@id": "pcf-aspect:validityPeriodStart",
       "@context": {
         "@definition": "Optional: Start of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. If specified, the validity period start must be equal to or greater than the reference period end.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#validityPeriodStart"
@@ -75,7 +79,7 @@
       "@type": "schema:string"
     },
     "validityPeriodEnd": {
-      "@id": "Pcf:validityPeriodEnd",
+      "@id": "pcf-aspect:validityPeriodEnd",
       "@context": {
         "@definition": "Optional: End of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#validityPeriodEnd"
@@ -83,7 +87,7 @@
       "@type": "schema:string"
     },
     "comment": {
-      "@id": "Pcf:comment",
+      "@id": "pcf-aspect:comment",
       "@context": {
         "@definition": "Optional: Additional information and instructions related to the calculation of the product (carbon) footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#comment"
@@ -91,7 +95,7 @@
       "@type": "schema:string"
     },
     "companyName": {
-      "@id": "Pcf:companyName",
+      "@id": "pcf-aspect:companyName",
       "@context": {
         "@definition": "Mandatory: Name of the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#companyName"
@@ -99,7 +103,7 @@
       "@type": "schema:string"
     },
     "companyIds": {
-      "@id": "Pcf:companyIds",
+      "@id": "pcf-aspect:companyIds",
       "@context": {
         "@definition": "Mandatory: Non-empty set of Uniform Resource Names (URN). Each value is supposed to uniquely identify the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. For Catena-X Industry Core compliance the set of URNs must contain at least the Business Partner Number Legal Entity (BPNL) in the specified format urn:bpn:id:BPNL[a-zA-Z0-9]{12}.\u00a0",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#companyIds"
@@ -108,7 +112,7 @@
       "@type": "schema:string"
     },
     "productDescription": {
-      "@id": "Pcf:productDescription",
+      "@id": "pcf-aspect:productDescription",
       "@context": {
         "@definition": "Optional: Free-form description of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#productDescription"
@@ -116,7 +120,7 @@
       "@type": "schema:string"
     },
     "productIds": {
-      "@id": "Pcf:productIds",
+      "@id": "pcf-aspect:productIds",
       "@context": {
         "@definition": "Mandatory: Non-empty set of product identifiers. Each value is supposed to uniquely identify the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productId corresponds with Industry Core manufacturerPartId.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#productIds"
@@ -125,7 +129,7 @@
       "@type": "schema:string"
     },
     "extWBCSD_productCodeCpc": {
-      "@id": "Pcf:extWBCSD_productCodeCpc",
+      "@id": "pcf-aspect:extWBCSD_productCodeCpc",
       "@context": {
         "@definition": "Mandatory: UN (United Nations) Product Classification Code (CPC - Central Classification Code) of a given product as specified the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, which will probably be declared as \"optional\" in a later WBCSD specification version. In Catena-X for example specified with default value \"011-99000\".",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#productCategoryCpc"
@@ -133,7 +137,7 @@
       "@type": "schema:string"
     },
     "productName": {
-      "@id": "Pcf:productName",
+      "@id": "pcf-aspect:productName",
       "@context": {
         "@definition": "Mandatory: Non-empty trade name of a product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productNameCompany corresponds with Industry Core nameAtManufacturer.\u00a0",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#productNameCompany"
@@ -141,7 +145,7 @@
       "@type": "schema:string"
     },
     "pcfLegalStatement": {
-      "@id": "Pcf:pcfLegalStatement",
+      "@id": "pcf-aspect:pcfLegalStatement",
       "@context": {
         "@definition": "Optional: Option for legal statement/ disclaimer as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#pcfLegalStatement"


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

Connected to this #866 PR, needed for the data trust & security kit, it was found with this tested now, that there is needed one attribute with the model name in the root @context

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
