### PR TITLE
[Bugfix] io.catenax.serial_part:3.0.1

### DIFF
--- a/io.catenax.serial_part/1.0.1/metadata.json
+++ b/io.catenax.serial_part/1.0.1/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "deprecate"} 
+{ "status" : "deprecated"} 

--- a/io.catenax.serial_part/2.0.0/metadata.json
+++ b/io.catenax.serial_part/2.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{ "status" : "deprecated"} 

--- a/io.catenax.serial_part/3.0.1/SerialPart.ttl
+++ b/io.catenax.serial_part/3.0.1/SerialPart.ttl
@@ -1,0 +1,207 @@
+#######################################################################
+# Copyright(c) 2022 BASF SE
+# Copyright(c) 2022 Bayerische Motoren Werke Aktiengesellschaft(BMW AG)
+# Copyright(c) 2022 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.(represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright(c) 2022 German Edge Cloud GmbH & Co. KG
+# Copyright(c) 2022 Henkel AG & Co. KGaA
+# Copyright(c) 2022 Mercedes Benz AG
+# Copyright(c) 2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright(c) 2022 SAP SE
+# Copyright(c) 2022 Siemens AG
+# Copyright(c) 2022 T-Systems International GmbH
+# Copyright(c) 2022 ZF Friedrichshafen AG
+# Copyright(c) 2025 Catena-X Automotive Network e.V.
+# Copyright(c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International(CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#>.
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#>.
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#>.
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix : <urn:samm:io.catenax.serial_part:3.0.1#>.
+@prefix ext-built: <urn:samm:io.catenax.shared.part_site_information_as_built:2.0.0#>.
+@prefix ext-classification: <urn:samm:io.catenax.shared.part_classification:1.0.0#>.
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#>.
+
+:SerialPart a samm:Aspect;
+   samm:preferredName "Serial Part"@en;
+   samm:description "A serialized part is an instantiation of a (design-)part, where the particular instantiation can be uniquely identified by means of a serial number or a similar identifier (e.g. VAN)or a combination of multiple identifiers (e.g. combination of manufacturer, date and number)"@en;
+   samm:properties (:catenaXId :localIdentifiers :manufacturingInformation :partTypeInformation);
+   samm:operations ();
+   samm:events ().
+
+:catenaXId a samm:Property;
+   samm:preferredName "Catena-X ID"@en;
+   samm:description "The fully anonymous Catena-X ID of the serialized part, valid for the Catena-X dataspace."@en;
+   samm:characteristic ext-uuid:UuidV4Trait;
+   samm:exampleValue "urn:uuid:580d3adf-1981-44a0-a214-13d6ceed9379".
+
+:localIdentifiers a samm:Property;
+   samm:preferredName "Local Identifiers"@en;
+   samm:description "A local identifier enables identification of a part in a specific dataspace, but is not unique in Catena-X dataspace. Multiple local identifiers may exist."@en;
+   samm:characteristic :LocalIdentifierCharacteristic.
+
+:manufacturingInformation a samm:Property;
+   samm:preferredName "Manufacturing Information"@en;
+   samm:description "Information from manufacturing process, such as manufacturing date and manufacturing country"@en;
+   samm:characteristic :ManufacturingCharacteristic.
+
+:partTypeInformation a samm:Property;
+   samm:preferredName "Part Type Information"@en;
+   samm:description "The part type from which the serialized part has been instantiated"@en;
+   samm:characteristic :PartTypeInformationCharacteristic.
+
+:LocalIdentifierCharacteristic a samm-c:Set;
+   samm:preferredName "Local Identifier Characteristic"@en;
+   samm:description "A single serialized part may have multiple attributes, that uniquely identify a that part in a specific dataspace (e.g. the manufacturer`s dataspace)"@en;
+   samm:dataType :KeyValueList.
+
+:ManufacturingCharacteristic a samm:Characteristic;
+   samm:preferredName "Manufacturing Characteristic"@en;
+   samm:description "Characteristic to describe manufacturing related data"@en;
+   samm:dataType :ManufacturingEntity.
+
+:PartTypeInformationCharacteristic a samm:Characteristic;
+   samm:preferredName "Part Type Information Characteristic"@en;
+   samm:description "The characteristics of the part type"@en;
+   samm:dataType :PartTypeInformationEntity.
+
+:KeyValueList a samm:Entity;
+   samm:preferredName "Key Value List"@en;
+   samm:description "A list of key value pairs for local identifiers, which are composed of a key and a corresponding value."@en;
+   samm:properties (:key :value).
+
+:ManufacturingEntity a samm:Entity;
+   samm:preferredName "Manufacturing Entity"@en;
+   samm:description "Encapsulates the manufacturing relevant attributes"@en;
+   samm:properties (:date [ samm:property :country; samm:optional true ] [ samm:property ext-built:sites; samm:optional true ]).
+
+:PartTypeInformationEntity a samm:Entity;
+   samm:preferredName "Part Type Information Entity"@en;
+   samm:description "Encapsulation for data related to the part type"@en;
+   samm:properties (:manufacturerPartId [ samm:property :customerPartId; samm:optional true ] :nameAtManufacturer [ samm:property :nameAtCustomer; samm:optional true ] [ samm:property ext-classification:partClassification; samm:optional true ]).
+
+:key a samm:Property;
+   samm:preferredName "Identifier Key"@en;
+   samm:description "The key of a local identifier. "@en;
+   samm:characteristic :KeyTrait;
+   samm:exampleValue "partInstanceId".
+
+:value a samm:Property;
+   samm:preferredName "Identifier Value"@en;
+   samm:description "The value of an identifier."@en;
+   samm:characteristic :ValueCharacteristic;
+   samm:exampleValue "SN12345678".
+
+:date a samm:Property;
+   samm:preferredName "Production Date"@en;
+   samm:description "Timestamp of the manufacturing date as the final step in production process (e.g. final quality check, ready-for-shipment event)"@en;
+   samm:characteristic :DateTimeTrait;
+   samm:exampleValue "2025-09-26".
+
+:country a samm:Property;
+   samm:preferredName "Country code"@en;
+   samm:description "Country code where the part was manufactured"@en;
+   samm:characteristic :ProductionCountryCodeTrait;
+   samm:exampleValue "HUR".
+
+:manufacturerPartId a samm:Property;
+   samm:preferredName "Manufacturer Part ID"@en;
+   samm:description "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part (as designed)in the manufacturer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number."@en;
+   samm:characteristic :PartIdCharacteristic;
+   samm:exampleValue "123-0.740-3434-A".
+
+:customerPartId a samm:Property;
+   samm:preferredName "Customer Part ID"@en;
+   samm:description "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part (as designed)in the customer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number."@en;
+   samm:characteristic :PartIdCharacteristic;
+   samm:exampleValue "PRT-12345".
+
+:nameAtManufacturer a samm:Property;
+   samm:preferredName "Name at Manufacturer"@en;
+   samm:description "Name of the part as assigned by the manufacturer"@en;
+   samm:characteristic :PartNameCharacteristic;
+   samm:exampleValue "Mirror left".
+
+:nameAtCustomer a samm:Property;
+   samm:preferredName "Name at Customer"@en;
+   samm:description "Name of the part as assigned by the customer"@en;
+   samm:characteristic :PartNameCharacteristic;
+   samm:exampleValue "side element A".
+
+:KeyTrait a samm-c:Trait;
+   samm:preferredName "Key Trait"@en;
+   samm:description "Trait that ensures the usage of predefined keys."@en;
+   samm-c:baseCharacteristic :KeyCharacteristic;
+   samm-c:constraint :KeyRegularExpression.
+
+:ValueCharacteristic a samm:Characteristic;
+   samm:preferredName "Value Characteristic"@en;
+   samm:description "The value of an identifier."@en;
+   samm:dataType xsd:string.
+
+:DateTimeTrait a samm-c:Trait;
+   samm:preferredName "Date Time Trait"@en;
+   samm:description "Trait to ensure regular expressions with different date and time(zone)formats."@en;
+   samm-c:baseCharacteristic :DateTimeCharacteristic;
+   samm-c:constraint :DateTimeRegularExpression.
+
+:ProductionCountryCodeTrait a samm-c:Trait;
+   samm:preferredName "Production Country Code Trait"@en;
+   samm:description "Trait to ensure standard data format for country code"@en;
+   samm-c:baseCharacteristic :CountryCodeCharacteristic;
+   samm-c:constraint :CountryCodeRegularExpression.
+
+:PartIdCharacteristic a samm:Characteristic;
+   samm:preferredName "Part ID Characteristic"@en;
+   samm:description "The part ID is a multi-character string, usually assigned by an ERP system"@en;
+   samm:dataType xsd:string.
+
+:PartNameCharacteristic a samm:Characteristic;
+   samm:preferredName "Part Name Characteristic"@en;
+   samm:description "Part Name in string format from the respective system in the value chain"@en;
+   samm:dataType xsd:string.
+
+:KeyCharacteristic a samm:Characteristic;
+   samm:preferredName "Key Characteristic"@en;
+   samm:description "The key characteristic of a local identifier. A specific subset of keys is predefined, but additionally any other custom key is allowed. Predefined keys (to be used when applicable):\n- \"manufacturerId\" - The Business Partner Number (BPN)of the manufacturer. Value: BPN-Nummer\n- \"partInstanceId\" - The identifier of the manufacturer for the serialized instance of the part, e.g. the serial number\n- \"batchId\" - The identifier of the batch, to which the serialzed part belongs\n- \"van\" - The anonymized vehicle identification number (VIN). Value: anonymized VIN according to OEM anonymization rules. Note: If the key \"van\" is available, \"partInstanceId\" must also be available and hold the identical value."@en;
+   samm:dataType xsd:string.
+
+:KeyRegularExpression a samm-c:RegularExpressionConstraint;
+   samm:preferredName "Key Regular Expression"@en;
+   samm:description "Constraint that ensures that the standard keys and custom key prefixes can be used."@en;
+   samm:value "^(manufacturerId|partInstanceId|batchId|van|customKey:\\w+)$".
+
+:DateTimeCharacteristic a samm:Characteristic;
+   samm:preferredName "Date Time Characteristic"@en;
+   samm:description "Describes a Property which contains the date and time with an optional timezone."@en;
+   samm:dataType xsd:string.
+
+:DateTimeRegularExpression a samm-c:RegularExpressionConstraint;
+   samm:preferredName "Date Time Regular Expression"@en;
+   samm:description "Regular Expression to enable UTC and Timezone formats and the possibility to exclude time information."@en;
+   samm:value "^(?:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?Z|[0-9]{4}-[0-9]{2}-[0-9]{2}(?:T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2}))?)$".
+
+:CountryCodeCharacteristic a samm:Characteristic;
+   samm:preferredName "Country Code Characteristic"@en;
+   samm:description "ISO 3166-1 alpha-3 - three-letter country codes "@en;
+   samm:see <https://www.iso.org/iso-3166-country-codes.html>;
+   samm:dataType xsd:string.
+
+:CountryCodeRegularExpression a samm-c:RegularExpressionConstraint;
+   samm:preferredName "Country Code Regular Expression"@en;
+   samm:description "Regular Expression that ensures a three-letter code "@en;
+   samm:value "^[A-Z][A-Z][A-Z]$".

--- a/io.catenax.serial_part/3.0.1/metadata.json
+++ b/io.catenax.serial_part/3.0.1/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.serial_part/RELEASE_NOTES.md
+++ b/io.catenax.serial_part/RELEASE_NOTES.md
@@ -1,43 +1,63 @@
 # Changelog
+
 All notable changes to this model will be documented in this file.
 
+## [3.0.1] 2025-09-26
+
+- Fixed example value of "date" to match the regular expression
+
 ## [3.0.0] 2024-02-05
+
 ### Added
+
 - Integration of the new shared PartClassifcation 1.0.0 aspect model as child-property of the PartTypeInformation
 - Added possibility to add date information excluding time
 - Include additional RegEx values for the local identifier key
 
 ### Changed
+
 - Change (shared) partSiteInformation to be a child-porperty of the manufacturerInformation
 
   
 ## [2.0.0] 2023-12-04
+
 ### Added
+
 - integration of the sites property and its childtree of the shared PartSiteInformationAsBuilt (1.0.0) aspect model as optional content
 - integration of the shared UUID characteristic and RegEx for the catenaXId property
 
 ### Changed
+
 - migrated current aspect model from BAMM to SAMM
 
 ### Removed
+
 - removed existing characteristic and RegEx of the catenaXId property and replaced it with content of the shared UUID aspect model (see added information)
 
 ## [1.0.1]
+
 ### Added
+
 n/a
 
 ### Changed
+
 - fixed casing in example value for `key` of `localIdentifier` to lower case
 
 ### Removed
+
 n/a
 
 ## [1.0.0]
+
 ### Added
+
 - renamed model from `io.catenax.serial_part_typization:2.0.0#SerialPartTypization`
 
 ### Changed
+
 - changed several descriptions due to aspect renaming
 
 ### Removed
+
 n/a


### PR DESCRIPTION
This PR fixes the example value to match the regular expression required by the defined characteristic of the date property

Closes #723 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
