### PR TITLE
metadata: added pcf `@context` with bugfix to `allOf`

### DIFF
--- a/io.catenax.pcf/7.0.0/gen/Pcf-context.jsonld
+++ b/io.catenax.pcf/7.0.0/gen/Pcf-context.jsonld
@@ -144,6 +144,466 @@
       },
       "@type": "schema:string"
     },
+    "pcf": {
+      "@id": "pcf-aspect:pcf",
+      "@context": {
+        "@version": 1.1,
+        "id": "@id",
+        "type": "@type",
+        "declaredUnit": {
+          "@id": "pcf-aspect:declaredUnit",
+          "@context": {
+            "@definition": "Mandatory: Unit of analysis of a product in context of the PCF (product carbon footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example list of valid units includes \"piece\".",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#declaredUnit"
+          },
+          "@type": "schema:string"
+        },
+        "unitaryProductAmount": {
+          "@id": "pcf-aspect:unitaryProductAmount",
+          "@context": {
+            "@definition": "Mandatory: Amount of units contained within a product in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#unitaryProductAmount"
+          },
+          "@type": "schema:number"
+        },
+        "productMassPerDeclaredUnit": {
+          "@id": "pcf-aspect:productMassPerDeclaredUnit",
+          "@context": {
+            "@definition": "Mandatory: Mass of a product per declared unit (net, unpackaged) in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#productMassPerDeclaredUnit"
+          },
+          "@type": "schema:number"
+        },
+        "exemptedEmissionsPercent": {
+          "@id": "pcf-aspect:exemptedEmissionsPercent",
+          "@context": {
+            "@definition": "Mandatory: Applied cut-off percentage of emissions excluded from PCF (Product Carbon Footprint).\nFor accordance with Catena-X PCF Rulebook (Version 3.0.0) <3%.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#exemptedEmissionsPercent"
+          },
+          "@type": "schema:number"
+        },
+        "exemptedEmissionsDescription": {
+          "@id": "pcf-aspect:exemptedEmissionsDescription",
+          "@context": {
+            "@definition": "Optional: Rationale behind exclusion of specific PCF (Product Carbon Footprint) emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#exemptedEmissionsDescription"
+          },
+          "@type": "schema:string"
+        },
+        "boundaryProcessesDescription": {
+          "@id": "pcf-aspect:boundaryProcessesDescription",
+          "@context": {
+            "@definition": "Optional: Processes attributable to each lifecycle stage as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#boundaryProcessesDescription"
+          },
+          "@type": "schema:string"
+        },
+        "geographyCountrySubdivision": {
+          "@id": "pcf-aspect:geographyCountrySubdivision",
+          "@context": {
+            "@definition": "Optional: Subdivision of a country which must be an ISO 3166-2 subdivision code as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#geographyCountrySubdivision"
+          },
+          "@type": "schema:string"
+        },
+        "geographyCountry": {
+          "@id": "pcf-aspect:geographyCountry",
+          "@context": {
+            "@definition": "Optional: Two letter country code that must conform to data type ISO 3166CC as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#geographyCountry"
+          },
+          "@type": "schema:string"
+        },
+        "geographyRegionOrSubregion": {
+          "@id": "pcf-aspect:geographyRegionOrSubregion",
+          "@context": {
+            "@definition": "Mandatory: Region according to list as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#geographyRegionOrSubregion"
+          },
+          "@type": "schema:string"
+        },
+        "referencePeriodStart": {
+          "@id": "pcf-aspect:referencePeriodStart",
+          "@context": {
+            "@definition": "Mandatory: Start of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#referencePeriodStart"
+          },
+          "@type": "schema:string"
+        },
+        "referencePeriodEnd": {
+          "@id": "pcf-aspect:referencePeriodEnd",
+          "@context": {
+            "@definition": "Mandatory: End of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#referencePeriodEnd"
+          },
+          "@type": "schema:string"
+        },
+        "crossSectoralStandardsUsed": {
+          "@id": "pcf-aspect:crossSectoralStandardsUsed",
+          "@context": {
+            "@version": 1.1,
+            "id": "@id",
+            "type": "@type",
+            "@context": {
+              "@version": 1.1,
+              "id": "@id",
+              "type": "@type",
+              "crossSectoralStandard": {
+                "@id": "pcf-aspect:crossSectoralStandard",
+                "@context": {
+                  "@definition": "Mandatory: Discloses a cross-sectoral standard applied for calculating or allocating GHG (Greenhouse Gas) emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+                  "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#crossSectoralStandard"
+                },
+                "@type": "schema:string"
+              }
+            },
+            "@definition": "Mandatory: Discloses the cross-sectoral standards applied for calculating or allocating GHG (Greenhouse Gas) emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#crossSectoralStandardsUsed"
+          },
+          "@container": "@list"
+        },
+        "productOrSectorSpecificRules": {
+          "@id": "pcf-aspect:productOrSectorSpecificRules",
+          "@context": {
+            "@version": 1.1,
+            "id": "@id",
+            "type": "@type",
+            "@context": {
+              "@version": 1.1,
+              "id": "@id",
+              "type": "@type",
+              "extWBCSD_operator": {
+                "@id": "pcf-aspect:extWBCSD_operator",
+                "@context": {
+                  "@definition": "Mandatory: Operator of PCR (Product Category Rule)/ PSR (Product Specific Rule) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example must always be \"Other\".",
+                  "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#operator"
+                },
+                "@type": "schema:string"
+              },
+              "productOrSectorSpecificRules": {
+                "@id": "pcf-aspect:productOrSectorSpecificRules",
+                "@context": {
+                  "@version": 1.1,
+                  "id": "@id",
+                  "type": "@type",
+                  "@context": {
+                    "@version": 1.1,
+                    "id": "@id",
+                    "type": "@type",
+                    "ruleName": {
+                      "@id": "pcf-aspect:ruleName",
+                      "@context": {
+                        "@definition": "Name of a rule applied by a specific operator as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+                        "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#ruleName"
+                      },
+                      "@type": "schema:string"
+                    }
+                  },
+                  "@definition": "Mandatory: Product-specific or sector-specific set of rules used for calculating or allocating GHG (Greenhouse Gas) emissions applied from the specified operator as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+                  "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#ruleNames"
+                },
+                "@container": "@list"
+              },
+              "extWBCSD_otherOperatorName": {
+                "@id": "pcf-aspect:extWBCSD_otherOperatorName",
+                "@context": {
+                  "@definition": "Optional: Other operator of PCR (Product Category Rule)/ PSR (Product Specific Rule) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by a default value.",
+                  "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#otherOperatorName"
+                },
+                "@type": "schema:string"
+              }
+            },
+            "@definition": "Mandatory: Product or sector specific rules applied for calculating or allocating GHG (Greenhouse Gas) emissions, e.g. PCRs (Product Category Rules), including operators or publishers and according rule names as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#productOrSectorSpecificRules"
+          },
+          "@container": "@list"
+        },
+        "extWBCSD_characterizationFactors": {
+          "@id": "pcf-aspect:extWBCSD_characterizationFactors",
+          "@context": {
+            "@definition": "Mandatory: IPCC (Intergovernmental Panel on Climate Change) version of the GWP (Global Warming Potential) characterization factors used for calculating the PCF (Product Carbon Footprint) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by default with value \\\"AR6\\\". Default value can be overwritten.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#characterizationFactors"
+          },
+          "@type": "schema:string"
+        },
+        "extWBCSD_allocationRulesDescription": {
+          "@id": "pcf-aspect:extWBCSD_allocationRulesDescription",
+          "@context": {
+            "@definition": "Optional: Allocation rules used and underlying reasoning in context of a product carbon footprint as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by default with value \"In accordance with Catena-X PCF Rulebook (Version 3.0.0)\".",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#allocationRulesDescription"
+          },
+          "@type": "schema:string"
+        },
+        "extTFS_allocationWasteIncineration": {
+          "@id": "pcf-aspect:extTFS_allocationWasteIncineration",
+          "@context": {
+            "@definition": "Mandatory: Allocation approach used for waste incineration with energy recovery as specified by the TFS (Together For Sustainability) initiative. In Catena-X for example must be specified by value \"cut-off\".",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#allocationWasteIncineration"
+          },
+          "@type": "schema:string"
+        },
+        "primaryDataShare": {
+          "@id": "pcf-aspect:primaryDataShare",
+          "@context": {
+            "@definition": "Mandatory starting 2025: Share of primary data in percent as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#primaryDataShare"
+          },
+          "@type": "schema:number"
+        },
+        "secondaryEmissionFactorSources": {
+          "@id": "pcf-aspect:secondaryEmissionFactorSources",
+          "@context": {
+            "@version": 1.1,
+            "id": "@id",
+            "type": "@type",
+            "@context": {
+              "@version": 1.1,
+              "id": "@id",
+              "type": "@type",
+              "secondaryEmissionFactorSource": {
+                "@id": "pcf-aspect:secondaryEmissionFactorSource",
+                "@context": {
+                  "@definition": "Mandatory: Emission factor data source used to calculate a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+                  "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#emissionFactorDS"
+                },
+                "@type": "schema:string"
+              }
+            },
+            "@definition": "Mandatory: Emission factors used for the PCF (Product Carbon Footprint) calculation as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#secondaryEmissionFactorSources"
+          },
+          "@container": "@list"
+        },
+        "dataQualityRating": {
+          "@id": "pcf-aspect:dataQualityRating",
+          "@context": {
+            "@version": 1.1,
+            "id": "@id",
+            "type": "@type",
+            "coveragePercent": {
+              "@id": "pcf-aspect:coveragePercent",
+              "@context": {
+                "@definition": "Mandatory starting 2025: Percentage of PCF (Product Carbon Footprint) included in the data quality assessment based on the >5% emissions threshold as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to \"100\" per default.",
+                "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#coveragePercent"
+              },
+              "@type": "schema:number"
+            },
+            "technologicalDQR": {
+              "@id": "pcf-aspect:technologicalDQR",
+              "@context": {
+                "@definition": "Optional: Technological representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+                "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#technologicalDQR"
+              },
+              "@type": "schema:number"
+            },
+            "temporalDQR": {
+              "@id": "pcf-aspect:temporalDQR",
+              "@context": {
+                "@definition": "Optional: Temporal representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+                "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#temporalDQR"
+              },
+              "@type": "schema:number"
+            },
+            "geographicalDQR": {
+              "@id": "pcf-aspect:geographicalDQR",
+              "@context": {
+                "@definition": "Optional: Geographical representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+                "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#geographicalDQR"
+              },
+              "@type": "schema:number"
+            },
+            "completenessDQR": {
+              "@id": "pcf-aspect:completenessDQR",
+              "@context": {
+                "@definition": "Optional: Completeness of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+                "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#completenessDQR"
+              },
+              "@type": "schema:number"
+            },
+            "reliabilityDQR": {
+              "@id": "pcf-aspect:reliabilityDQR",
+              "@context": {
+                "@definition": "Optional: Reliability of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+                "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#reliabilityDQR"
+              },
+              "@type": "schema:number"
+            },
+            "@definition": "Mandatory starting 2025: Quantitative data quality indicators of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#dqi"
+          }
+        },
+        "extWBCSD_packagingEmissionsIncluded": {
+          "@id": "pcf-aspect:extWBCSD_packagingEmissionsIncluded",
+          "@context": {
+            "@definition": "Mandatory: The Catena-X PCF Rulebook requires to include packaging from a system boundary perspective. \"FALSE\" is only possible due to the application of the cut-off rule.\nFlag indicating whether packaging emissions are included in a PCF (Product Carbon Footprint) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#packagingEmissionsIncluded"
+          },
+          "@type": "schema:boolean"
+        },
+        "pcfExcludingBiogenic": {
+          "@id": "pcf-aspect:pcfExcludingBiogenic",
+          "@context": {
+            "@definition": "Mandatory: Product carbon footprint of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#pcfExcludingBiogenic"
+          },
+          "@type": "schema:number"
+        },
+        "pcfIncludingBiogenic": {
+          "@id": "pcf-aspect:pcfIncludingBiogenic",
+          "@context": {
+            "@definition": "Mandatory starting 2025: Product carbon footprint of a product including biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Optional value in current specification version but will be mandatory in future version.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#pcfIncludingBiogenic"
+          },
+          "@type": "schema:number"
+        },
+        "fossilGhgEmissions": {
+          "@id": "pcf-aspect:fossilGhgEmissions",
+          "@context": {
+            "@definition": "Mandatory starting 2025: Emissions from combustion of fossil sources as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Identical to \"pcfExcludingBiogenic\", will be removed in later version.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#fossilGhgEmissions"
+          },
+          "@type": "schema:number"
+        },
+        "biogenicCarbonEmissionsOtherThanCO2": {
+          "@id": "pcf-aspect:biogenicCarbonEmissionsOtherThanCO2",
+          "@context": {
+            "@definition": "Mandatory starting 2025: GWP (Global Warming Potential) of biogenic CO2e-emissions in production phase which contain only GHG (Greenhouse Gas) emissions other than CO2 - excludes biogenic CO2. For specification see Catena-X PCF Rulebook (Version 3.0.0).",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#biogenicCarbonEmissionsOtherThanCO2"
+          },
+          "@type": "schema:number"
+        },
+        "biogenicCarbonWithdrawal": {
+          "@id": "pcf-aspect:biogenicCarbonWithdrawal",
+          "@context": {
+            "@definition": "Mandatory starting 2025: Biogenic carbon content in the product converted to CO2e as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#biogenicCarbonWithdrawal"
+          },
+          "@type": "schema:number"
+        },
+        "dlucGhgEmissions": {
+          "@id": "pcf-aspect:dlucGhgEmissions",
+          "@context": {
+            "@definition": "Mandatory starting 2025: Direct land use change CO2e emissions in context of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#dlucGhgEmissions"
+          },
+          "@type": "schema:number"
+        },
+        "extTFS_luGhgEmissions": {
+          "@id": "pcf-aspect:extTFS_luGhgEmissions",
+          "@context": {
+            "@definition": "Mandatory starting 2025: Land use CO2 emissions in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#luGhgEmissions"
+          },
+          "@type": "schema:number"
+        },
+        "aircraftGhgEmissions": {
+          "@id": "pcf-aspect:aircraftGhgEmissions",
+          "@context": {
+            "@definition": "Mandatory starting 2025: GHG (Greenhouse Gas) emissions resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#aircraftGhgEmissions"
+          },
+          "@type": "schema:number"
+        },
+        "extWBCSD_packagingGhgEmissions": {
+          "@id": "pcf-aspect:extWBCSD_packagingGhgEmissions",
+          "@context": {
+            "@definition": "Optional: Emissions resulting from the packaging of the product as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension. In Catena-X not relevant to be reported separately.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#packagingGhgEmissions"
+          },
+          "@type": "schema:number"
+        },
+        "distributionStagePcfExcludingBiogenic": {
+          "@id": "pcf-aspect:distributionStagePcfExcludingBiogenic",
+          "@context": {
+            "@definition": "Optional: Product carbon footprint for the distribution stage of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStagePcfExcludingBiogenic"
+          },
+          "@type": "schema:number"
+        },
+        "distributionStagePcfIncludingBiogenic": {
+          "@id": "pcf-aspect:distributionStagePcfIncludingBiogenic",
+          "@context": {
+            "@definition": "Optional: Product carbon footprint for the distribution stage of a product including biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStagePcfIncludingBiogenic"
+          },
+          "@type": "schema:number"
+        },
+        "distributionStageFossilGhgEmissions": {
+          "@id": "pcf-aspect:distributionStageFossilGhgEmissions",
+          "@context": {
+            "@definition": "Optional: Emissions from the combustion of fossil sources in the distribution stage as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageFossilGhgEmissions"
+          },
+          "@type": "schema:number"
+        },
+        "distributionStageBiogenicCarbonEmissionsOtherThanCO2": {
+          "@id": "pcf-aspect:distributionStageBiogenicCarbonEmissionsOtherThanCO2",
+          "@context": {
+            "@definition": "Optional: GWP (Global Warming Potential) of biogenic CO2e-emissions in distribution phase which contain only GHG (Greenhouse Gas) emissions other than CO2 ? excludes biogenic CO2. For specification see Catena-X PCF Rulebook (Version 3.0.0).",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageBiogenicCarbonEmissionsOtherThanCO2"
+          },
+          "@type": "schema:number"
+        },
+        "distributionStageBiogenicCarbonWithdrawal": {
+          "@id": "pcf-aspect:distributionStageBiogenicCarbonWithdrawal",
+          "@context": {
+            "@definition": "Optional: GWP (Global Warming Potential) of biogenic CO2-withdrawal in distribution stage (biogenic CO2 contained in the product) as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageBiogenicCarbonWithdrawal"
+          },
+          "@type": "schema:number"
+        },
+        "extTFS_distributionStageDlucGhgEmissions": {
+          "@id": "pcf-aspect:extTFS_distributionStageDlucGhgEmissions",
+          "@context": {
+            "@definition": "Optional: Direct land use change CO2 emissions during distribution stage in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageDlucGhgEmissions"
+          },
+          "@type": "schema:number"
+        },
+        "extTFS_distributionStageLuGhgEmissions": {
+          "@id": "pcf-aspect:extTFS_distributionStageLuGhgEmissions",
+          "@context": {
+            "@definition": "Optional: Land use CO2 emissions in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageLuGhgEmissions"
+          },
+          "@type": "schema:number"
+        },
+        "carbonContentTotal": {
+          "@id": "pcf-aspect:carbonContentTotal",
+          "@context": {
+            "@definition": "Mandatory starting 2025: Total carbon content per declared unit in context of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#carbonContentTotal"
+          },
+          "@type": "schema:number"
+        },
+        "extWBCSD_fossilCarbonContent": {
+          "@id": "pcf-aspect:extWBCSD_fossilCarbonContent",
+          "@context": {
+            "@definition": "Mandatory starting 2025: Fossil carbon amount embodied in a product as specified in the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Must be calculated with kgC (kilogram Carbon) / declaredUnit equal to or greater zero; WBCSD specific extension, in Catena-X specified by a calculated value.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#fossilCarbonContent"
+          },
+          "@type": "schema:number"
+        },
+        "carbonContentBiogenic": {
+          "@id": "pcf-aspect:carbonContentBiogenic",
+          "@context": {
+            "@definition": "Mandatory starting 2025: Biogenic carbon amount embodied in a product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Must be calculated with kgC (kilogram Carbon) / declaredUnit equal to or greater zero.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#biogenicCarbonContent"
+          },
+          "@type": "schema:number"
+        },
+        "distributionStageAircraftGhgEmissions": {
+          "@id": "pcf-aspect:distributionStageAircraftGhgEmissions",
+          "@context": {
+            "@definition": "Optional: GHG (Greenhouse Gas) emissions for the distribution stage resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+            "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageAircraftGhgEmissions"
+          },
+          "@type": "schema:number"
+        },
+        "@definition": "A PCF (Product Carbon Footprint) represents the carbon footprint of a product and related data as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+        "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#pcf"
+      }
+    },
     "pcfLegalStatement": {
       "@id": "pcf-aspect:pcfLegalStatement",
       "@context": {


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

I have found a problem but just in the PCF models. It includes in some properties the `allOf` property, which needs to be interpreted  differently by the translator tool.

#867 
#866 

Closes #

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
