### PR TITLE
metadata: added extra context metadata which was missing

### DIFF
--- a/io.catenax.business_partner_certificate/3.1.0/gen/BusinessPartnerCertificate-context.jsonld
+++ b/io.catenax.business_partner_certificate/3.1.0/gen/BusinessPartnerCertificate-context.jsonld
@@ -2,13 +2,40 @@
   "@context": {
     "@version": 1.1,
     "schema": "https://schema.org/",
-    "businesspartnercertificate-aspect": "urn:samm:io.catenax.business_partner_certificate:3.1.0#",
+    "cx": "urn:samm:io.catenax.business_partner_certificate:3.1.0#",
     "BusinessPartnerCertificate": {
-      "@id": "businesspartnercertificate-aspect:BusinessPartnerCertificate",
+      "@id": "cx:BusinessPartnerCertificate",
       "@type": "@id"
     },
+    "id": "@id",
+    "cx:type": {
+      "@id": "cx:type",
+      "@context": {
+        "@version": 1.1,
+        "id": "@id",
+        "type": "@type",
+        "certificateType": {
+          "@id": "cx:certificateType",
+          "@context": {
+            "@definition": "Type of the certificate as defined on the document,valid types are registered at BPN metadatacontroller",
+            "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#certificateType"
+          },
+          "@type": "schema:string"
+        },
+        "certificateVersion": {
+          "@id": "cx:certificateVersion",
+          "@context": {
+            "@definition": "Version of the certificate as defined on the document, usually the specific version of a certification standard",
+            "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#certificateVersion"
+          },
+          "@type": "schema:string"
+        },
+        "@definition": "Type of the certificate as defined on the document like IS09001, IATF 16949 or other",
+        "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#type"
+      }
+    },
     "businessPartnerNumber": {
-      "@id": "businesspartnercertificate-aspect:businessPartnerNumber",
+      "@id": "cx:businessPartnerNumber",
       "@context": {
         "@definition": "The Business Partner Number (BPN) of the certified legal entity (on which the certificate is issued).",
         "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#businessPartnerNumber"
@@ -16,7 +43,7 @@
       "@type": "schema:string"
     },
     "registrationNumber": {
-      "@id": "businesspartnercertificate-aspect:registrationNumber",
+      "@id": "cx:registrationNumber",
       "@context": {
         "@definition": "Registration number of the certificate as defined on the certificate",
         "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#registrationNumber"
@@ -24,7 +51,7 @@
       "@type": "schema:string"
     },
     "areaOfApplication": {
-      "@id": "businesspartnercertificate-aspect:areaOfApplication",
+      "@id": "cx:areaOfApplication",
       "@context": {
         "@definition": "Details on which areas / application types a certificate is valid for a company and/or site.",
         "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#areaOfApplication"
@@ -32,7 +59,7 @@
       "@type": "schema:string"
     },
     "enclosedSites": {
-      "@id": "businesspartnercertificate-aspect:enclosedSites",
+      "@id": "cx:enclosedSites",
       "@context": {
         "@version": 1.1,
         "id": "@id",
@@ -42,7 +69,7 @@
           "id": "@id",
           "type": "@type",
           "enclosedSiteBpn": {
-            "@id": "businesspartnercertificate-aspect:enclosedSiteBpn",
+            "@id": "cx:enclosedSiteBpn",
             "@context": {
               "@definition": "The Business Partner Number (BPNS or BPNA) of an enclosed site",
               "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#enclosedSiteBpn"
@@ -50,7 +77,7 @@
             "@type": "schema:string"
           },
           "areaOfApplication": {
-            "@id": "businesspartnercertificate-aspect:areaOfApplication",
+            "@id": "cx:areaOfApplication",
             "@context": {
               "@definition": "Details on which areas / application types a certificate is valid for a company and/or site.",
               "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#areaOfApplication"
@@ -64,7 +91,7 @@
       "@container": "@list"
     },
     "validFrom": {
-      "@id": "businesspartnercertificate-aspect:validFrom",
+      "@id": "cx:validFrom",
       "@context": {
         "@definition": "Valid from date as defined on the certificate.",
         "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#validFrom"
@@ -72,7 +99,7 @@
       "@type": "schema:string"
     },
     "validUntil": {
-      "@id": "businesspartnercertificate-aspect:validUntil",
+      "@id": "cx:validUntil",
       "@context": {
         "@definition": "Valid valid until as defined on the certificate. If certificate never expires value until expected to be 9999-12-31",
         "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#validUntil"
@@ -80,13 +107,13 @@
       "@type": "schema:string"
     },
     "issuer": {
-      "@id": "businesspartnercertificate-aspect:issuer",
+      "@id": "cx:issuer",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "issuerName": {
-          "@id": "businesspartnercertificate-aspect:issuerName",
+          "@id": "cx:issuerName",
           "@context": {
             "@definition": "Name of the Issuer i.e. Certifying Authority.",
             "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#issuerName"
@@ -94,7 +121,7 @@
           "@type": "schema:string"
         },
         "issuerBpn": {
-          "@id": "businesspartnercertificate-aspect:issuerBpn",
+          "@id": "cx:issuerBpn",
           "@context": {
             "@definition": "The Business Partner Number (BPN) of the Issuer.",
             "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#issuerBpn"
@@ -106,7 +133,7 @@
       }
     },
     "trustLevel": {
-      "@id": "businesspartnercertificate-aspect:trustLevel",
+      "@id": "cx:trustLevel",
       "@context": {
         "@definition": "The trust level of the given certificate - none,low, high, trusted",
         "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#trustLevel"
@@ -114,13 +141,13 @@
       "@type": "schema:string"
     },
     "validator": {
-      "@id": "businesspartnercertificate-aspect:validator",
+      "@id": "cx:validator",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "validatorName": {
-          "@id": "businesspartnercertificate-aspect:validatorName",
+          "@id": "cx:validatorName",
           "@context": {
             "@definition": "The optional name of the data service provider who validated the given certificate",
             "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#validatorName"
@@ -128,7 +155,7 @@
           "@type": "schema:string"
         },
         "validatorBpn": {
-          "@id": "businesspartnercertificate-aspect:validatorBpn",
+          "@id": "cx:validatorBpn",
           "@context": {
             "@definition": "The Business Partner Number (BPN) of the data service provider who validated the given certificate",
             "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#validatorBpn"
@@ -140,7 +167,7 @@
       }
     },
     "uploader": {
-      "@id": "businesspartnercertificate-aspect:uploader",
+      "@id": "cx:uploader",
       "@context": {
         "@definition": "The Business Partner Number (BPN) of the business partner who originally provided the certifcate data or document.",
         "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#uploader"
@@ -148,13 +175,13 @@
       "@type": "schema:string"
     },
     "document": {
-      "@id": "businesspartnercertificate-aspect:document",
+      "@id": "cx:document",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "creationDate": {
-          "@id": "businesspartnercertificate-aspect:creationDate",
+          "@id": "cx:creationDate",
           "@context": {
             "@definition": "The creation date of the document.",
             "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#creationDate"
@@ -162,7 +189,7 @@
           "@type": "schema:string"
         },
         "documentID": {
-          "@id": "businesspartnercertificate-aspect:documentID",
+          "@id": "cx:documentID",
           "@context": {
             "@definition": "The id of the certificate document as stored by the data service provider.",
             "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#documentID"
@@ -170,7 +197,7 @@
           "@type": "schema:string"
         },
         "contentType": {
-          "@id": "businesspartnercertificate-aspect:contentType",
+          "@id": "cx:contentType",
           "@context": {
             "@definition": "The content type of the document.",
             "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#contentType"
@@ -178,7 +205,7 @@
           "@type": "schema:string"
         },
         "contentBase64": {
-          "@id": "businesspartnercertificate-aspect:contentBase64",
+          "@id": "cx:contentBase64",
           "@context": {
             "@definition": "The data is encoded using the Base64 encoding scheme, which converts binary data into a string of ASCII characters. ",
             "@samm-urn": "urn:samm:io.catenax.business_partner_certificate:3.1.0#contentBase64"

--- a/io.catenax.generic.digital_product_passport/6.0.0/gen/DigitalProductPassport-context.jsonld
+++ b/io.catenax.generic.digital_product_passport/6.0.0/gen/DigitalProductPassport-context.jsonld
@@ -2,19 +2,21 @@
   "@context": {
     "@version": 1.1,
     "schema": "https://schema.org/",
-    "digitalproductpassport-aspect": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#",
+    "cx": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#",
     "DigitalProductPassport": {
-      "@id": "digitalproductpassport-aspect:DigitalProductPassport",
+      "@id": "cx:DigitalProductPassport",
       "@type": "@id"
     },
+    "id": "@id",
+    "type": "@type",
     "metadata": {
-      "@id": "digitalproductpassport-aspect:metadata",
+      "@id": "cx:metadata",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "version": {
-          "@id": "digitalproductpassport-aspect:version",
+          "@id": "cx:version",
           "@context": {
             "@definition": "The current version of the product passport. The possibility of modification/ updating the product passport needs to include versioning of the dataset. This attribute is an internal versioning from the passport issuer. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(1) [...] The information in the product passport shall be accurate, complete, and up to date.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#version"
@@ -22,7 +24,7 @@
           "@type": "schema:string"
         },
         "status": {
-          "@id": "digitalproductpassport-aspect:status",
+          "@id": "cx:status",
           "@context": {
             "@definition": "The current status of the product passport declared through either: draft, approved, invalid or expired.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#status"
@@ -30,7 +32,7 @@
           "@type": "schema:string"
         },
         "expirationDate": {
-          "@id": "digitalproductpassport-aspect:expirationDate",
+          "@id": "cx:expirationDate",
           "@context": {
             "@definition": "The timestamp in the format (yyyy-mm-dd) for the product passport until when it is available or a comment describing this period. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(2) (h) the period during which the product passport is to remain available, which shall correspond to at least the expected lifetime of a specific product.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#expirationDate"
@@ -38,7 +40,7 @@
           "@type": "schema:string"
         },
         "issueDate": {
-          "@id": "digitalproductpassport-aspect:issueDate",
+          "@id": "cx:issueDate",
           "@context": {
             "@definition": "The timestamp in the format (yyyy-mm-dd) since when the product passport is available.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#issueDate"
@@ -46,7 +48,7 @@
           "@type": "schema:string"
         },
         "economicOperatorId": {
-          "@id": "digitalproductpassport-aspect:economicOperatorId",
+          "@id": "cx:economicOperatorId",
           "@context": {
             "@definition": "The identification of the owner/economic operator of the passport. Proposed, according to ISO 15459, is the CIN (company identification code). Other identification numbers like the tax identification number, value added tax identification number, commercial register number and the like are also valid entries. In the Catena-X network, the BPNL is used for the identification of companies and the information stored like contact information and addresses. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex III:\n(k) the [...] unique operator identifier code of the economic operator established in the Union responsible for carrying out the tasks set out in Article 4 of Regulation (EU) 2019/1020, or Article 15 of Regulation (EU) on general product safety, or similar tasks pursuant to other EU legislation applicable to the product.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#economicOperatorId"
@@ -54,7 +56,7 @@
           "@type": "schema:string"
         },
         "passportIdentifier": {
-          "@id": "digitalproductpassport-aspect:passportIdentifier",
+          "@id": "cx:passportIdentifier",
           "@context": {
             "@definition": "The identifier of the product passport, which is an uuidv4.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#passportIdentifier"
@@ -62,7 +64,7 @@
           "@type": "schema:string"
         },
         "predecessor": {
-          "@id": "digitalproductpassport-aspect:predecessor",
+          "@id": "cx:predecessor",
           "@context": {
             "@definition": "Identification of the preceding product passport. If there is no preceding passport, input a dummy value. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(2)(g) [...] Any new product passport shall be linked to the product passport or passports of the original product whenever appropriate.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#predecessor"
@@ -70,7 +72,7 @@
           "@type": "schema:string"
         },
         "backupReference": {
-          "@id": "digitalproductpassport-aspect:backupReference",
+          "@id": "cx:backupReference",
           "@context": {
             "@definition": "A reference to the data backup of the passport. This mandatory attribute will be further defined in the future. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex III:\n(kb) the reference of the certified independent third-party product passport service provider hosting the back-up copy of the product passport.\nArticle 10 also mentions:\n(c) the data included in the product passport shall be stored by the economic operator responsible for its creation or by certified independent third-party product passport service providers authorised to act on their behalf.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#backupReference"
@@ -78,7 +80,7 @@
           "@type": "schema:string"
         },
         "registrationIdentifier": {
-          "@id": "digitalproductpassport-aspect:registrationIdentifier",
+          "@id": "cx:registrationIdentifier",
           "@context": {
             "@definition": "Identifier in the respective registry. This will be further defined in the future. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 in Article 12:\nBy [2 years from entering into force of this Regulation], the Commission shall set up and manage a digital registry (\"the registry\") storing in a secure manner at least the unique product identifier, the unique operator identifier, the unique facility identifiers. In case of products intended to be placed under the customs procedure 'release for free circulation', the registry shall also store the product commodity code. The registry shall also store the batteries' unique identifiers referred to in Article 77(3) of Regulation (EU) 2023/1542.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#registrationIdentifier"
@@ -86,7 +88,7 @@
           "@type": "schema:string"
         },
         "lastModification": {
-          "@id": "digitalproductpassport-aspect:lastModification",
+          "@id": "cx:lastModification",
           "@context": {
             "@definition": "Date of the latest modification.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#lastModification"
@@ -94,7 +96,7 @@
           "@type": "schema:string"
         },
         "language": {
-          "@id": "digitalproductpassport-aspect:language",
+          "@id": "cx:language",
           "@context": {
             "@definition": "Specific language in which the passport content is created. Language code is based on the ISO 639-1.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#language"
@@ -106,18 +108,18 @@
       }
     },
     "identification": {
-      "@id": "digitalproductpassport-aspect:identification",
+      "@id": "cx:identification",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": {
-          "@id": "digitalproductpassport-aspect:type",
+          "@id": "cx:type",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "manufacturerPartId": {
-              "@id": "digitalproductpassport-aspect:manufacturerPartId",
+              "@id": "cx:manufacturerPartId",
               "@context": {
                 "@definition": "Part ID as assigned by the manufacturer of the part. The part ID identifies the part in the manufacturer`s dataspace. The part ID references a specific version of a part. The version number must be included in the part ID if it is available. The part ID does not reference a specific instance of a part and must not be confused with the serial number.",
                 "@samm-urn": "urn:samm:io.catenax.part_type_information:1.0.0#manufacturerPartId"
@@ -125,7 +127,7 @@
               "@type": "schema:string"
             },
             "nameAtManufacturer": {
-              "@id": "digitalproductpassport-aspect:nameAtManufacturer",
+              "@id": "cx:nameAtManufacturer",
               "@context": {
                 "@definition": "Name of the part as assigned by the manufacturer.",
                 "@samm-urn": "urn:samm:io.catenax.part_type_information:1.0.0#nameAtManufacturer"
@@ -137,7 +139,7 @@
           }
         },
         "serial": {
-          "@id": "digitalproductpassport-aspect:serial",
+          "@id": "cx:serial",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -147,7 +149,7 @@
               "id": "@id",
               "type": "@type",
               "key": {
-                "@id": "digitalproductpassport-aspect:key",
+                "@id": "cx:key",
                 "@context": {
                   "@definition": "The key of a local identifier. ",
                   "@samm-urn": "urn:samm:io.catenax.serial_part:3.0.0#key"
@@ -155,7 +157,7 @@
                 "@type": "schema:string"
               },
               "value": {
-                "@id": "digitalproductpassport-aspect:value",
+                "@id": "cx:value",
                 "@context": {
                   "@definition": "The value of an identifier.",
                   "@samm-urn": "urn:samm:io.catenax.serial_part:3.0.0#value"
@@ -169,7 +171,7 @@
           "@container": "@list"
         },
         "batch": {
-          "@id": "digitalproductpassport-aspect:batch",
+          "@id": "cx:batch",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -179,7 +181,7 @@
               "id": "@id",
               "type": "@type",
               "key": {
-                "@id": "digitalproductpassport-aspect:key",
+                "@id": "cx:key",
                 "@context": {
                   "@definition": "The key of a local identifier.",
                   "@samm-urn": "urn:samm:io.catenax.batch:3.0.0#key"
@@ -187,7 +189,7 @@
                 "@type": "schema:string"
               },
               "value": {
-                "@id": "digitalproductpassport-aspect:value",
+                "@id": "cx:value",
                 "@context": {
                   "@definition": "The value of an identifier.",
                   "@samm-urn": "urn:samm:io.catenax.batch:3.0.0#value"
@@ -201,7 +203,7 @@
           "@container": "@list"
         },
         "codes": {
-          "@id": "digitalproductpassport-aspect:codes",
+          "@id": "cx:codes",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -211,7 +213,7 @@
               "id": "@id",
               "type": "@type",
               "key": {
-                "@id": "digitalproductpassport-aspect:key",
+                "@id": "cx:key",
                 "@context": {
                   "@definition": "The code key for the identification of the product. Examples are GTIN, hash, DID, ISBN, TARIC. This attribute is mentioned in the ESPR proposal from March 30th, 2022 ANNEX III:\n(b) the unique product identifier at the level indicated in the applicable delegated act adopted pursuant to Article 4;\n(c) the Global Trade Identification Number as provided for in standard ISO/IEC 15459-6 or equivalent of products or their parts;\n(d) relevant commodity codes, such as a TARIC code as defined in Council Regulation (EEC) No 2658/87.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#codeKey"
@@ -219,7 +221,7 @@
                 "@type": "schema:string"
               },
               "value": {
-                "@id": "digitalproductpassport-aspect:value",
+                "@id": "cx:value",
                 "@context": {
                   "@definition": "The code value for the identification of the product in regard to the chosen code name.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#codeValue"
@@ -233,13 +235,13 @@
           "@container": "@list"
         },
         "dataCarrier": {
-          "@id": "digitalproductpassport-aspect:dataCarrier",
+          "@id": "cx:dataCarrier",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "carrierType": {
-              "@id": "digitalproductpassport-aspect:carrierType",
+              "@id": "cx:carrierType",
               "@context": {
                 "@definition": "The type of data carrier such as a QR code on the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 8:\n(2) (b) the types of data carrier to be used.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#carrierType"
@@ -247,7 +249,7 @@
               "@type": "schema:string"
             },
             "carrierLayout": {
-              "@id": "digitalproductpassport-aspect:carrierLayout",
+              "@id": "cx:carrierLayout",
               "@context": {
                 "@definition": "The positioning of data carrier on the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 8:\n(2) (c) the layout in which the data carrier shall be presented and its positioning.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#carrierLayout"
@@ -259,7 +261,7 @@
           }
         },
         "classification": {
-          "@id": "digitalproductpassport-aspect:classification",
+          "@id": "cx:classification",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -269,7 +271,7 @@
               "id": "@id",
               "type": "@type",
               "classificationStandard": {
-                "@id": "digitalproductpassport-aspect:classificationStandard",
+                "@id": "cx:classificationStandard",
                 "@context": {
                   "@definition": "Identified classification standards that align to the Catena-X needs.",
                   "@samm-urn": "urn:samm:io.catenax.shared.part_classification:1.0.0#classificationStandard"
@@ -277,7 +279,7 @@
                 "@type": "schema:string"
               },
               "classificationID": {
-                "@id": "digitalproductpassport-aspect:classificationID",
+                "@id": "cx:classificationID",
                 "@context": {
                   "@definition": "The classification ID of the part type according to the corresponding standard definition mentioned in the key value pair.",
                   "@samm-urn": "urn:samm:io.catenax.shared.part_classification:1.0.0#classificationID"
@@ -285,7 +287,7 @@
                 "@type": "schema:string"
               },
               "classificationDescription": {
-                "@id": "digitalproductpassport-aspect:classificationDescription",
+                "@id": "cx:classificationDescription",
                 "@context": {
                   "@definition": "Optional property describing the classification standard.",
                   "@samm-urn": "urn:samm:io.catenax.shared.part_classification:1.0.0#classificationDescription"
@@ -303,19 +305,19 @@
       }
     },
     "operation": {
-      "@id": "digitalproductpassport-aspect:operation",
+      "@id": "cx:operation",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "manufacturer": {
-          "@id": "digitalproductpassport-aspect:manufacturer",
+          "@id": "cx:manufacturer",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "facility": {
-              "@id": "digitalproductpassport-aspect:facility",
+              "@id": "cx:facility",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -325,7 +327,7 @@
                   "id": "@id",
                   "type": "@type",
                   "facility": {
-                    "@id": "digitalproductpassport-aspect:facility",
+                    "@id": "cx:facility",
                     "@context": {
                       "@definition": "The identifier used for a location. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#facility"
@@ -339,7 +341,7 @@
               "@container": "@list"
             },
             "manufacturer": {
-              "@id": "digitalproductpassport-aspect:manufacturer",
+              "@id": "cx:manufacturer",
               "@context": {
                 "@definition": "The main manufacturer, if different from the passport owner, represented by an identification number. In the Catena-X use case, the BPNL can be stated. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(h) unique operator identifiers other than that of the manufacturer;\n(k) the name, contact details and unique operator identifier code of the economic operator established in the Union responsible for carrying out the tasks set out in Article 4 of Regulation (EU) 2019/1020, or Article 15 of Regulation (EU) [.../...] on general product safety, or similar tasks pursuant to other EU legislation applicable to the product.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#manufacturerIdentification"
@@ -347,7 +349,7 @@
               "@type": "schema:string"
             },
             "manufacturingDate": {
-              "@id": "digitalproductpassport-aspect:manufacturingDate",
+              "@id": "cx:manufacturingDate",
               "@context": {
                 "@definition": "The timestamp in the format (yyyy-mm-dd) of the manufacturing date as the final step in production process (e.g. final quality check, ready-for-shipment event).",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#manufacturingDate"
@@ -359,17 +361,17 @@
           }
         },
         "import": {
-          "@id": "digitalproductpassport-aspect:import",
+          "@id": "cx:import",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "content": {
-              "@id": "digitalproductpassport-aspect:content",
+              "@id": "cx:content",
               "@context": {
                 "@version": 1.1,
                 "id": {
-                  "@id": "digitalproductpassport-aspect:id",
+                  "@id": "cx:id",
                   "@context": {
                     "@definition": "The importer of the product, if different from the owner of the passport. In the Catena-X network, the BPNL is used for the identification of companies and the information stored for this like contact information and addresses.\nThis attribute is mentioned in the ESPR provisional agreement from January 9th, 2024  Annex III:\n(j) information related to the importer, including the information referred to in Article 23(3) and its EORI number;\nArticle 23 states:\n(3) Importers shall, for products covered by a delegated act adopted pursuant to Article 4, indicate their name, registered trade name or registered trade mark and the postal address and electronic means of communication, where they can be contacted:  (a) on the public part of the product passport, when applicable, and\n(b) on the product or, where this is not possible, on the packaging, or in a document accompanying the product.",
                     "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#importerIdentification"
@@ -378,7 +380,7 @@
                 },
                 "type": "@type",
                 "eori": {
-                  "@id": "digitalproductpassport-aspect:eori",
+                  "@id": "cx:eori",
                   "@context": {
                     "@definition": "An economic operator established in the customs territory of the Union needs, for customs purposes, an EORI number. EORI stands for economic operators registration and identification number. In this case, the importer's EORI must be provided. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex III:\n(j) information related to the importer, including the information referred to in Article 23(3) and its EORI number.",
                     "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#eori"
@@ -390,7 +392,7 @@
               }
             },
             "applicable": {
-              "@id": "digitalproductpassport-aspect:applicable",
+              "@id": "cx:applicable",
               "@context": {
                 "@definition": "Check whether the connected attributes are applicable to the product. If it is not applicable (false), dummy data can be delivered.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#applicable"
@@ -402,11 +404,11 @@
           }
         },
         "other": {
-          "@id": "digitalproductpassport-aspect:other",
+          "@id": "cx:other",
           "@context": {
             "@version": 1.1,
             "id": {
-              "@id": "digitalproductpassport-aspect:id",
+              "@id": "cx:id",
               "@context": {
                 "@definition": "Identifier of the other operator. This can be a BPN.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#otherOperatorId"
@@ -415,7 +417,7 @@
             },
             "type": "@type",
             "role": {
-              "@id": "digitalproductpassport-aspect:role",
+              "@id": "cx:role",
               "@context": {
                 "@definition": "Role of the other operator.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#otherOperatorRole"
@@ -431,19 +433,19 @@
       }
     },
     "handling": {
-      "@id": "digitalproductpassport-aspect:handling",
+      "@id": "cx:handling",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "content": {
-          "@id": "digitalproductpassport-aspect:content",
+          "@id": "cx:content",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "producer": {
-              "@id": "digitalproductpassport-aspect:producer",
+              "@id": "cx:producer",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -451,7 +453,7 @@
                 "@context": {
                   "@version": 1.1,
                   "id": {
-                    "@id": "digitalproductpassport-aspect:id",
+                    "@id": "cx:id",
                     "@context": {
                       "@definition": "The identifier of a spare part producer of the product. In the Catena-X network, the BPNL is used for the identification of companies and the information stored for this like contact information and addresses.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#sourcesIdentification"
@@ -466,7 +468,7 @@
               "@container": "@list"
             },
             "sparePart": {
-              "@id": "digitalproductpassport-aspect:sparePart",
+              "@id": "cx:sparePart",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -476,7 +478,7 @@
                   "id": "@id",
                   "type": "@type",
                   "manufacturerPartId": {
-                    "@id": "digitalproductpassport-aspect:manufacturerPartId",
+                    "@id": "cx:manufacturerPartId",
                     "@context": {
                       "@definition": "Part ID as assigned by the manufacturer of the part. The part ID identifies the part in the manufacturer`s dataspace. The part ID references a specific version of a part. The version number must be included in the part ID if it is available. The part ID does not reference a specific instance of a part and must not be confused with the serial number.",
                       "@samm-urn": "urn:samm:io.catenax.part_type_information:1.0.0#manufacturerPartId"
@@ -484,7 +486,7 @@
                     "@type": "schema:string"
                   },
                   "nameAtManufacturer": {
-                    "@id": "digitalproductpassport-aspect:nameAtManufacturer",
+                    "@id": "cx:nameAtManufacturer",
                     "@context": {
                       "@definition": "Name of the part as assigned by the manufacturer.",
                       "@samm-urn": "urn:samm:io.catenax.part_type_information:1.0.0#nameAtManufacturer"
@@ -502,7 +504,7 @@
           }
         },
         "applicable": {
-          "@id": "digitalproductpassport-aspect:applicable",
+          "@id": "cx:applicable",
           "@context": {
             "@definition": "Check whether the connected attributes are applicable to the product. If it is not applicable (false), dummy data can be delivered.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#applicable"
@@ -514,13 +516,13 @@
       }
     },
     "characteristics": {
-      "@id": "digitalproductpassport-aspect:characteristics",
+      "@id": "cx:characteristics",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "lifespan": {
-          "@id": "digitalproductpassport-aspect:lifespan",
+          "@id": "cx:lifespan",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -530,7 +532,7 @@
               "id": "@id",
               "type": "@type",
               "unit": {
-                "@id": "digitalproductpassport-aspect:unit",
+                "@id": "cx:unit",
                 "@context": {
                   "@definition": "The unit of the respective lifespan expressed through the possible units day, month, cycle, year and runningOrOperatingHour.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#lifeUnit"
@@ -538,7 +540,7 @@
                 "@type": "schema:string"
               },
               "value": {
-                "@id": "digitalproductpassport-aspect:value",
+                "@id": "cx:value",
                 "@context": {
                   "@definition": "The value as an integer for the respective lifespan.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#lifeValue"
@@ -546,7 +548,7 @@
                 "@type": "schema:number"
               },
               "key": {
-                "@id": "digitalproductpassport-aspect:key",
+                "@id": "cx:key",
                 "@context": {
                   "@definition": "The type of lifespan represented with the values guaranteed lifetime, technical lifetime and mean time between failures. This attribute is mentioned in the ESPR proposal from March 30th, 2022 ANNEX I:\n(a) durability and reliability of the product or its components as expressed through the product's guaranteed lifetime, technical lifetime [or] mean time between failures [...].",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#lifeType"
@@ -560,19 +562,19 @@
           "@container": "@list"
         },
         "physicalDimension": {
-          "@id": "digitalproductpassport-aspect:physicalDimension",
+          "@id": "cx:physicalDimension",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "width": {
-              "@id": "digitalproductpassport-aspect:width",
+              "@id": "cx:width",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "digitalproductpassport-aspect:value",
+                  "@id": "cx:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -580,7 +582,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "digitalproductpassport-aspect:unit",
+                  "@id": "cx:unit",
                   "@context": {
                     "@definition": "The unit of a linear attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#linearUnit"
@@ -592,13 +594,13 @@
               }
             },
             "length": {
-              "@id": "digitalproductpassport-aspect:length",
+              "@id": "cx:length",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "digitalproductpassport-aspect:value",
+                  "@id": "cx:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -606,7 +608,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "digitalproductpassport-aspect:unit",
+                  "@id": "cx:unit",
                   "@context": {
                     "@definition": "The unit of a linear attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#linearUnit"
@@ -618,13 +620,13 @@
               }
             },
             "diameter": {
-              "@id": "digitalproductpassport-aspect:diameter",
+              "@id": "cx:diameter",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "digitalproductpassport-aspect:value",
+                  "@id": "cx:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -632,7 +634,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "digitalproductpassport-aspect:unit",
+                  "@id": "cx:unit",
                   "@context": {
                     "@definition": "The unit of a linear attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#linearUnit"
@@ -644,13 +646,13 @@
               }
             },
             "height": {
-              "@id": "digitalproductpassport-aspect:height",
+              "@id": "cx:height",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "digitalproductpassport-aspect:value",
+                  "@id": "cx:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -658,7 +660,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "digitalproductpassport-aspect:unit",
+                  "@id": "cx:unit",
                   "@context": {
                     "@definition": "The unit of a linear attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#linearUnit"
@@ -670,13 +672,13 @@
               }
             },
             "grossWeight": {
-              "@id": "digitalproductpassport-aspect:grossWeight",
+              "@id": "cx:grossWeight",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "digitalproductpassport-aspect:value",
+                  "@id": "cx:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -684,7 +686,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "digitalproductpassport-aspect:unit",
+                  "@id": "cx:unit",
                   "@context": {
                     "@definition": "The unit of a mass related attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#massUnit"
@@ -696,13 +698,13 @@
               }
             },
             "grossVolume": {
-              "@id": "digitalproductpassport-aspect:grossVolume",
+              "@id": "cx:grossVolume",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "digitalproductpassport-aspect:value",
+                  "@id": "cx:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -710,7 +712,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "digitalproductpassport-aspect:unit",
+                  "@id": "cx:unit",
                   "@context": {
                     "@definition": "The unit of a volume related attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#volumeUnit"
@@ -722,13 +724,13 @@
               }
             },
             "weight": {
-              "@id": "digitalproductpassport-aspect:weight",
+              "@id": "cx:weight",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "digitalproductpassport-aspect:value",
+                  "@id": "cx:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -736,7 +738,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "digitalproductpassport-aspect:unit",
+                  "@id": "cx:unit",
                   "@context": {
                     "@definition": "The unit of a mass related attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#massUnit"
@@ -748,13 +750,13 @@
               }
             },
             "volume": {
-              "@id": "digitalproductpassport-aspect:volume",
+              "@id": "cx:volume",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
                 "type": "@type",
                 "value": {
-                  "@id": "digitalproductpassport-aspect:value",
+                  "@id": "cx:value",
                   "@context": {
                     "@definition": "The quantity value associated with the unit.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#quantityValue"
@@ -762,7 +764,7 @@
                   "@type": "schema:number"
                 },
                 "unit": {
-                  "@id": "digitalproductpassport-aspect:unit",
+                  "@id": "cx:unit",
                   "@context": {
                     "@definition": "The unit of a volume related attribute.",
                     "@samm-urn": "urn:samm:io.catenax.shared.quantity:2.0.0#volumeUnit"
@@ -778,7 +780,7 @@
           }
         },
         "physicalState": {
-          "@id": "digitalproductpassport-aspect:physicalState",
+          "@id": "cx:physicalState",
           "@context": {
             "@definition": "The physical state of the item. There are four states of matter solid, liquid, gas and plasma which can be chosen from an enumeration.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#physicalState"
@@ -786,7 +788,7 @@
           "@type": "schema:string"
         },
         "generalPerformanceClass": {
-          "@id": "digitalproductpassport-aspect:generalPerformanceClass",
+          "@id": "cx:generalPerformanceClass",
           "@context": {
             "@definition": "The performance class of the product. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n4. When establishing the information requirements referred to in paragraph 2, point (b), point (i), the Commission shall, as appropriate in view of the specificity of the product group, determine classes of performance. Classes of performance may be based on single parameters, on aggregated scores, in absolute terms or in any other form that enables potential customers to choose the best performing products. Those classes of performance shall correspond to significant improvements in performance levels. Where classes of performance are based on parameters in relation to which performance requirements are established, they shall use as the minimum level the minimum performance required at the time when the classes of performance start to apply.\nDefinition:\n'class of performance': means a range of performance levels in relation to one or more product parameters referred to in Annex I, based on a common methodology for the product or product group, ordered into successive steps to allow for product differentiation.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#generalPerformanceClass"
@@ -798,13 +800,13 @@
       }
     },
     "commercial": {
-      "@id": "digitalproductpassport-aspect:commercial",
+      "@id": "cx:commercial",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "placedOnMarket": {
-          "@id": "digitalproductpassport-aspect:placedOnMarket",
+          "@id": "cx:placedOnMarket",
           "@context": {
             "@definition": "The timestamp in the format (yyyy-mm-dd) with or without time zone when the product was put in the market.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#placedOnMarket"
@@ -812,7 +814,7 @@
           "@type": "schema:string"
         },
         "purpose": {
-          "@id": "digitalproductpassport-aspect:purpose",
+          "@id": "cx:purpose",
           "@context": {
             "@definition": "One or more intended industry/industries of the product described by the digital product passport. If exchanged via Catena-X, 'automotive ' is a must choice included in the list.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#purpose"
@@ -821,7 +823,7 @@
           "@type": "schema:string"
         },
         "purchaseOrder": {
-          "@id": "digitalproductpassport-aspect:purchaseOrder",
+          "@id": "cx:purchaseOrder",
           "@context": {
             "@definition": "A unique identifier assigned to the order of the product for tracking purposes between supplier and customer.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#purchaseOrder"
@@ -829,13 +831,13 @@
           "@type": "schema:string"
         },
         "recallInformation": {
-          "@id": "digitalproductpassport-aspect:recallInformation",
+          "@id": "cx:recallInformation",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "applicable": {
-              "@id": "digitalproductpassport-aspect:applicable",
+              "@id": "cx:applicable",
               "@context": {
                 "@definition": "Check whether the connected attributes are applicable to the product. If it is not applicable (false), dummy data can be delivered.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#applicable"
@@ -843,7 +845,7 @@
               "@type": "schema:boolean"
             },
             "recallInformationDocumentation": {
-              "@id": "digitalproductpassport-aspect:recallInformationDocumentation",
+              "@id": "cx:recallInformationDocumentation",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -853,7 +855,7 @@
                   "id": "@id",
                   "type": "@type",
                   "content": {
-                    "@id": "digitalproductpassport-aspect:content",
+                    "@id": "cx:content",
                     "@context": {
                       "@definition": "The content of the document e.g a link.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -861,7 +863,7 @@
                     "@type": "schema:string"
                   },
                   "contentType": {
-                    "@id": "digitalproductpassport-aspect:contentType",
+                    "@id": "cx:contentType",
                     "@context": {
                       "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -869,7 +871,7 @@
                     "@type": "schema:string"
                   },
                   "header": {
-                    "@id": "digitalproductpassport-aspect:header",
+                    "@id": "cx:header",
                     "@context": {
                       "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -891,19 +893,19 @@
       }
     },
     "materials": {
-      "@id": "digitalproductpassport-aspect:materials",
+      "@id": "cx:materials",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "substancesOfConcern": {
-          "@id": "digitalproductpassport-aspect:substancesOfConcern",
+          "@id": "cx:substancesOfConcern",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "applicable": {
-              "@id": "digitalproductpassport-aspect:applicable",
+              "@id": "cx:applicable",
               "@context": {
                 "@definition": "Check whether the connected attributes are applicable to the product. If it is not applicable (false), dummy data can be delivered.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#applicable"
@@ -911,7 +913,7 @@
               "@type": "schema:boolean"
             },
             "content": {
-              "@id": "digitalproductpassport-aspect:content",
+              "@id": "cx:content",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -919,7 +921,7 @@
                 "@context": {
                   "@version": 1.1,
                   "id": {
-                    "@id": "digitalproductpassport-aspect:id",
+                    "@id": "cx:id",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -927,7 +929,7 @@
                       "@context": {
                         "@version": 1.1,
                         "id": {
-                          "@id": "digitalproductpassport-aspect:id",
+                          "@id": "cx:id",
                           "@context": {
                             "@definition": "The substance identification, in accordance with the specification in the attribute for the list type.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#chemicalId"
@@ -935,7 +937,7 @@
                           "@type": "schema:string"
                         },
                         "type": {
-                          "@id": "digitalproductpassport-aspect:type",
+                          "@id": "cx:type",
                           "@context": {
                             "@definition": "The type of standard used for the identification of the substances. Selected can be for example CAS, IUPAC or EC.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#listTypeId"
@@ -943,7 +945,7 @@
                           "@type": "schema:string"
                         },
                         "name": {
-                          "@id": "digitalproductpassport-aspect:name",
+                          "@id": "cx:name",
                           "@context": {
                             "@definition": "The name of the material which is present in the product.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#chemicalName"
@@ -958,7 +960,7 @@
                   },
                   "type": "@type",
                   "location": {
-                    "@id": "digitalproductpassport-aspect:location",
+                    "@id": "cx:location",
                     "@context": {
                       "@definition": "The location of the substances of concern within the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (b) the location of the substances of concern within the product.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#location"
@@ -966,7 +968,7 @@
                     "@type": "schema:string"
                   },
                   "unit": {
-                    "@id": "digitalproductpassport-aspect:unit",
+                    "@id": "cx:unit",
                     "@context": {
                       "@definition": "The unit of concentration chosen from an enumeration: mass percent, volume percent, parts per thousand, parts per million, parts per billion and  parts per trillion.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#materialUnit"
@@ -974,7 +976,7 @@
                     "@type": "schema:string"
                   },
                   "concentration": {
-                    "@id": "digitalproductpassport-aspect:concentration",
+                    "@id": "cx:concentration",
                     "@context": {
                       "@definition": "Concentration of the material at the level of the product. This attribute is specially mentioned for substances of concern mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product [...].\nOther substances are mentioned for the purpose of recycling in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(d) design for recycling, ease and quality of recycling as expressed through: use of easily recyclable materials, safe, easy and non-destructive access to recyclable components and materials or components and materials containing hazardous substances and material composition and homogeneity, possibility for high-purity sorting, number of materials and components used, use of standard components, use of component and material coding standards for the identification of components and materials, number and complexity of processes and tools needed, ease of nondestructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed.\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#concentration"
@@ -982,7 +984,7 @@
                     "@type": "schema:number"
                   },
                   "exemption": {
-                    "@id": "digitalproductpassport-aspect:exemption",
+                    "@id": "cx:exemption",
                     "@context": {
                       "@definition": "Exemptions to the substance of concern. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 7:\n(5) (c) provide duly justified exemptions for substances of concern or information elements from the information requirements referred to in the first subparagraph based on the technical feasibility or relevance of tracking substances of concern, the existence of analytical methods to detect and quantify them, the need to protect confidential business information or in other duly justified cases. Substances of concern within the meaning of Article 2(28), point a), shall not be exempted if they are present in products, their relevant components or spare parts in a concentration above 0,1 % weight by weight.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#exemption"
@@ -990,13 +992,13 @@
                     "@type": "schema:string"
                   },
                   "hazardClassification": {
-                    "@id": "digitalproductpassport-aspect:hazardClassification",
+                    "@id": "cx:hazardClassification",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
                       "type": "@type",
                       "category": {
-                        "@id": "digitalproductpassport-aspect:category",
+                        "@id": "cx:category",
                         "@context": {
                           "@definition": "The hazard category of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n2. 'hazard category' means the division of criteria within each hazard class, specifying hazard severity.",
                           "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#hazardCategory"
@@ -1004,7 +1006,7 @@
                         "@type": "schema:string"
                       },
                       "class": {
-                        "@id": "digitalproductpassport-aspect:class",
+                        "@id": "cx:class",
                         "@context": {
                           "@definition": "The hazard class of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n1. 'hazard class' means the nature of the physical, health or environmental hazard.",
                           "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#hazardClass"
@@ -1012,7 +1014,7 @@
                         "@type": "schema:string"
                       },
                       "statement": {
-                        "@id": "digitalproductpassport-aspect:statement",
+                        "@id": "cx:statement",
                         "@context": {
                           "@definition": "The hazard statement of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n5. 'hazard statement' means a phrase assigned to a hazard class and category that describes the nature of the hazards of a hazardous substance or mixture, including, where appropriate, the degree of hazard.",
                           "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#hazardStatement"
@@ -1024,7 +1026,7 @@
                     }
                   },
                   "concentrationRange": {
-                    "@id": "digitalproductpassport-aspect:concentrationRange",
+                    "@id": "cx:concentrationRange",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1034,7 +1036,7 @@
                         "id": "@id",
                         "type": "@type",
                         "min": {
-                          "@id": "digitalproductpassport-aspect:min",
+                          "@id": "cx:min",
                           "@context": {
                             "@definition": "The minimum concentration of the substance of concern at the level of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) [...] concentration range of the substances of concern, at the level of the product [...].",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#minConcentration"
@@ -1042,7 +1044,7 @@
                           "@type": "schema:number"
                         },
                         "max": {
-                          "@id": "digitalproductpassport-aspect:max",
+                          "@id": "cx:max",
                           "@context": {
                             "@definition": "The maximum concentration of the substance of concern at the level of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product [...].",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#maxConcentration"
@@ -1056,7 +1058,7 @@
                     "@container": "@list"
                   },
                   "documentation": {
-                    "@id": "digitalproductpassport-aspect:documentation",
+                    "@id": "cx:documentation",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1066,7 +1068,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "digitalproductpassport-aspect:content",
+                          "@id": "cx:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1074,7 +1076,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "digitalproductpassport-aspect:contentType",
+                          "@id": "cx:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1082,7 +1084,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "digitalproductpassport-aspect:header",
+                          "@id": "cx:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1106,13 +1108,13 @@
           }
         },
         "materialComposition": {
-          "@id": "digitalproductpassport-aspect:materialComposition",
+          "@id": "cx:materialComposition",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "applicable": {
-              "@id": "digitalproductpassport-aspect:applicable",
+              "@id": "cx:applicable",
               "@context": {
                 "@definition": "Check whether the connected attributes are applicable to the product. If it is not applicable (false), dummy data can be delivered.",
                 "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#applicable"
@@ -1120,7 +1122,7 @@
               "@type": "schema:boolean"
             },
             "content": {
-              "@id": "digitalproductpassport-aspect:content",
+              "@id": "cx:content",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -1128,7 +1130,7 @@
                 "@context": {
                   "@version": 1.1,
                   "id": {
-                    "@id": "digitalproductpassport-aspect:id",
+                    "@id": "cx:id",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1136,7 +1138,7 @@
                       "@context": {
                         "@version": 1.1,
                         "id": {
-                          "@id": "digitalproductpassport-aspect:id",
+                          "@id": "cx:id",
                           "@context": {
                             "@definition": "The substance identification, in accordance with the specification in the attribute for the list type.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#chemicalId"
@@ -1144,7 +1146,7 @@
                           "@type": "schema:string"
                         },
                         "type": {
-                          "@id": "digitalproductpassport-aspect:type",
+                          "@id": "cx:type",
                           "@context": {
                             "@definition": "The type of standard used for the identification of the substances. Selected can be for example CAS, IUPAC or EC.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#listTypeId"
@@ -1152,7 +1154,7 @@
                           "@type": "schema:string"
                         },
                         "name": {
-                          "@id": "digitalproductpassport-aspect:name",
+                          "@id": "cx:name",
                           "@context": {
                             "@definition": "The name of the material which is present in the product.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#chemicalName"
@@ -1167,7 +1169,7 @@
                   },
                   "type": "@type",
                   "recycled": {
-                    "@id": "digitalproductpassport-aspect:recycled",
+                    "@id": "cx:recycled",
                     "@context": {
                       "@definition": "The share of the material, which is recovered recycled content from the product. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(h) use or content of recycled materials and recovery of materials, including critical raw materials;",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#recycled"
@@ -1175,7 +1177,7 @@
                     "@type": "schema:number"
                   },
                   "renewable": {
-                    "@id": "digitalproductpassport-aspect:renewable",
+                    "@id": "cx:renewable",
                     "@context": {
                       "@definition": "The share of the material, which is from a renewable resource that can be replenished. Renewable resources are those that can be reproduced by physical, chemical, or mechanical processes. These are the kind of resources that can be regenerated throughout time. Forest wood, for example, can be grown through reforestation. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(ha) use or content of sustainable renewable materials;\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#renewable"
@@ -1183,7 +1185,7 @@
                     "@type": "schema:number"
                   },
                   "unit": {
-                    "@id": "digitalproductpassport-aspect:unit",
+                    "@id": "cx:unit",
                     "@context": {
                       "@definition": "The unit of concentration chosen from an enumeration: mass percent, volume percent, parts per thousand, parts per million, parts per billion and  parts per trillion.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#materialUnit"
@@ -1191,7 +1193,7 @@
                     "@type": "schema:string"
                   },
                   "critical": {
-                    "@id": "digitalproductpassport-aspect:critical",
+                    "@id": "cx:critical",
                     "@context": {
                       "@definition": "A flag, if the material is a critical raw material. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(h) use or content of recycled materials and recovery of materials, including critical raw materials;\nIn Annex II of the connected proposal Act of Critical Raw Materials, a list of critical raw materials can be found.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#critical"
@@ -1199,7 +1201,7 @@
                     "@type": "schema:boolean"
                   },
                   "concentration": {
-                    "@id": "digitalproductpassport-aspect:concentration",
+                    "@id": "cx:concentration",
                     "@context": {
                       "@definition": "Concentration of the material at the level of the product. This attribute is specially mentioned for substances of concern mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product [...].\nOther substances are mentioned for the purpose of recycling in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(d) design for recycling, ease and quality of recycling as expressed through: use of easily recyclable materials, safe, easy and non-destructive access to recyclable components and materials or components and materials containing hazardous substances and material composition and homogeneity, possibility for high-purity sorting, number of materials and components used, use of standard components, use of component and material coding standards for the identification of components and materials, number and complexity of processes and tools needed, ease of nondestructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed.\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#concentration"
@@ -1207,7 +1209,7 @@
                     "@type": "schema:number"
                   },
                   "documentation": {
-                    "@id": "digitalproductpassport-aspect:documentation",
+                    "@id": "cx:documentation",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1217,7 +1219,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "digitalproductpassport-aspect:content",
+                          "@id": "cx:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1225,7 +1227,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "digitalproductpassport-aspect:contentType",
+                          "@id": "cx:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1233,7 +1235,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "digitalproductpassport-aspect:header",
+                          "@id": "cx:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1261,13 +1263,13 @@
       }
     },
     "sustainability": {
-      "@id": "digitalproductpassport-aspect:sustainability",
+      "@id": "cx:sustainability",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "status": {
-          "@id": "digitalproductpassport-aspect:status",
+          "@id": "cx:status",
           "@context": {
             "@definition": "The status of the product (original, repurposed, re-used, remanufactured or waste) to indicated, whether it is a used product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(j) incorporation of used components.",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#state"
@@ -1275,13 +1277,13 @@
           "@type": "schema:string"
         },
         "productFootprint": {
-          "@id": "digitalproductpassport-aspect:productFootprint",
+          "@id": "cx:productFootprint",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "environmental": {
-              "@id": "digitalproductpassport-aspect:environmental",
+              "@id": "cx:environmental",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -1290,7 +1292,7 @@
                   "@version": 1.1,
                   "id": "@id",
                   "type": {
-                    "@id": "digitalproductpassport-aspect:type",
+                    "@id": "cx:type",
                     "@context": {
                       "@definition": "The type of the environmental footprint of the product. This could be one of the environmental impact categories. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nAnnex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories.\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintType"
@@ -1298,7 +1300,7 @@
                     "@type": "schema:string"
                   },
                   "value": {
-                    "@id": "digitalproductpassport-aspect:value",
+                    "@id": "cx:value",
                     "@context": {
                       "@definition": "The value of the footprint of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories;\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintValue"
@@ -1306,7 +1308,7 @@
                     "@type": "schema:number"
                   },
                   "rulebook": {
-                    "@id": "digitalproductpassport-aspect:rulebook",
+                    "@id": "cx:rulebook",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1316,7 +1318,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "digitalproductpassport-aspect:content",
+                          "@id": "cx:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1324,7 +1326,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "digitalproductpassport-aspect:contentType",
+                          "@id": "cx:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1332,7 +1334,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "digitalproductpassport-aspect:header",
+                          "@id": "cx:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1346,7 +1348,7 @@
                     "@container": "@list"
                   },
                   "lifecycle": {
-                    "@id": "digitalproductpassport-aspect:lifecycle",
+                    "@id": "cx:lifecycle",
                     "@context": {
                       "@definition": "The lifecycle stage, to which the environmental footprint corresponds. These could be for example \"raw material acquisition and pre-processing\", \"main product production\", \"distribution\" or \"end of life and recycling\".",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintLifecycle"
@@ -1354,7 +1356,7 @@
                     "@type": "schema:string"
                   },
                   "unit": {
-                    "@id": "digitalproductpassport-aspect:unit",
+                    "@id": "cx:unit",
                     "@context": {
                       "@definition": "The unit of measurement of the environmental impact category. For each impact category a specific unit is used. If an aggregation is used, utilize the normalization and weighting methods used in the referenced rulebook.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintUnit"
@@ -1362,7 +1364,7 @@
                     "@type": "schema:string"
                   },
                   "performanceClass": {
-                    "@id": "digitalproductpassport-aspect:performanceClass",
+                    "@id": "cx:performanceClass",
                     "@context": {
                       "@definition": "The performance classification of the footprint.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#performanceClass"
@@ -1370,7 +1372,7 @@
                     "@type": "schema:string"
                   },
                   "manufacturingPlant": {
-                    "@id": "digitalproductpassport-aspect:manufacturingPlant",
+                    "@id": "cx:manufacturingPlant",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1380,7 +1382,7 @@
                         "id": "@id",
                         "type": "@type",
                         "facility": {
-                          "@id": "digitalproductpassport-aspect:facility",
+                          "@id": "cx:facility",
                           "@context": {
                             "@definition": "The identifier used for a location. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#facility"
@@ -1394,7 +1396,7 @@
                     "@container": "@list"
                   },
                   "declaration": {
-                    "@id": "digitalproductpassport-aspect:declaration",
+                    "@id": "cx:declaration",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1404,7 +1406,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "digitalproductpassport-aspect:content",
+                          "@id": "cx:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1412,7 +1414,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "digitalproductpassport-aspect:contentType",
+                          "@id": "cx:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1420,7 +1422,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "digitalproductpassport-aspect:header",
+                          "@id": "cx:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1440,7 +1442,7 @@
               "@container": "@list"
             },
             "carbon": {
-              "@id": "digitalproductpassport-aspect:carbon",
+              "@id": "cx:carbon",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -1449,7 +1451,7 @@
                   "@version": 1.1,
                   "id": "@id",
                   "type": {
-                    "@id": "digitalproductpassport-aspect:type",
+                    "@id": "cx:type",
                     "@context": {
                       "@definition": "The type of the environmental footprint of the product. This could be one of the environmental impact categories. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nAnnex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories.\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintType"
@@ -1457,7 +1459,7 @@
                     "@type": "schema:string"
                   },
                   "value": {
-                    "@id": "digitalproductpassport-aspect:value",
+                    "@id": "cx:value",
                     "@context": {
                       "@definition": "The value of the footprint of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories;\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintValue"
@@ -1465,7 +1467,7 @@
                     "@type": "schema:number"
                   },
                   "rulebook": {
-                    "@id": "digitalproductpassport-aspect:rulebook",
+                    "@id": "cx:rulebook",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1475,7 +1477,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "digitalproductpassport-aspect:content",
+                          "@id": "cx:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1483,7 +1485,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "digitalproductpassport-aspect:contentType",
+                          "@id": "cx:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1491,7 +1493,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "digitalproductpassport-aspect:header",
+                          "@id": "cx:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1505,7 +1507,7 @@
                     "@container": "@list"
                   },
                   "lifecycle": {
-                    "@id": "digitalproductpassport-aspect:lifecycle",
+                    "@id": "cx:lifecycle",
                     "@context": {
                       "@definition": "The lifecycle stage, to which the environmental footprint corresponds. These could be for example \"raw material acquisition and pre-processing\", \"main product production\", \"distribution\" or \"end of life and recycling\".",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintLifecycle"
@@ -1513,7 +1515,7 @@
                     "@type": "schema:string"
                   },
                   "unit": {
-                    "@id": "digitalproductpassport-aspect:unit",
+                    "@id": "cx:unit",
                     "@context": {
                       "@definition": "The unit of measurement of the environmental impact category. For each impact category a specific unit is used. If an aggregation is used, utilize the normalization and weighting methods used in the referenced rulebook.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintUnit"
@@ -1521,7 +1523,7 @@
                     "@type": "schema:string"
                   },
                   "performanceClass": {
-                    "@id": "digitalproductpassport-aspect:performanceClass",
+                    "@id": "cx:performanceClass",
                     "@context": {
                       "@definition": "The performance classification of the footprint.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#performanceClass"
@@ -1529,7 +1531,7 @@
                     "@type": "schema:string"
                   },
                   "manufacturingPlant": {
-                    "@id": "digitalproductpassport-aspect:manufacturingPlant",
+                    "@id": "cx:manufacturingPlant",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1539,7 +1541,7 @@
                         "id": "@id",
                         "type": "@type",
                         "facility": {
-                          "@id": "digitalproductpassport-aspect:facility",
+                          "@id": "cx:facility",
                           "@context": {
                             "@definition": "The identifier used for a location. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#facility"
@@ -1553,7 +1555,7 @@
                     "@container": "@list"
                   },
                   "declaration": {
-                    "@id": "digitalproductpassport-aspect:declaration",
+                    "@id": "cx:declaration",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1563,7 +1565,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "digitalproductpassport-aspect:content",
+                          "@id": "cx:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1571,7 +1573,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "digitalproductpassport-aspect:contentType",
+                          "@id": "cx:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1579,7 +1581,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "digitalproductpassport-aspect:header",
+                          "@id": "cx:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1599,7 +1601,7 @@
               "@container": "@list"
             },
             "material": {
-              "@id": "digitalproductpassport-aspect:material",
+              "@id": "cx:material",
               "@context": {
                 "@version": 1.1,
                 "id": "@id",
@@ -1608,7 +1610,7 @@
                   "@version": 1.1,
                   "id": "@id",
                   "type": {
-                    "@id": "digitalproductpassport-aspect:type",
+                    "@id": "cx:type",
                     "@context": {
                       "@definition": "The type of the environmental footprint of the product. This could be one of the environmental impact categories. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nAnnex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories.\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintType"
@@ -1616,7 +1618,7 @@
                     "@type": "schema:string"
                   },
                   "value": {
-                    "@id": "digitalproductpassport-aspect:value",
+                    "@id": "cx:value",
                     "@context": {
                       "@definition": "The value of the footprint of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories;\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.\n",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintValue"
@@ -1624,7 +1626,7 @@
                     "@type": "schema:number"
                   },
                   "rulebook": {
-                    "@id": "digitalproductpassport-aspect:rulebook",
+                    "@id": "cx:rulebook",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1634,7 +1636,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "digitalproductpassport-aspect:content",
+                          "@id": "cx:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1642,7 +1644,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "digitalproductpassport-aspect:contentType",
+                          "@id": "cx:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1650,7 +1652,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "digitalproductpassport-aspect:header",
+                          "@id": "cx:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1664,7 +1666,7 @@
                     "@container": "@list"
                   },
                   "lifecycle": {
-                    "@id": "digitalproductpassport-aspect:lifecycle",
+                    "@id": "cx:lifecycle",
                     "@context": {
                       "@definition": "The lifecycle stage, to which the environmental footprint corresponds. These could be for example \"raw material acquisition and pre-processing\", \"main product production\", \"distribution\" or \"end of life and recycling\".",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintLifecycle"
@@ -1672,7 +1674,7 @@
                     "@type": "schema:string"
                   },
                   "unit": {
-                    "@id": "digitalproductpassport-aspect:unit",
+                    "@id": "cx:unit",
                     "@context": {
                       "@definition": "The unit of measurement of the environmental impact category. For each impact category a specific unit is used. If an aggregation is used, utilize the normalization and weighting methods used in the referenced rulebook.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#footprintUnit"
@@ -1680,7 +1682,7 @@
                     "@type": "schema:string"
                   },
                   "performanceClass": {
-                    "@id": "digitalproductpassport-aspect:performanceClass",
+                    "@id": "cx:performanceClass",
                     "@context": {
                       "@definition": "The performance classification of the footprint.",
                       "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#performanceClass"
@@ -1688,7 +1690,7 @@
                     "@type": "schema:string"
                   },
                   "manufacturingPlant": {
-                    "@id": "digitalproductpassport-aspect:manufacturingPlant",
+                    "@id": "cx:manufacturingPlant",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1698,7 +1700,7 @@
                         "id": "@id",
                         "type": "@type",
                         "facility": {
-                          "@id": "digitalproductpassport-aspect:facility",
+                          "@id": "cx:facility",
                           "@context": {
                             "@definition": "The identifier used for a location. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#facility"
@@ -1712,7 +1714,7 @@
                     "@container": "@list"
                   },
                   "declaration": {
-                    "@id": "digitalproductpassport-aspect:declaration",
+                    "@id": "cx:declaration",
                     "@context": {
                       "@version": 1.1,
                       "id": "@id",
@@ -1722,7 +1724,7 @@
                         "id": "@id",
                         "type": "@type",
                         "content": {
-                          "@id": "digitalproductpassport-aspect:content",
+                          "@id": "cx:content",
                           "@context": {
                             "@definition": "The content of the document e.g a link.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1730,7 +1732,7 @@
                           "@type": "schema:string"
                         },
                         "contentType": {
-                          "@id": "digitalproductpassport-aspect:contentType",
+                          "@id": "cx:contentType",
                           "@context": {
                             "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1738,7 +1740,7 @@
                           "@type": "schema:string"
                         },
                         "header": {
-                          "@id": "digitalproductpassport-aspect:header",
+                          "@id": "cx:header",
                           "@context": {
                             "@definition": "The header as a short description of the document with a maximum of 100 characters.",
                             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1762,7 +1764,7 @@
           }
         },
         "reparabilityScore": {
-          "@id": "digitalproductpassport-aspect:reparabilityScore",
+          "@id": "cx:reparabilityScore",
           "@context": {
             "@definition": "The reparability score. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n(b) as appropriate, also require products to be accompanied by:\n(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability [...].",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#reparabilityScore"
@@ -1770,7 +1772,7 @@
           "@type": "schema:string"
         },
         "durabilityScore": {
-          "@id": "digitalproductpassport-aspect:durabilityScore",
+          "@id": "cx:durabilityScore",
           "@context": {
             "@definition": "The durability score. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n(b) as appropriate, also require products to be accompanied by:\n(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability [...].",
             "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#durabilityScore"
@@ -1782,7 +1784,7 @@
       }
     },
     "sources": {
-      "@id": "digitalproductpassport-aspect:sources",
+      "@id": "cx:sources",
       "@context": {
         "@version": 1.1,
         "id": "@id",
@@ -1791,7 +1793,7 @@
           "@version": 1.1,
           "id": "@id",
           "type": {
-            "@id": "digitalproductpassport-aspect:type",
+            "@id": "cx:type",
             "@context": {
               "@definition": "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#contentType"
@@ -1799,7 +1801,7 @@
             "@type": "schema:string"
           },
           "content": {
-            "@id": "digitalproductpassport-aspect:content",
+            "@id": "cx:content",
             "@context": {
               "@definition": "The content of the document e.g a link.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#content"
@@ -1807,7 +1809,7 @@
             "@type": "schema:string"
           },
           "category": {
-            "@id": "digitalproductpassport-aspect:category",
+            "@id": "cx:category",
             "@context": {
               "@definition": "The category in which the document can be sorted. These are mentioned in the ESPR proposal from March 30th, 2022 ANNEX III:\n(e) compliance documentation and information required under this Regulation or other Union law applicable to the product, such as the declaration of conformity, technical documentation or conformity certificates;\nANNEX IV states additional information regarding the content of the technical documentation\nFurther information on documents are mentioned in the proposal from March 30th, 2022 ANNEX III:\n(f) user manuals, instructions, warnings or safety information, as required by other Union legislation applicable to the product.\nAdditionally requirements are mentioned in Article 21:\n(7) Manufacturers shall ensure that that a product covered by a delegated act adopted pursuant to Article 4 is accompanied by instructions that enable consumers and other end-users to safely assemble, install, operate, store, maintain, repair and dispose of the product in a language that can be easily understood by consumers and other end-users, as determined by the Member State concerned. Such instructions shall be clear, understandable and legible and include at least the information specified in the delegated acts adopted pursuant to Article 4 and pursuant to Article 7(2)(b), point (ii).\nArticle 7 states additionally:\n(2) (b) (ii) information for consumers and other end-users on how to install, use, maintain and repair the product in order to minimize its impact on the environment and to ensure optimum durability, as well as on how to return or dispose of the product at end-of-life;\n(2) (b) (iii) information for treatment facilities on disassembly, recycling, or disposal at end-of-life;\n(2) (b) (iv) other information that may influence the way the product is handled by parties other than the manufacturer in order to improve performance in relation to product parameters referred to in Annex I.\n(5) (d) relevant instructions for the safe use of the product.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#category"
@@ -1815,7 +1817,7 @@
             "@type": "schema:string"
           },
           "header": {
-            "@id": "digitalproductpassport-aspect:header",
+            "@id": "cx:header",
             "@context": {
               "@definition": "The header as a short description of the document with a maximum of 100 characters.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#header"
@@ -1829,7 +1831,7 @@
       "@container": "@list"
     },
     "additionalData": {
-      "@id": "digitalproductpassport-aspect:additionalData",
+      "@id": "cx:additionalData",
       "@context": {
         "@version": 1.1,
         "id": "@id",
@@ -1838,13 +1840,13 @@
           "@version": 1.1,
           "id": "@id",
           "type": {
-            "@id": "digitalproductpassport-aspect:type",
+            "@id": "cx:type",
             "@context": {
               "@version": 1.1,
               "id": "@id",
               "type": "@type",
               "typeUnit": {
-                "@id": "digitalproductpassport-aspect:typeUnit",
+                "@id": "cx:typeUnit",
                 "@context": {
                   "@definition": "Choose a unit type from the unit catalog, or if the property \"children\" is filled, leave empty.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#typeUnit"
@@ -1852,7 +1854,7 @@
                 "@type": "schema:string"
               },
               "dataType": {
-                "@id": "digitalproductpassport-aspect:dataType",
+                "@id": "cx:dataType",
                 "@context": {
                   "@definition": "Data type that describe the content of the attributes children and data. In case \"object\" is selected in the enumeration, the children field will be used in the AdditionalDataEntity instead of the \"data\" property. If it is an other type, the content will be specified in \"data\" as a string.",
                   "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#dataType"
@@ -1864,7 +1866,7 @@
             }
           },
           "label": {
-            "@id": "digitalproductpassport-aspect:label",
+            "@id": "cx:label",
             "@context": {
               "@definition": "The human readable name of the attribute.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#label"
@@ -1872,7 +1874,7 @@
             "@type": "schema:string"
           },
           "description": {
-            "@id": "digitalproductpassport-aspect:description",
+            "@id": "cx:description",
             "@context": {
               "@definition": "The description of the attribute context.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#description"
@@ -1880,7 +1882,7 @@
             "@type": "schema:string"
           },
           "data": {
-            "@id": "digitalproductpassport-aspect:data",
+            "@id": "cx:data",
             "@context": {
               "@definition": "The content from the attribute which is a depended of the data type and typeUnit.",
               "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#data"
@@ -1888,7 +1890,7 @@
             "@type": "schema:string"
           },
           "children": {
-            "@id": "digitalproductpassport-aspect:children",
+            "@id": "cx:children",
             "@context": {
               "@version": 1.1,
               "id": "@id",
@@ -1897,13 +1899,13 @@
                 "@version": 1.1,
                 "id": "@id",
                 "type": {
-                  "@id": "digitalproductpassport-aspect:type",
+                  "@id": "cx:type",
                   "@context": {
                     "@version": 1.1,
                     "id": "@id",
                     "type": "@type",
                     "typeUnit": {
-                      "@id": "digitalproductpassport-aspect:typeUnit",
+                      "@id": "cx:typeUnit",
                       "@context": {
                         "@definition": "Choose a unit type from the unit catalog, or if the property \"children\" is filled, leave empty.",
                         "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#typeUnit"
@@ -1911,7 +1913,7 @@
                       "@type": "schema:string"
                     },
                     "dataType": {
-                      "@id": "digitalproductpassport-aspect:dataType",
+                      "@id": "cx:dataType",
                       "@context": {
                         "@definition": "Data type that describe the content of the attributes children and data. In case \"object\" is selected in the enumeration, the children field will be used in the AdditionalDataEntity instead of the \"data\" property. If it is an other type, the content will be specified in \"data\" as a string.",
                         "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#dataType"
@@ -1923,7 +1925,7 @@
                   }
                 },
                 "label": {
-                  "@id": "digitalproductpassport-aspect:label",
+                  "@id": "cx:label",
                   "@context": {
                     "@definition": "The human readable name of the attribute.",
                     "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#label"
@@ -1931,7 +1933,7 @@
                   "@type": "schema:string"
                 },
                 "description": {
-                  "@id": "digitalproductpassport-aspect:description",
+                  "@id": "cx:description",
                   "@context": {
                     "@definition": "The description of the attribute context.",
                     "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#description"
@@ -1939,7 +1941,7 @@
                   "@type": "schema:string"
                 },
                 "data": {
-                  "@id": "digitalproductpassport-aspect:data",
+                  "@id": "cx:data",
                   "@context": {
                     "@definition": "The content from the attribute which is a depended of the data type and typeUnit.",
                     "@samm-urn": "urn:samm:io.catenax.generic.digital_product_passport:6.0.0#data"

--- a/io.catenax.pcf/7.0.0/gen/Pcf-context.jsonld
+++ b/io.catenax.pcf/7.0.0/gen/Pcf-context.jsonld
@@ -2,13 +2,22 @@
   "@context": {
     "@version": 1.1,
     "schema": "https://schema.org/",
-    "pcf-aspect": "urn:samm:io.catenax.pcf:7.0.0#",
+    "cx": "urn:samm:io.catenax.pcf:7.0.0#",
     "Pcf": {
-      "@id": "pcf-aspect:Pcf",
+      "@id": "cx:Pcf",
       "@type": "@id"
     },
+    "cx:id": {
+      "@id": "cx:id",
+      "@context": {
+        "@definition": "Mandatory: The product footprint identifier as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
+        "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#id"
+      },
+      "@type": "schema:string"
+    },
+    "type": "@type",
     "specVersion": {
-      "@id": "pcf-aspect:specVersion",
+      "@id": "cx:specVersion",
       "@context": {
         "@definition": "Mandatory: Version of the product footprint data specification as defined in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#specVersion"
@@ -16,7 +25,7 @@
       "@type": "schema:string"
     },
     "partialFullPcf": {
-      "@id": "pcf-aspect:partialFullPcf",
+      "@id": "cx:partialFullPcf",
       "@context": {
         "@definition": "Mandatory: Indicator for partial or full PCF (Product Carbon Footprint) declaration as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#partialFullPcf"
@@ -24,7 +33,7 @@
       "@type": "schema:string"
     },
     "precedingPfIds": {
-      "@id": "pcf-aspect:precedingPfIds",
+      "@id": "cx:precedingPfIds",
       "@context": {
         "@version": 1.1,
         "id": "@id",
@@ -32,7 +41,7 @@
         "@context": {
           "@version": 1.1,
           "id": {
-            "@id": "pcf-aspect:id",
+            "@id": "cx:id",
             "@context": {
               "@definition": "Mandatory: The product footprint identifier as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
               "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#id"
@@ -47,7 +56,7 @@
       "@container": "@list"
     },
     "version": {
-      "@id": "pcf-aspect:version",
+      "@id": "cx:version",
       "@context": {
         "@definition": "Mandatory: Version of the product (carbon) footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to \"0\" per default.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#version"
@@ -55,7 +64,7 @@
       "@type": "schema:number"
     },
     "created": {
-      "@id": "pcf-aspect:created",
+      "@id": "cx:created",
       "@context": {
         "@definition": "Mandatory: Timestamp of the creation of the Product (Carbon) Footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#created"
@@ -63,7 +72,7 @@
       "@type": "schema:string"
     },
     "extWBCSD_pfStatus": {
-      "@id": "pcf-aspect:extWBCSD_pfStatus",
+      "@id": "cx:extWBCSD_pfStatus",
       "@context": {
         "@definition": "Mandatory: Status indicator of a product (carbon) footprint as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example set to \"Active\" per default.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#status"
@@ -71,7 +80,7 @@
       "@type": "schema:string"
     },
     "validityPeriodStart": {
-      "@id": "pcf-aspect:validityPeriodStart",
+      "@id": "cx:validityPeriodStart",
       "@context": {
         "@definition": "Optional: Start of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. If specified, the validity period start must be equal to or greater than the reference period end.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#validityPeriodStart"
@@ -79,7 +88,7 @@
       "@type": "schema:string"
     },
     "validityPeriodEnd": {
-      "@id": "pcf-aspect:validityPeriodEnd",
+      "@id": "cx:validityPeriodEnd",
       "@context": {
         "@definition": "Optional: End of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#validityPeriodEnd"
@@ -87,7 +96,7 @@
       "@type": "schema:string"
     },
     "comment": {
-      "@id": "pcf-aspect:comment",
+      "@id": "cx:comment",
       "@context": {
         "@definition": "Optional: Additional information and instructions related to the calculation of the product (carbon) footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#comment"
@@ -95,7 +104,7 @@
       "@type": "schema:string"
     },
     "companyName": {
-      "@id": "pcf-aspect:companyName",
+      "@id": "cx:companyName",
       "@context": {
         "@definition": "Mandatory: Name of the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#companyName"
@@ -103,7 +112,7 @@
       "@type": "schema:string"
     },
     "companyIds": {
-      "@id": "pcf-aspect:companyIds",
+      "@id": "cx:companyIds",
       "@context": {
         "@definition": "Mandatory: Non-empty set of Uniform Resource Names (URN). Each value is supposed to uniquely identify the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. For Catena-X Industry Core compliance the set of URNs must contain at least the Business Partner Number Legal Entity (BPNL) in the specified format urn:bpn:id:BPNL[a-zA-Z0-9]{12}.\u00a0",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#companyIds"
@@ -112,7 +121,7 @@
       "@type": "schema:string"
     },
     "productDescription": {
-      "@id": "pcf-aspect:productDescription",
+      "@id": "cx:productDescription",
       "@context": {
         "@definition": "Optional: Free-form description of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#productDescription"
@@ -120,7 +129,7 @@
       "@type": "schema:string"
     },
     "productIds": {
-      "@id": "pcf-aspect:productIds",
+      "@id": "cx:productIds",
       "@context": {
         "@definition": "Mandatory: Non-empty set of product identifiers. Each value is supposed to uniquely identify the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productId corresponds with Industry Core manufacturerPartId.",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#productIds"
@@ -129,7 +138,7 @@
       "@type": "schema:string"
     },
     "extWBCSD_productCodeCpc": {
-      "@id": "pcf-aspect:extWBCSD_productCodeCpc",
+      "@id": "cx:extWBCSD_productCodeCpc",
       "@context": {
         "@definition": "Mandatory: UN (United Nations) Product Classification Code (CPC - Central Classification Code) of a given product as specified the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, which will probably be declared as \"optional\" in a later WBCSD specification version. In Catena-X for example specified with default value \"011-99000\".",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#productCategoryCpc"
@@ -137,7 +146,7 @@
       "@type": "schema:string"
     },
     "productName": {
-      "@id": "pcf-aspect:productName",
+      "@id": "cx:productName",
       "@context": {
         "@definition": "Mandatory: Non-empty trade name of a product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productNameCompany corresponds with Industry Core nameAtManufacturer.\u00a0",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#productNameCompany"
@@ -145,13 +154,13 @@
       "@type": "schema:string"
     },
     "pcf": {
-      "@id": "pcf-aspect:pcf",
+      "@id": "cx:pcf",
       "@context": {
         "@version": 1.1,
         "id": "@id",
         "type": "@type",
         "declaredUnit": {
-          "@id": "pcf-aspect:declaredUnit",
+          "@id": "cx:declaredUnit",
           "@context": {
             "@definition": "Mandatory: Unit of analysis of a product in context of the PCF (product carbon footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example list of valid units includes \"piece\".",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#declaredUnit"
@@ -159,7 +168,7 @@
           "@type": "schema:string"
         },
         "unitaryProductAmount": {
-          "@id": "pcf-aspect:unitaryProductAmount",
+          "@id": "cx:unitaryProductAmount",
           "@context": {
             "@definition": "Mandatory: Amount of units contained within a product in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#unitaryProductAmount"
@@ -167,7 +176,7 @@
           "@type": "schema:number"
         },
         "productMassPerDeclaredUnit": {
-          "@id": "pcf-aspect:productMassPerDeclaredUnit",
+          "@id": "cx:productMassPerDeclaredUnit",
           "@context": {
             "@definition": "Mandatory: Mass of a product per declared unit (net, unpackaged) in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#productMassPerDeclaredUnit"
@@ -175,7 +184,7 @@
           "@type": "schema:number"
         },
         "exemptedEmissionsPercent": {
-          "@id": "pcf-aspect:exemptedEmissionsPercent",
+          "@id": "cx:exemptedEmissionsPercent",
           "@context": {
             "@definition": "Mandatory: Applied cut-off percentage of emissions excluded from PCF (Product Carbon Footprint).\nFor accordance with Catena-X PCF Rulebook (Version 3.0.0) <3%.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#exemptedEmissionsPercent"
@@ -183,7 +192,7 @@
           "@type": "schema:number"
         },
         "exemptedEmissionsDescription": {
-          "@id": "pcf-aspect:exemptedEmissionsDescription",
+          "@id": "cx:exemptedEmissionsDescription",
           "@context": {
             "@definition": "Optional: Rationale behind exclusion of specific PCF (Product Carbon Footprint) emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#exemptedEmissionsDescription"
@@ -191,7 +200,7 @@
           "@type": "schema:string"
         },
         "boundaryProcessesDescription": {
-          "@id": "pcf-aspect:boundaryProcessesDescription",
+          "@id": "cx:boundaryProcessesDescription",
           "@context": {
             "@definition": "Optional: Processes attributable to each lifecycle stage as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#boundaryProcessesDescription"
@@ -199,7 +208,7 @@
           "@type": "schema:string"
         },
         "geographyCountrySubdivision": {
-          "@id": "pcf-aspect:geographyCountrySubdivision",
+          "@id": "cx:geographyCountrySubdivision",
           "@context": {
             "@definition": "Optional: Subdivision of a country which must be an ISO 3166-2 subdivision code as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#geographyCountrySubdivision"
@@ -207,7 +216,7 @@
           "@type": "schema:string"
         },
         "geographyCountry": {
-          "@id": "pcf-aspect:geographyCountry",
+          "@id": "cx:geographyCountry",
           "@context": {
             "@definition": "Optional: Two letter country code that must conform to data type ISO 3166CC as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#geographyCountry"
@@ -215,7 +224,7 @@
           "@type": "schema:string"
         },
         "geographyRegionOrSubregion": {
-          "@id": "pcf-aspect:geographyRegionOrSubregion",
+          "@id": "cx:geographyRegionOrSubregion",
           "@context": {
             "@definition": "Mandatory: Region according to list as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#geographyRegionOrSubregion"
@@ -223,7 +232,7 @@
           "@type": "schema:string"
         },
         "referencePeriodStart": {
-          "@id": "pcf-aspect:referencePeriodStart",
+          "@id": "cx:referencePeriodStart",
           "@context": {
             "@definition": "Mandatory: Start of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#referencePeriodStart"
@@ -231,7 +240,7 @@
           "@type": "schema:string"
         },
         "referencePeriodEnd": {
-          "@id": "pcf-aspect:referencePeriodEnd",
+          "@id": "cx:referencePeriodEnd",
           "@context": {
             "@definition": "Mandatory: End of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#referencePeriodEnd"
@@ -239,7 +248,7 @@
           "@type": "schema:string"
         },
         "crossSectoralStandardsUsed": {
-          "@id": "pcf-aspect:crossSectoralStandardsUsed",
+          "@id": "cx:crossSectoralStandardsUsed",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -249,7 +258,7 @@
               "id": "@id",
               "type": "@type",
               "crossSectoralStandard": {
-                "@id": "pcf-aspect:crossSectoralStandard",
+                "@id": "cx:crossSectoralStandard",
                 "@context": {
                   "@definition": "Mandatory: Discloses a cross-sectoral standard applied for calculating or allocating GHG (Greenhouse Gas) emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
                   "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#crossSectoralStandard"
@@ -263,7 +272,7 @@
           "@container": "@list"
         },
         "productOrSectorSpecificRules": {
-          "@id": "pcf-aspect:productOrSectorSpecificRules",
+          "@id": "cx:productOrSectorSpecificRules",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -273,7 +282,7 @@
               "id": "@id",
               "type": "@type",
               "extWBCSD_operator": {
-                "@id": "pcf-aspect:extWBCSD_operator",
+                "@id": "cx:extWBCSD_operator",
                 "@context": {
                   "@definition": "Mandatory: Operator of PCR (Product Category Rule)/ PSR (Product Specific Rule) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example must always be \"Other\".",
                   "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#operator"
@@ -281,7 +290,7 @@
                 "@type": "schema:string"
               },
               "productOrSectorSpecificRules": {
-                "@id": "pcf-aspect:productOrSectorSpecificRules",
+                "@id": "cx:productOrSectorSpecificRules",
                 "@context": {
                   "@version": 1.1,
                   "id": "@id",
@@ -291,7 +300,7 @@
                     "id": "@id",
                     "type": "@type",
                     "ruleName": {
-                      "@id": "pcf-aspect:ruleName",
+                      "@id": "cx:ruleName",
                       "@context": {
                         "@definition": "Name of a rule applied by a specific operator as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
                         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#ruleName"
@@ -305,7 +314,7 @@
                 "@container": "@list"
               },
               "extWBCSD_otherOperatorName": {
-                "@id": "pcf-aspect:extWBCSD_otherOperatorName",
+                "@id": "cx:extWBCSD_otherOperatorName",
                 "@context": {
                   "@definition": "Optional: Other operator of PCR (Product Category Rule)/ PSR (Product Specific Rule) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by a default value.",
                   "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#otherOperatorName"
@@ -319,7 +328,7 @@
           "@container": "@list"
         },
         "extWBCSD_characterizationFactors": {
-          "@id": "pcf-aspect:extWBCSD_characterizationFactors",
+          "@id": "cx:extWBCSD_characterizationFactors",
           "@context": {
             "@definition": "Mandatory: IPCC (Intergovernmental Panel on Climate Change) version of the GWP (Global Warming Potential) characterization factors used for calculating the PCF (Product Carbon Footprint) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by default with value \\\"AR6\\\". Default value can be overwritten.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#characterizationFactors"
@@ -327,7 +336,7 @@
           "@type": "schema:string"
         },
         "extWBCSD_allocationRulesDescription": {
-          "@id": "pcf-aspect:extWBCSD_allocationRulesDescription",
+          "@id": "cx:extWBCSD_allocationRulesDescription",
           "@context": {
             "@definition": "Optional: Allocation rules used and underlying reasoning in context of a product carbon footprint as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by default with value \"In accordance with Catena-X PCF Rulebook (Version 3.0.0)\".",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#allocationRulesDescription"
@@ -335,7 +344,7 @@
           "@type": "schema:string"
         },
         "extTFS_allocationWasteIncineration": {
-          "@id": "pcf-aspect:extTFS_allocationWasteIncineration",
+          "@id": "cx:extTFS_allocationWasteIncineration",
           "@context": {
             "@definition": "Mandatory: Allocation approach used for waste incineration with energy recovery as specified by the TFS (Together For Sustainability) initiative. In Catena-X for example must be specified by value \"cut-off\".",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#allocationWasteIncineration"
@@ -343,7 +352,7 @@
           "@type": "schema:string"
         },
         "primaryDataShare": {
-          "@id": "pcf-aspect:primaryDataShare",
+          "@id": "cx:primaryDataShare",
           "@context": {
             "@definition": "Mandatory starting 2025: Share of primary data in percent as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#primaryDataShare"
@@ -351,7 +360,7 @@
           "@type": "schema:number"
         },
         "secondaryEmissionFactorSources": {
-          "@id": "pcf-aspect:secondaryEmissionFactorSources",
+          "@id": "cx:secondaryEmissionFactorSources",
           "@context": {
             "@version": 1.1,
             "id": "@id",
@@ -361,7 +370,7 @@
               "id": "@id",
               "type": "@type",
               "secondaryEmissionFactorSource": {
-                "@id": "pcf-aspect:secondaryEmissionFactorSource",
+                "@id": "cx:secondaryEmissionFactorSource",
                 "@context": {
                   "@definition": "Mandatory: Emission factor data source used to calculate a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
                   "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#emissionFactorDS"
@@ -375,13 +384,13 @@
           "@container": "@list"
         },
         "dataQualityRating": {
-          "@id": "pcf-aspect:dataQualityRating",
+          "@id": "cx:dataQualityRating",
           "@context": {
             "@version": 1.1,
             "id": "@id",
             "type": "@type",
             "coveragePercent": {
-              "@id": "pcf-aspect:coveragePercent",
+              "@id": "cx:coveragePercent",
               "@context": {
                 "@definition": "Mandatory starting 2025: Percentage of PCF (Product Carbon Footprint) included in the data quality assessment based on the >5% emissions threshold as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to \"100\" per default.",
                 "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#coveragePercent"
@@ -389,7 +398,7 @@
               "@type": "schema:number"
             },
             "technologicalDQR": {
-              "@id": "pcf-aspect:technologicalDQR",
+              "@id": "cx:technologicalDQR",
               "@context": {
                 "@definition": "Optional: Technological representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
                 "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#technologicalDQR"
@@ -397,7 +406,7 @@
               "@type": "schema:number"
             },
             "temporalDQR": {
-              "@id": "pcf-aspect:temporalDQR",
+              "@id": "cx:temporalDQR",
               "@context": {
                 "@definition": "Optional: Temporal representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
                 "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#temporalDQR"
@@ -405,7 +414,7 @@
               "@type": "schema:number"
             },
             "geographicalDQR": {
-              "@id": "pcf-aspect:geographicalDQR",
+              "@id": "cx:geographicalDQR",
               "@context": {
                 "@definition": "Optional: Geographical representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
                 "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#geographicalDQR"
@@ -413,7 +422,7 @@
               "@type": "schema:number"
             },
             "completenessDQR": {
-              "@id": "pcf-aspect:completenessDQR",
+              "@id": "cx:completenessDQR",
               "@context": {
                 "@definition": "Optional: Completeness of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
                 "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#completenessDQR"
@@ -421,7 +430,7 @@
               "@type": "schema:number"
             },
             "reliabilityDQR": {
-              "@id": "pcf-aspect:reliabilityDQR",
+              "@id": "cx:reliabilityDQR",
               "@context": {
                 "@definition": "Optional: Reliability of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
                 "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#reliabilityDQR"
@@ -433,7 +442,7 @@
           }
         },
         "extWBCSD_packagingEmissionsIncluded": {
-          "@id": "pcf-aspect:extWBCSD_packagingEmissionsIncluded",
+          "@id": "cx:extWBCSD_packagingEmissionsIncluded",
           "@context": {
             "@definition": "Mandatory: The Catena-X PCF Rulebook requires to include packaging from a system boundary perspective. \"FALSE\" is only possible due to the application of the cut-off rule.\nFlag indicating whether packaging emissions are included in a PCF (Product Carbon Footprint) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#packagingEmissionsIncluded"
@@ -441,7 +450,7 @@
           "@type": "schema:boolean"
         },
         "pcfExcludingBiogenic": {
-          "@id": "pcf-aspect:pcfExcludingBiogenic",
+          "@id": "cx:pcfExcludingBiogenic",
           "@context": {
             "@definition": "Mandatory: Product carbon footprint of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#pcfExcludingBiogenic"
@@ -449,7 +458,7 @@
           "@type": "schema:number"
         },
         "pcfIncludingBiogenic": {
-          "@id": "pcf-aspect:pcfIncludingBiogenic",
+          "@id": "cx:pcfIncludingBiogenic",
           "@context": {
             "@definition": "Mandatory starting 2025: Product carbon footprint of a product including biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Optional value in current specification version but will be mandatory in future version.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#pcfIncludingBiogenic"
@@ -457,7 +466,7 @@
           "@type": "schema:number"
         },
         "fossilGhgEmissions": {
-          "@id": "pcf-aspect:fossilGhgEmissions",
+          "@id": "cx:fossilGhgEmissions",
           "@context": {
             "@definition": "Mandatory starting 2025: Emissions from combustion of fossil sources as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Identical to \"pcfExcludingBiogenic\", will be removed in later version.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#fossilGhgEmissions"
@@ -465,7 +474,7 @@
           "@type": "schema:number"
         },
         "biogenicCarbonEmissionsOtherThanCO2": {
-          "@id": "pcf-aspect:biogenicCarbonEmissionsOtherThanCO2",
+          "@id": "cx:biogenicCarbonEmissionsOtherThanCO2",
           "@context": {
             "@definition": "Mandatory starting 2025: GWP (Global Warming Potential) of biogenic CO2e-emissions in production phase which contain only GHG (Greenhouse Gas) emissions other than CO2 - excludes biogenic CO2. For specification see Catena-X PCF Rulebook (Version 3.0.0).",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#biogenicCarbonEmissionsOtherThanCO2"
@@ -473,7 +482,7 @@
           "@type": "schema:number"
         },
         "biogenicCarbonWithdrawal": {
-          "@id": "pcf-aspect:biogenicCarbonWithdrawal",
+          "@id": "cx:biogenicCarbonWithdrawal",
           "@context": {
             "@definition": "Mandatory starting 2025: Biogenic carbon content in the product converted to CO2e as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#biogenicCarbonWithdrawal"
@@ -481,7 +490,7 @@
           "@type": "schema:number"
         },
         "dlucGhgEmissions": {
-          "@id": "pcf-aspect:dlucGhgEmissions",
+          "@id": "cx:dlucGhgEmissions",
           "@context": {
             "@definition": "Mandatory starting 2025: Direct land use change CO2e emissions in context of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#dlucGhgEmissions"
@@ -489,7 +498,7 @@
           "@type": "schema:number"
         },
         "extTFS_luGhgEmissions": {
-          "@id": "pcf-aspect:extTFS_luGhgEmissions",
+          "@id": "cx:extTFS_luGhgEmissions",
           "@context": {
             "@definition": "Mandatory starting 2025: Land use CO2 emissions in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#luGhgEmissions"
@@ -497,7 +506,7 @@
           "@type": "schema:number"
         },
         "aircraftGhgEmissions": {
-          "@id": "pcf-aspect:aircraftGhgEmissions",
+          "@id": "cx:aircraftGhgEmissions",
           "@context": {
             "@definition": "Mandatory starting 2025: GHG (Greenhouse Gas) emissions resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#aircraftGhgEmissions"
@@ -505,7 +514,7 @@
           "@type": "schema:number"
         },
         "extWBCSD_packagingGhgEmissions": {
-          "@id": "pcf-aspect:extWBCSD_packagingGhgEmissions",
+          "@id": "cx:extWBCSD_packagingGhgEmissions",
           "@context": {
             "@definition": "Optional: Emissions resulting from the packaging of the product as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension. In Catena-X not relevant to be reported separately.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#packagingGhgEmissions"
@@ -513,7 +522,7 @@
           "@type": "schema:number"
         },
         "distributionStagePcfExcludingBiogenic": {
-          "@id": "pcf-aspect:distributionStagePcfExcludingBiogenic",
+          "@id": "cx:distributionStagePcfExcludingBiogenic",
           "@context": {
             "@definition": "Optional: Product carbon footprint for the distribution stage of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStagePcfExcludingBiogenic"
@@ -521,7 +530,7 @@
           "@type": "schema:number"
         },
         "distributionStagePcfIncludingBiogenic": {
-          "@id": "pcf-aspect:distributionStagePcfIncludingBiogenic",
+          "@id": "cx:distributionStagePcfIncludingBiogenic",
           "@context": {
             "@definition": "Optional: Product carbon footprint for the distribution stage of a product including biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStagePcfIncludingBiogenic"
@@ -529,7 +538,7 @@
           "@type": "schema:number"
         },
         "distributionStageFossilGhgEmissions": {
-          "@id": "pcf-aspect:distributionStageFossilGhgEmissions",
+          "@id": "cx:distributionStageFossilGhgEmissions",
           "@context": {
             "@definition": "Optional: Emissions from the combustion of fossil sources in the distribution stage as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageFossilGhgEmissions"
@@ -537,7 +546,7 @@
           "@type": "schema:number"
         },
         "distributionStageBiogenicCarbonEmissionsOtherThanCO2": {
-          "@id": "pcf-aspect:distributionStageBiogenicCarbonEmissionsOtherThanCO2",
+          "@id": "cx:distributionStageBiogenicCarbonEmissionsOtherThanCO2",
           "@context": {
             "@definition": "Optional: GWP (Global Warming Potential) of biogenic CO2e-emissions in distribution phase which contain only GHG (Greenhouse Gas) emissions other than CO2 ? excludes biogenic CO2. For specification see Catena-X PCF Rulebook (Version 3.0.0).",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageBiogenicCarbonEmissionsOtherThanCO2"
@@ -545,7 +554,7 @@
           "@type": "schema:number"
         },
         "distributionStageBiogenicCarbonWithdrawal": {
-          "@id": "pcf-aspect:distributionStageBiogenicCarbonWithdrawal",
+          "@id": "cx:distributionStageBiogenicCarbonWithdrawal",
           "@context": {
             "@definition": "Optional: GWP (Global Warming Potential) of biogenic CO2-withdrawal in distribution stage (biogenic CO2 contained in the product) as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageBiogenicCarbonWithdrawal"
@@ -553,7 +562,7 @@
           "@type": "schema:number"
         },
         "extTFS_distributionStageDlucGhgEmissions": {
-          "@id": "pcf-aspect:extTFS_distributionStageDlucGhgEmissions",
+          "@id": "cx:extTFS_distributionStageDlucGhgEmissions",
           "@context": {
             "@definition": "Optional: Direct land use change CO2 emissions during distribution stage in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageDlucGhgEmissions"
@@ -561,7 +570,7 @@
           "@type": "schema:number"
         },
         "extTFS_distributionStageLuGhgEmissions": {
-          "@id": "pcf-aspect:extTFS_distributionStageLuGhgEmissions",
+          "@id": "cx:extTFS_distributionStageLuGhgEmissions",
           "@context": {
             "@definition": "Optional: Land use CO2 emissions in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageLuGhgEmissions"
@@ -569,7 +578,7 @@
           "@type": "schema:number"
         },
         "carbonContentTotal": {
-          "@id": "pcf-aspect:carbonContentTotal",
+          "@id": "cx:carbonContentTotal",
           "@context": {
             "@definition": "Mandatory starting 2025: Total carbon content per declared unit in context of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#carbonContentTotal"
@@ -577,7 +586,7 @@
           "@type": "schema:number"
         },
         "extWBCSD_fossilCarbonContent": {
-          "@id": "pcf-aspect:extWBCSD_fossilCarbonContent",
+          "@id": "cx:extWBCSD_fossilCarbonContent",
           "@context": {
             "@definition": "Mandatory starting 2025: Fossil carbon amount embodied in a product as specified in the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Must be calculated with kgC (kilogram Carbon) / declaredUnit equal to or greater zero; WBCSD specific extension, in Catena-X specified by a calculated value.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#fossilCarbonContent"
@@ -585,7 +594,7 @@
           "@type": "schema:number"
         },
         "carbonContentBiogenic": {
-          "@id": "pcf-aspect:carbonContentBiogenic",
+          "@id": "cx:carbonContentBiogenic",
           "@context": {
             "@definition": "Mandatory starting 2025: Biogenic carbon amount embodied in a product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Must be calculated with kgC (kilogram Carbon) / declaredUnit equal to or greater zero.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#biogenicCarbonContent"
@@ -593,7 +602,7 @@
           "@type": "schema:number"
         },
         "distributionStageAircraftGhgEmissions": {
-          "@id": "pcf-aspect:distributionStageAircraftGhgEmissions",
+          "@id": "cx:distributionStageAircraftGhgEmissions",
           "@context": {
             "@definition": "Optional: GHG (Greenhouse Gas) emissions for the distribution stage resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.",
             "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#distributionStageAircraftGhgEmissions"
@@ -605,7 +614,7 @@
       }
     },
     "pcfLegalStatement": {
-      "@id": "pcf-aspect:pcfLegalStatement",
+      "@id": "cx:pcfLegalStatement",
       "@context": {
         "@definition": "Optional: Option for legal statement/ disclaimer as specified in the Catena-X PCF Rulebook (Version 3.0.0).",
         "@samm-urn": "urn:samm:io.catenax.pcf:7.0.0#pcfLegalStatement"


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

I found out that some attributes like `id` and `type` cant be overwritten and were not being included in the models. Now the models can include the `cx` prefix to include the id and type attributes in "root" level.

Closes #

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
