### PR TITLE
metadata: added context ld for BusinessPartnerCertificate-context.jsonld

### DIFF
--- a/io.catenax.business_partner_certificate/3.1.0/gen/BusinessPartnerCertificate-context.jsonld
+++ b/io.catenax.business_partner_certificate/3.1.0/gen/BusinessPartnerCertificate-context.jsonld
@@ -1,0 +1,195 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "schema": "https://schema.org/",
+    "businesspartnercertificate-aspect": "urn:samm:io.catenax.business_partner_certificate:3.1.0#",
+    "BusinessPartnerCertificate": {
+      "@id": "businesspartnercertificate-aspect:BusinessPartnerCertificate",
+      "@type": "@id"
+    },
+    "businessPartnerNumber": {
+      "@id": "businesspartnercertificate-aspect:businessPartnerNumber",
+      "@context": {
+        "@definition": "The Business Partner Number (BPN) of the certified legal entity (on which the certificate is issued).",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#businessPartnerNumber"
+      },
+      "@type": "schema:string"
+    },
+    "registrationNumber": {
+      "@id": "businesspartnercertificate-aspect:registrationNumber",
+      "@context": {
+        "@definition": "Registration number of the certificate as defined on the certificate",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#registrationNumber"
+      },
+      "@type": "schema:string"
+    },
+    "areaOfApplication": {
+      "@id": "businesspartnercertificate-aspect:areaOfApplication",
+      "@context": {
+        "@definition": "Details on which areas / application types a certificate is valid for a company and/or site.",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#areaOfApplication"
+      },
+      "@type": "schema:string"
+    },
+    "enclosedSites": {
+      "@id": "businesspartnercertificate-aspect:enclosedSites",
+      "@context": {
+        "@version": 1.1,
+        "id": "@id",
+        "type": "@type",
+        "@context": {
+          "@version": 1.1,
+          "id": "@id",
+          "type": "@type",
+          "enclosedSiteBpn": {
+            "@id": "businesspartnercertificate-aspect:enclosedSiteBpn",
+            "@context": {
+              "@definition": "The Business Partner Number (BPNS or BPNA) of an enclosed site",
+              "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#enclosedSiteBpn"
+            },
+            "@type": "schema:string"
+          },
+          "areaOfApplication": {
+            "@id": "businesspartnercertificate-aspect:areaOfApplication",
+            "@context": {
+              "@definition": "Details on which areas / application types a certificate is valid for a company and/or site.",
+              "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#areaOfApplication"
+            },
+            "@type": "schema:string"
+          }
+        },
+        "@definition": "Additional sites covered by the certificate, which can be either the Business Partner Number Site (BPNS) or Business Partner Number Address (BPNA)",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#enclosedSites"
+      },
+      "@container": "@list"
+    },
+    "validFrom": {
+      "@id": "businesspartnercertificate-aspect:validFrom",
+      "@context": {
+        "@definition": "Valid from date as defined on the certificate.",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#validFrom"
+      },
+      "@type": "schema:string"
+    },
+    "validUntil": {
+      "@id": "businesspartnercertificate-aspect:validUntil",
+      "@context": {
+        "@definition": "Valid valid until as defined on the certificate. If certificate never expires value until expected to be 9999-12-31",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#validUntil"
+      },
+      "@type": "schema:string"
+    },
+    "issuer": {
+      "@id": "businesspartnercertificate-aspect:issuer",
+      "@context": {
+        "@version": 1.1,
+        "id": "@id",
+        "type": "@type",
+        "issuerName": {
+          "@id": "businesspartnercertificate-aspect:issuerName",
+          "@context": {
+            "@definition": "Name of the Issuer i.e. Certifying Authority.",
+            "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#issuerName"
+          },
+          "@type": "schema:string"
+        },
+        "issuerBpn": {
+          "@id": "businesspartnercertificate-aspect:issuerBpn",
+          "@context": {
+            "@definition": "The Business Partner Number (BPN) of the Issuer.",
+            "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#issuerBpn"
+          },
+          "@type": "schema:string"
+        },
+        "@definition": "The BPN of the issuing authority e.g. TUEV Sued ",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#issuer"
+      }
+    },
+    "trustLevel": {
+      "@id": "businesspartnercertificate-aspect:trustLevel",
+      "@context": {
+        "@definition": "The trust level of the given certificate - none,low, high, trusted",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#trustLevel"
+      },
+      "@type": "schema:string"
+    },
+    "validator": {
+      "@id": "businesspartnercertificate-aspect:validator",
+      "@context": {
+        "@version": 1.1,
+        "id": "@id",
+        "type": "@type",
+        "validatorName": {
+          "@id": "businesspartnercertificate-aspect:validatorName",
+          "@context": {
+            "@definition": "The optional name of the data service provider who validated the given certificate",
+            "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#validatorName"
+          },
+          "@type": "schema:string"
+        },
+        "validatorBpn": {
+          "@id": "businesspartnercertificate-aspect:validatorBpn",
+          "@context": {
+            "@definition": "The Business Partner Number (BPN) of the data service provider who validated the given certificate",
+            "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#validatorBpn"
+          },
+          "@type": "schema:string"
+        },
+        "@definition": "The Business Partner Number (BPN) of the data service provider who validates the given certificate.",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#validator"
+      }
+    },
+    "uploader": {
+      "@id": "businesspartnercertificate-aspect:uploader",
+      "@context": {
+        "@definition": "The Business Partner Number (BPN) of the business partner who originally provided the certifcate data or document.",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#uploader"
+      },
+      "@type": "schema:string"
+    },
+    "document": {
+      "@id": "businesspartnercertificate-aspect:document",
+      "@context": {
+        "@version": 1.1,
+        "id": "@id",
+        "type": "@type",
+        "creationDate": {
+          "@id": "businesspartnercertificate-aspect:creationDate",
+          "@context": {
+            "@definition": "The creation date of the document.",
+            "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#creationDate"
+          },
+          "@type": "schema:string"
+        },
+        "documentID": {
+          "@id": "businesspartnercertificate-aspect:documentID",
+          "@context": {
+            "@definition": "The id of the certificate document as stored by the data service provider.",
+            "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#documentID"
+          },
+          "@type": "schema:string"
+        },
+        "contentType": {
+          "@id": "businesspartnercertificate-aspect:contentType",
+          "@context": {
+            "@definition": "The content type of the document.",
+            "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#contentType"
+          },
+          "@type": "schema:string"
+        },
+        "contentBase64": {
+          "@id": "businesspartnercertificate-aspect:contentBase64",
+          "@context": {
+            "@definition": "The data is encoded using the Base64 encoding scheme, which converts binary data into a string of ASCII characters. ",
+            "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#contentBase64"
+          },
+          "@type": "schema:string"
+        },
+        "@definition": "The content and ID of the document.",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#document"
+      }
+    },
+    "@definition": "A business partner certifcate describes a certificate (eg ISO9001, IATF-16949) via a certifcate document  of a Catena-X business partner",
+    "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#BusinessPartnerCertificate"
+  }
+}


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

Another use case that uses the Data Trust & security kit is the CCM

So we need the JSON-LD context
<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
