### PR TITLE
[Update Model]: Digital Priduct Passport v.7.0.0

### DIFF
--- a/io.catenax.generic.digital_product_passport/7.0.0/DigitalProductPassport.ttl
+++ b/io.catenax.generic.digital_product_passport/7.0.0/DigitalProductPassport.ttl
@@ -1,0 +1,1805 @@
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.generic.digital_product_passport:5.0.0#> .
+@prefix ext-batch: <urn:samm:io.catenax.batch:3.0.1#> .
+@prefix ext-characteristic: <urn:samm:io.catenax.shared.address_characteristic:4.0.0#> .
+@prefix ext-classification: <urn:samm:io.catenax.shared.part_classification:1.0.0#> .
+@prefix ext-information: <urn:samm:io.catenax.part_type_information:1.0.0#> .
+@prefix ext-information2: <urn:samm:io.catenax.shared.contact_information:4.0.0#> .
+@prefix ext-part: <urn:samm:io.catenax.serial_part:3.0.1#> .
+@prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:2.0.0#> .
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
+
+:DigitalProductPassport a samm:Aspect ;
+   samm:preferredName "Digital Product Passport"@en ;
+   samm:description "The Digital Product Passport (DPP) allows for the sharing of process and product-related information amongst supply chain businesses, authorities, and consumers. The DPP allows for efficient information flows following best practices, and the possibility of accompanying the measures under this Regulation with mitigating measures so that impacts are expected to remain proportionate for SMEs.This is expected to increase transparency, both for supply chain businesses and for the general public, and increase efficiencies in terms of information transfer to support the data exchange between economic actors in integrating circularity in product design and manufacturing.\\nIn particular, it is likely to help facilitate and streamline the monitoring and enforcement of the regulation carried out by EU and Member State authorities. It is also likely to provide a market-intelligence tool that may be used for revising and refining obligations in the future.\\nThe DPP includes data about components, materials, and chemical substances, information on reparability, spare parts, environmental impact, and professional disposal for a product, and many other information related to the data.\\nThe data model will be updated, as newer versions of the regulation will be published and new regulations for product groups will be publisched \\nThe main basis is provided by the document: Regulation (EU) 2024/1781 of the European Parliament and of the Council of 13 June 2024 establishing a framework for the setting of ecodesign requirements for sustainable products, amending Directive (EU) 2020/1828 and Regulation (EU) 2023/1542 and repealing Directive 2009/125/EC. and achieving the aims of the  Communication of Circular Economy Action Plan. The generic model can also be used to provide information about packaging."@en ;
+   samm:see <https://eur-lex.europa.eu/eli/reg/2024/1781/oj> ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L_202500040> ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex%3A32023R0988> ;
+   samm:properties ( :metadata :identification :operation :handling :characteristics :commercial :sustainability :sources [ samm:property :additionalData; samm:optional true ] :compliances :composition ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:metadata a samm:Property ;
+   samm:preferredName "Metadata"@en ;
+   samm:description "Metadata of the product passport. These are mentioned in the ESPR proposal from March 30th, 2022 and some changed by the provisional agreement from January 9th, 2024."@en ;
+   samm:characteristic :MetadataCharacteristic .
+
+:identification a samm:Property ;
+   samm:preferredName "Identification"@en ;
+   samm:description "Identification information of the product, especially identifiers and codes. These are mentioned in the ESPR provisional agreement from January 9th, 2024 ANNEX III:\n(b) the unique product identifier at the level indicated in the applicable delegated act adopted pursuant to Article 4.\nAdditionally in Article 9 regarding general requirements for the product passport is stated that:\nA product passport shall meet the following conditions:\n(a) it shall be connected through a data carrier to a persistent unique product identifier;\n(e) the information included in the product passport shall refer to the product model, batch, or item as specified in the delegated act adopted pursuant to Article 4.\nArticle 2 Definitions: \n(31) 'unique product identifier' means a unique string of characters for the identification of products that also enables a web link to the product passport;\nRecital (27): A 'model' usually means a version of a product of which all units share the same technical characteristics relevant for the ecodesign requirements and the same model identifier, a 'batch' usually means a subset of a specific model composed of all products produced in a specific manufacturing plant at a specific moment in time and an 'item' usually means a single unit of a model."@en ;
+   samm:characteristic :IdentificationCharacteristic .
+
+:operation a samm:Property ;
+   samm:preferredName "Operation"@en ;
+   samm:description "Operational information of the product."@en ;
+   samm:characteristic :OperationCharacteristic .
+
+:handling a samm:Property ;
+   samm:preferredName "handling"@en ;
+   samm:description "Properties connected with the handling of the product."@en ;
+   samm:characteristic :HandlingCharacteristic .
+
+:characteristics a samm:Property ;
+   samm:preferredName "Characteristics"@en ;
+   samm:description "Defines specific characteristics of a product."@en ;
+   samm:characteristic :ProductCharacteristics .
+
+:commercial a samm:Property ;
+   samm:preferredName "Commercial"@en ;
+   samm:description "Commercial information of the product."@en ;
+   samm:characteristic :CommercialCharacteristic .
+
+:sustainability a samm:Property ;
+   samm:preferredName "Sustainability"@en ;
+   samm:description "Sustainability related attributes."@en ;
+   samm:characteristic :SustainabilityCharacteristic .
+
+:sources a samm:Property ;
+   samm:preferredName "Sources"@en ;
+   samm:description "Documents that are mandatory if applicable for the product. These are mentioned in the ESPR provisional agreement from January 9th, 2024 ANNEX III:\n(e) compliance documentation and information required under this Regulation or other Union law applicable to the product, such as the declaration of conformity, technical documentation or conformity certificates;\n(f) user manuals, instructions, warnings or safety information, as required by other Union legislation applicable to the product.\nAdditionally requirements are mentioned in Article 21:\n7. Manufacturers shall ensure that a product covered by a delegated act adopted pursuant to Article 4 is accompanied by instructions in digital format that enable customers and other relevant actors to assemble, install, operate, store, maintain, repair and dispose of the product in a language that can be easily understood, as determined by the Member State concerned. Such instructions shall be clear, understandable and legible and include at least the information set out in Article 7(2), point (b), point (ii) specified in the delegated acts adopted pursuant to Article 4.\nArticle 7 states additionally:\n(ii) information for customers and other actors on how to install, use, maintain and repair the product, in order to minimise its impact on the environment and to ensure optimum durability, on how to install third-party operating systems where relevant, as well as on collection for refurbishment or remanufacture, and on how to return or handle the product at the end of its life;\n(2) (b) (iii) information for treatment facilities on disassembly, reuse, refurbishment, recycling, or disposal at end-of-life;\n(2) (b) (iv) other information that may influence sustainable product choices for customers and the way the product is handled by parties other than the manufacturer in order to facilitate appropriate use, value retaining operations and correct treatment at end-of-life.\n(5) (d) relevant instructions for the safe use of the product.\n(5) (e) information relevant for disassembly, preparation for reuse, reuse, recycling and the environmentally sound management of the product at the end of its life.\nAnnex I:\n(b) [...] availability of repair and maintenance instructions, number of materials and components used, use of standard components,[...] number and complexity of processes and whether specialised toolsare needed, ease of non-destructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed;\n(c) ease of upgrading, re-use, remanufacturing and refurbishment as expressed through: [...] number and complexity of processes and tools needed, ease of non-destructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed, conditions of access to test protocols or not commonly available testing equipment, availability of guarantees specific to remanufactured or refurbished products, conditions for access to or use of technologies protected by intellectual property rights, modularity;\n(d) design for recycling, ease and quality of recycling as expressed through: use of easily recyclable materials, safe, easy and non-destructive access to recyclable components and materials or components and materials containing hazardous substances and material composition and homogeneity, possibility for high-purity sorting, [...] number and complexity of processes and tools needed, ease of nondestructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed;\n(q) functional performance and conditions for use including as expressed through ability in performing its intended use, precautions of use, skills required, compatibility with other products or systems.\nAdditionally to consider are guidelines and instructions regarding the proper management and disposal of packaging materials after use. This can include instructions for separation, reuse, and recycling."@en ;
+   samm:characteristic :SourceList .
+
+:additionalData a samm:Property ;
+   samm:preferredName "Additional Data"@en ;
+   samm:description "Data in form of open fields which need to be transferred in addition. The regulation is still under development and may change in the future. To accommodate this, additional data allows the option to include additional data required by future changes to the regulation. In addition, the DPP can be easily updated and adapted to the new requirements. \nThe ESPR provisional agreement from January 9th, 2024 Article 9 mentions:\n2. Where other Union legislation requires or allows the inclusion of specific information in the product passport, that information may be included in the product passport pursuant to the applicable delegated act adopted pursuant to Article 4."@en ;
+   samm:characteristic :AdditionalDataList .
+
+:compliances a samm:Property ;
+   samm:preferredName "Compliances"@en ;
+   samm:description "Compliance refers to adhering to relevant regulations, standards, or specifications regarding the testing, certification, assessments, ratings, documentation, and presentation of parameters, methods, and results, tests, marks (like CE mark), and compliance statements. This ensures that the product meets required safety (including dual-use products, chemical weapons conventions, and explosive precursor regulations), quality, and regulatory standards throughout its lifecycle. It can serve to display voluntary certification and labelling schemes and self-declarations (eg, ISO 14021),  type-approval documentation (Euro 7). The compliance section is not only for the EU market, but can also report United Nations standards (like UN labour standards) and other country-specific requirements."@en ;
+   samm:characteristic :ComplianceList .
+
+:composition a samm:Property ;
+   samm:preferredName "Composition"@en ;
+   samm:description "Information about the components and material composition of the product."@en ;
+   samm:characteristic :CompositionCharacteristic .
+
+:MetadataCharacteristic a samm:Characteristic ;
+   samm:preferredName "Metadata Characteristic"@en ;
+   samm:description "Characteristic for the passport metadata of the digital product passport."@en ;
+   samm:dataType :MetadataEntity .
+
+:IdentificationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Identification Characteristic"@en ;
+   samm:description "Identification information of the product."@en ;
+   samm:dataType :IdentificationEntity .
+
+:OperationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Operation Characteristic"@en ;
+   samm:description "Operational information of the product."@en ;
+   samm:dataType :OperationEntity .
+
+:HandlingCharacteristic a samm:Characteristic ;
+   samm:preferredName "Handling Characteristic"@en ;
+   samm:description "Characteristic to describe aspects which are connected with the handling of the product."@en ;
+   samm:dataType :HandlingEntity .
+
+:ProductCharacteristics a samm:Characteristic ;
+   samm:preferredName "Product Characteristics"@en ;
+   samm:description "Defines a set of specific characteristics of a product."@en ;
+   samm:dataType :ProductCharacteristicsEntity .
+
+:CommercialCharacteristic a samm:Characteristic ;
+   samm:preferredName "Commercial Characteristic"@en ;
+   samm:description "Commercial information of the product."@en ;
+   samm:dataType :CommercialEntity .
+
+:SustainabilityCharacteristic a samm:Characteristic ;
+   samm:preferredName "Sustainability Characteristic"@en ;
+   samm:description "Characteristic which describes relevant information for the sustainability of the product."@en ;
+   samm:dataType :SustainabilityEntity .
+
+:SourceList a samm-c:List ;
+   samm:preferredName "Source List"@en ;
+   samm:description "A list of documents."@en ;
+   samm:dataType :DocumentEntity .
+
+:AdditionalDataList a samm-c:List ;
+   samm:preferredName "Additional Data List"@en ;
+   samm:description "List of additional data."@en ;
+   samm:dataType :AdditionalDataEntity .
+
+:ComplianceList a samm-c:List ;
+   samm:preferredName "Compliance List"@en ;
+   samm:description "List of compliance of the product."@en ;
+   samm:dataType :ComplianceEntity .
+
+:CompositionCharacteristic a samm:Characteristic ;
+   samm:preferredName "Composition Characteristic"@en ;
+   samm:description "Characteristic for composition."@en ;
+   samm:dataType :CompositionEntity .
+
+:MetadataEntity a samm:Entity ;
+   samm:preferredName "Metadata Entity"@en ;
+   samm:description "Passport Entity to describe version, status, end and issue date."@en ;
+   samm:properties ( :version [ samm:property :passportStatus; samm:optional true ] :expirationDate :issueDate :passportIdentifier :predecessor :backupReference [ samm:property :registrationIdentifier; samm:optional true ] [ samm:property :lastModification; samm:optional true ] :language :economicOperator [ samm:property :specVersion; samm:optional true ] ) .
+
+:IdentificationEntity a samm:Entity ;
+   samm:preferredName "Identification Entity"@en ;
+   samm:description "Entity with identification information of the product with part type information, local identifiers, other codes and the data carrier."@en ;
+   samm:properties ( [ samm:property :serialInformation; samm:optional true; samm:payloadName "serial" ] [ samm:property :batchInformation; samm:optional true; samm:payloadName "batch" ] [ samm:property :partTypeInformation; samm:payloadName "type" ] :codes [ samm:property :dataCarriers; samm:optional true ] [ samm:property :productImages; samm:optional true ] ext-classification:partClassification ) .
+
+:OperationEntity a samm:Entity ;
+   samm:preferredName "Operation Entity"@en ;
+   samm:description "Operational information of the product such as the owner, manufacturer and importer."@en ;
+   samm:properties ( :manufacturing :import [ samm:property :otherOperators; samm:optional true ] :extendedProducerResponsibilityScheme ) .
+
+:HandlingEntity a samm:Entity ;
+   samm:preferredName "Handling Entity"@en ;
+   samm:description "Entity to describe different aspects in relation with the handling of the product with attributes if applicable to the product."@en ;
+   samm:properties ( [ samm:property :spareParts; samm:optional true; samm:payloadName "content" ] :applicable ) .
+
+:ProductCharacteristicsEntity a samm:Entity ;
+   samm:preferredName "Product Characteristics Entity"@en ;
+   samm:description "Entity which defines specific characteristics of a product such as different life spans and physical dimensions."@en ;
+   samm:properties ( :lifespan :physicalDimension [ samm:property :physicalState; samm:optional true ] [ samm:property :generalPerformanceClass; samm:optional true ] [ samm:property :otherCharacteristics; samm:optional true ] ) .
+
+:CommercialEntity a samm:Entity ;
+   samm:preferredName "Commercial Entity"@en ;
+   samm:description "Commercial information."@en ;
+   samm:properties ( [ samm:property :placedOnMarket; samm:optional true ] :purpose [ samm:property :purchaseOrder; samm:optional true ] :recallInformation ) .
+
+:SustainabilityEntity a samm:Entity ;
+   samm:preferredName "Sustainability Entity"@en ;
+   samm:description "Entity with the properties regarding the sustainability of the product."@en ;
+   samm:properties ( :productStatus :productFootprint [ samm:property :reparabilityScore; samm:optional true ] [ samm:property :durabilityScore; samm:optional true ] :reusability :recycleabilityPerformance ) .
+
+:DocumentEntity a samm:Entity ;
+   samm:preferredName "Document Entity"@en ;
+   samm:description "Document entity with header, content, category and type."@en ;
+   samm:properties ( :content :category :contentType :header ) .
+
+:AdditionalDataEntity a samm:Entity ;
+   samm:preferredName "Additional Data Entity"@en ;
+   samm:description "Entity with additional data. Properties are label, description, type, data and children. Either the fields data or children filled. Children constructs a hierarchy with the same attributes. Data is filled as the end of an path/leaf."@en ;
+   samm:properties ( :label :description :type [ samm:property :data; samm:optional true ] [ samm:property :children; samm:optional true ] ) .
+
+:ComplianceEntity a samm:Entity ;
+   samm:preferredName "Compliance Entity"@en ;
+   samm:description "Entity for compliance information."@en ;
+   samm:properties ( :requirementName :complianceStatement :complianceCountries [ samm:property :reasonsForExemption; samm:optional true ] [ samm:property :remarks; samm:optional true ] [ samm:property :complianceDocuments; samm:optional true ] ) .
+
+:CompositionEntity a samm:Entity ;
+   samm:preferredName "Composition Entity"@en ;
+   samm:description "Entity for composition of the product."@en ;
+   samm:properties ( :componentInformation :materialInformation ) .
+
+:version a samm:Property ;
+   samm:preferredName "Version"@en ;
+   samm:description "The current version of the product passport. The possibility of modification/ updating the product passport needs to include versioning of the dataset. This attribute is an internal versioning from the passport issuer. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(1) [...] The information in the product passport shall be accurate, complete, and up to date."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "1.0.0" .
+
+:passportStatus a samm:Property ;
+   samm:preferredName "Passport Status"@en ;
+   samm:description "The current status of the product passport declared through either: draft, approved, invalid or expired."@en ;
+   samm:characteristic :PassportStatusEnumeration ;
+   samm:exampleValue "draft" .
+
+:expirationDate a samm:Property ;
+   samm:preferredName "Expiration Date"@en ;
+   samm:description "The timestamp in the format (yyyy-mm-dd) for the product passport until when it is available or a comment describing this period. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(2) (h) the period during which the product passport is to remain available, which shall correspond to at least the expected lifetime of a specific product."@en ;
+   samm:characteristic :DateTrait ;
+   samm:exampleValue "2030-01-01" .
+
+:issueDate a samm:Property ;
+   samm:preferredName "Issue Date"@en ;
+   samm:description "The timestamp in the format (yyyy-mm-dd) since when the product passport is available."@en ;
+   samm:characteristic :DateTrait ;
+   samm:exampleValue "2000-01-01" .
+
+:passportIdentifier a samm:Property ;
+   samm:preferredName "Passport Identifier"@en ;
+   samm:description "The identifier of the product passport, which is an uuidv4."@en ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
+   samm:exampleValue "urn:uuid:550e8400-e29b-41d4-a716-446655440000" .
+
+:predecessor a samm:Property ;
+   samm:preferredName "Predecessor"@en ;
+   samm:description "Identification of the preceding product passport. If there is no preceding passport, input a dummy value. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 8:\n(2)(g) [...] Any new product passport shall be linked to the product passport or passports of the original product whenever appropriate."@en ;
+   samm:characteristic :PredecessorCharacteristic .
+
+:backupReference a samm:Property ;
+   samm:preferredName "Backup Reference"@en ;
+   samm:description "A reference to the data backup of the passport. This mandatory attribute will be further defined in the future. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex III:\n(kb) the reference of the certified independent third-party product passport service provider hosting the back-up copy of the product passport.\nArticle 10 also mentions:\n(c) the data included in the product passport shall be stored by the economic operator responsible for its creation or by certified independent third-party product passport service providers authorised to act on their behalf."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "https://dummy.link" .
+
+:registrationIdentifier a samm:Property ;
+   samm:preferredName "Registration Identifier"@en ;
+   samm:description "Identifier in the respective registry. This will be further defined in the future. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 in Article 12:\nBy [2 years from entering into force of this Regulation], the Commission shall set up and manage a digital registry (\"the registry\") storing in a secure manner at least the unique product identifier, the unique operator identifier, the unique facility identifiers. In case of products intended to be placed under the customs procedure 'release for free circulation', the registry shall also store the product commodity code. The registry shall also store the batteries' unique identifiers referred to in Article 77(3) of Regulation (EU) 2023/1542."@en ;
+   samm:characteristic :IdentifierCharacteristic ;
+   samm:exampleValue "https://dummy.link/ID8283746239078" .
+
+:lastModification a samm:Property ;
+   samm:preferredName "Last Modification"@en ;
+   samm:description "Date of the latest modification."@en ;
+   samm:characteristic :DateTrait ;
+   samm:exampleValue "2000-01-01" .
+
+:language a samm:Property ;
+   samm:preferredName "Language"@en ;
+   samm:description "Specific language in which the passport content is created. Language code is based on the ISO 639-1."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "EN" .
+
+:economicOperator a samm:Property ;
+   samm:preferredName "Economic Operator"@en ;
+   samm:description "Information about the economic operator of the Digital Product Passport."@en ;
+   samm:characteristic :EconomicOperatorCharacteristic .
+
+:specVersion a samm:Property ;
+   samm:preferredName "Digital Product Passport Specification Version"@en ;
+   samm:description "Specification of the DPP format/data model (name and version number), which is used."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "urn:io.catenax.generic.digital_product_passport:6.1.0" .
+
+:serialInformation a samm:Property ;
+   samm:preferredName "Serial Information"@en ;
+   samm:description "Identifier for a serial part if available. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Recital (27):\n[...] an 'item' usually means a single unit of a model."@en ;
+   samm:characteristic ext-part:LocalIdentifierCharacteristic .
+
+:batchInformation a samm:Property ;
+   samm:preferredName "Batch Information"@en ;
+   samm:description "Identifier for a batch part if available. Identifier for a serial part if available. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Recital (27):\n[...] a 'batch' usually means a subset of a specific model composed of all products produced in a specific manufacturing plant at a specific moment in time [...]."@en ;
+   samm:characteristic ext-batch:LocalIdentifierCharacteristic .
+
+:partTypeInformation a samm:Property ;
+   samm:preferredName "Part Type Information"@en ;
+   samm:description "Identifier on the level of a part model or type. Identifier for a serial part if available. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Recital (27):\n[...] A 'model' usually means a version of a product of which all units share the same technical characteristics relevant for the ecodesign requirements and the same model identifier [...]."@en ;
+   samm:characteristic :PartTypeCharacteristic .
+
+:codes a samm:Property ;
+   samm:preferredName "Codes"@en ;
+   samm:description "Codes for identification."@en ;
+   samm:characteristic :CodeList .
+
+:dataCarriers a samm:Property ;
+   samm:preferredName "Data Carriers"@en ;
+   samm:description "The type and layout of the data carriers on the product. These are mentioned in the ESPR proposal from March 30th, 2022 Article 8:\n(b) the types of data carrier to be used;\n(c) the layout in which the data carrier shall be presented and its positioning;\nArticle 2 defines:\n(30) 'data carrier' means a linear bar code symbol, a two-dimensional symbol or other automatic identification data capture medium that can be read by a device."@en ;
+   samm:characteristic :DataCarrierList .
+
+:productImages a samm:Property ;
+   samm:preferredName "Product Images"@en ;
+   samm:description "According Regulation (EU) 2024/1781 of the European Parliament and of the Council of 13 June 2024 establishing a framework for the setting of ecodesign requirements for sustainable products, amending Directive (EU) 2020/1828 and Regulation (EU) 2023/1542 and repealing Directive 2009/125/EC in Article 36 Information obligations of economic operators\n1.   When making a product covered by a delegated act adopted pursuant to Article 4 available on the market through distance selling, economic operators shall ensure that the product offer clearly and visibly provides at least the following information:\n(c) information allowing the identification of the product, including a picture of it, its type and any other product identifier.\n\nAccording Regulation (EU) 2023/988 of the European Parliament and of the Council of 10 May 2023 on general product safety, amending Regulation (EU) No 1025/2012 of the European Parliament and of the Council and Directive (EU) 2020/1828 of the European Parliament and the Council, and repealing Directive 2001/95/EC of the European Parliament and of the Council and Council Directive 87/357/EEC in Article 19 Obligations of economic operators in the case of distance sales:\nWhere economic operators make products available on the market online or through other means of distance sales, the offer of those products shall clearly and visibly indicate at least the following information:\n[...]\n(c) information allowing the identification of the product, including a picture of it, its type and any other product identifier;\n\nThis attribute is mentioned in the proposal for a Regulation of the European Parliament and of the Council on detergents and surfactants, amending Regulation (EU) 2019/1020 and repealing Regulation (EC) No 648/2004 - Mandate for negotiations with the European Parliament:\nANNEX VI DIGITAL PRODUCT PASSPORT \nThe digital product passport shall include the following information: \n[...]\n(c) the identification of detergent or surfactant allowing traceability, including its trade \nname and a colour image of the packaging of the detergent or surfactant of \nsufficient clarity to enable itsthe identification of the detergent or surfactant."@en ;
+   samm:characteristic :ProductImageList .
+
+:manufacturing a samm:Property ;
+   samm:preferredName "Manufacturing"@en ;
+   samm:description "Manufacturing information of the product. In the CATENA-X use case, the BPNL and BPNA can be stated. These attributes are mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(h) unique operator identifiers other than that of the manufacturer;\n(k) the name, contact details and unique operator identifier code of the economic operator established in the Union responsible for carrying out the tasks set out in Article 4 of Regulation (EU) 2019/1020, or Article 15 of Regulation (EU) [.../...] on general product safety, or similar tasks pursuant to other EU legislation applicable to the product."@en ;
+   samm:characteristic :ManufacturingCharacteristic .
+
+:import a samm:Property ;
+   samm:preferredName "Import"@en ;
+   samm:description "Importer details such as the identification."@en ;
+   samm:characteristic :ImportCharacteristic .
+
+:otherOperators a samm:Property ;
+   samm:preferredName "Other Operators"@en ;
+   samm:description "Other operators relevant for the product."@en ;
+   samm:characteristic :OtherOperatorList .
+
+:extendedProducerResponsibilityScheme a samm:Property ;
+   samm:preferredName "Extended Producer Responsibility Scheme"@en ;
+   samm:description "DIRECTIVE 2008/98/EC OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 19 November 2008 on waste and repealing certain Directives Article 3 (21) Definitions:\n 21.  extended producer responsibility scheme  means a set of measures taken by Member States to ensure that producers of products bear financial responsibility or financial and organisational responsibility for the management of the waste stage of a product s life cycle."@en ;
+   samm:characteristic :ExtendedProducerResponsibilitySchemeCharacteristic .
+
+:spareParts a samm:Property ;
+   samm:preferredName "spareParts"@en ;
+   samm:description "The list of spare parts available for the product from various suppliers."@en ;
+   samm:characteristic :SparePartList .
+
+:applicable a samm:Property ;
+   samm:preferredName "Applicable"@en ;
+   samm:description "Check whether the connected attributes are applicable to the product. If applicable (true), content must be provided."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:lifespan a samm:Property ;
+   samm:preferredName "Lifespan"@en ;
+   samm:description "The type of lifespan represented with the values guaranteed lifetime, technical lifetime and mean time between failures. Both can be described through the attributes: type, which defines the type such as guaranteed lifetime or technical lifetime, the unit for the lifetime, and the value represented by an integer. These attributes are mentioned in the ESPR proposal from March 30th, 2022 ANNEX I:\n(a) durability and reliability of the product or its components as expressed through the products guaranteed lifetime, technical lifetime [or] mean time between failures [...]."@en ;
+   samm:characteristic :LifespanList .
+
+:physicalDimension a samm:Property ;
+   samm:preferredName "Physical Dimension"@en ;
+   samm:description "Physical dimensions are properties  associated with physical quantities for purposes of classification or differentiation. These attributes are mentioned in the ESPR provisional agreement from January 9th, Article 7:\n(2) (b) (i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I;\nAnnex I (i) weight and volume of the product and its packaging, and the product-to-packaging ratio."@en ;
+   samm:characteristic :PhysicalDimensionCharacteristic .
+
+:physicalState a samm:Property ;
+   samm:preferredName "Physical State"@en ;
+   samm:description "The physical state of the item. There are four states of matter solid, liquid, gas and plasma which can be chosen from an enumeration."@en ;
+   samm:characteristic :PhysicalStateEnumeration ;
+   samm:exampleValue "solid" .
+
+:generalPerformanceClass a samm:Property ;
+   samm:preferredName "General Performance Class"@en ;
+   samm:description "The performance class of the product. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n4. When establishing the information requirements referred to in paragraph 2, point (b), point (i), the Commission shall, as appropriate in view of the specificity of the product group, determine classes of performance. Classes of performance may be based on single parameters, on aggregated scores, in absolute terms or in any other form that enables potential customers to choose the best performing products. Those classes of performance shall correspond to significant improvements in performance levels. Where classes of performance are based on parameters in relation to which performance requirements are established, they shall use as the minimum level the minimum performance required at the time when the classes of performance start to apply.\nDefinition:\n'class of performance': means a range of performance levels in relation to one or more product parameters referred to in Annex I, based on a common methodology for the product or product group, ordered into successive steps to allow for product differentiation."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A" .
+
+:otherCharacteristics a samm:Property ;
+   samm:preferredName "Other Characteristics"@en ;
+   samm:description "Optional other characteristics of the product."@en ;
+   samm:characteristic :OtherCharacteristicList .
+
+:placedOnMarket a samm:Property ;
+   samm:preferredName "Placed on Market"@en ;
+   samm:description "The timestamp in the format (yyyy-mm-dd) with or without time zone when the product was put in the market."@en ;
+   samm:characteristic :DateTrait ;
+   samm:exampleValue "2000-01-01" .
+
+:purpose a samm:Property ;
+   samm:preferredName "Purpose"@en ;
+   samm:description "One or more intended industry/industries of the product described by the digital product passport. If exchanged via Catena-X, 'automotive ' is a must choice included in the list."@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "automotive" .
+
+:purchaseOrder a samm:Property ;
+   samm:preferredName "Purchase Order"@en ;
+   samm:description "A unique identifier assigned to the order of the product for tracking purposes between supplier and customer."@en ;
+   samm:characteristic samm-c:Text .
+
+:recallInformation a samm:Property ;
+   samm:preferredName "Recall Information"@en ;
+   samm:description "Information regarding the recall of the product.\nRegulation (EU) 2023/988 of the European Parliament and of the Council of 10 May 2023 on general product safety, amending Regulation (EU) No 1025/2012 of the European Parliament and of the Council and Directive (EU) 2020/1828 of the European Parliament and the Council, and repealing Directive 2001/95/EC of the European Parliament and of the Council and Council Directive 87/357/EEC\n\nArticle 9 (Obligations of manufacturers)\n8.   Where a manufacturer considers or has reason to believe, on the basis of the information in that manufacturer s possession, that a product which it has placed on the market is a dangerous product, the manufacturer shall immediately:\n(a) take the corrective measures necessary to bring in an effective manner the product into conformity, including a withdrawal or recall, as appropriate;\n(b) inform consumers thereof, in accordance with Article 35 or 36, or both; and\n(c) inform, through the Safety Business Gateway, the market surveillance authorities of the Member States in which the product has been made available on the market thereof.\nFor the purposes of points (b) and (c) of the first subparagraph, the manufacturer shall give details, in particular, of the risk to the health and safety of consumers and of any corrective measure already taken, and, if available, of the quantity, by Member State, of products still circulating on the market."@en ;
+   samm:characteristic :RecallInformationCharacteristic .
+
+:productStatus a samm:Property ;
+   samm:preferredName "ProductStatus"@en ;
+   samm:description "The status of the product (original, repurposed, re-used, remanufactured or waste) to indicated, whether it is a used product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(j) incorporation of used components."@en ;
+   samm:characteristic :ProductStatusEnumeration ;
+   samm:exampleValue "original" .
+
+:productFootprint a samm:Property ;
+   samm:preferredName "Product Footprint"@en ;
+   samm:description "The carbon and environmental footprint or material footprint of the product. These attributes are mentioned in the ESPR provisional agreement from January 9th 2024 Annex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories;\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product;\nAll are defined by Article 2:\n(23) 'environmental footprint' means a quantification of product environmental impacts throughout its life cycle, whether in relation to a single environmental impact category or an aggregated set of impact categories based on the Product Environmental Footprint method or other scientific methods developed by international organisations and widely tested in collaboration with different industry sectors and adopted or implemented by the Commission in other Union \nlegislation;\n(25) 'carbon footprint' means the sum of greenhouse gas (GHG) emissions and GHG removals in a product system, expressed as CO2 equivalents and based on a life cycle assessment using the single impact category of climate change.\n(25a) 'material footprint' refers to the total amount of raw materials extracted to meet final consumption demands;"@en ;
+   samm:characteristic :ProductFootprintCharacteristic .
+
+:reparabilityScore a samm:Property ;
+   samm:preferredName "Reparability Score"@en ;
+   samm:description "The reparability score. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n(b) as appropriate, also require products to be accompanied by:\n(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability [...]."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "B" .
+
+:durabilityScore a samm:Property ;
+   samm:preferredName "Durability Score"@en ;
+   samm:description "The durability score. This attribute is mentioned ESPR provisional agreement from January 9th, 2024 Article 7:\n(b) as appropriate, also require products to be accompanied by:\n(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability [...]."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A" .
+
+:reusability a samm:Property ;
+   samm:preferredName "Reusability"@en ;
+   samm:description "Reusability of the product."@en ;
+   samm:characteristic :ReusabilityCharacteristic .
+
+:recycleabilityPerformance a samm:Property ;
+   samm:preferredName "Recycleability Performance"@en ;
+   samm:description "This attribute is mentioned in the Regulation (EU) 2024/1781 of the European Parliament and of the Council of 13 June 2024 establishing a framework for the setting of ecodesign requirements for sustainable products, amending Directive (EU) 2020/1828 and Regulation (EU) 2023/1542 and repealing Directive 2009/125/EC Article 7 (2 )(b)(iii):\n(iii) information for treatment facilities on disassembly, reuse, refurbishment, recycling, or disposal at end-of-life.\n\nThese are mentioned in the Regulation (EU) 2025/40: (28) Packaging recyclability should be expressed in recyclability performance grades established on the basis of design for recycling criteria from 2030 and on the basis of both design for recycling and recycled-at-scale criteria from 2035 for packaging categories as listed in Annex II and expressed in grades A, B or C. Packaging of those grades should be considered to be recyclable and, consequently, be allowed to be placed on the market. Packaging below grade C should be considered to be technically non-recyclable and the placing on the market of such packaging should be restricted. However, packaging should comply with those criteria only from 1 January 2030 in order to give sufficient time to the economic operators to adapt. From 1 January 2038, packaging should be at least grade B in order to be placed on the market. \n\nDesign for recycling will fall into 3 performance grades (A to C) and when a packaging unit s recyclability performance grade is below 70 %, it is considered to be non-compliant with the recyclability performance grades and therefore the packaging will be considered technically non-recyclable and its placing on the market shall be restricted.\n\nProposal for a REGULATION OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL on circularity requirements for vehicle design and on management of end-of-life vehicles, amending Regulations (EU) 2018/858 and 2019/1020 and repealing Directives 2000/53/EC and 2005/64/EC: \n(6) recyclability  means the possibility for recycling of parts, components or materials diverted from an end-of-life vehicle; \nArticle 4:\n[...]  3.The Commission shall, by [OP: please enter the date = the last day of the month following 35 months after the date of entry into force of this Regulation], adopt an implementing act establishing a new methodology for calculation and verification of the rates of reusability, recyclability and recoverability of a vehicle, taking into account the elements set out in Annex II."@en ;
+   samm:characteristic :RecycleabilityPerformanceCharacteristic .
+
+:content a samm:Property ;
+   samm:preferredName "Content"@en ;
+   samm:description "The content of the document e.g a link."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "https://dummy.link" .
+
+:category a samm:Property ;
+   samm:preferredName "Category"@en ;
+   samm:description "The category in which the document can be sorted. These are mentioned in the ESPR proposal from March 30th, 2022 ANNEX III:\n(e) compliance documentation and information required under this Regulation or other Union law applicable to the product, such as the declaration of conformity, technical documentation or conformity certificates;\nANNEX IV states additional information regarding the content of the technical documentation\nFurther information on documents are mentioned in the proposal from March 30th, 2022 ANNEX III:\n(f) user manuals, instructions, warnings or safety information, as required by other Union legislation applicable to the product.\nAdditionally requirements are mentioned in Article 21:\n(7) Manufacturers shall ensure that that a product covered by a delegated act adopted pursuant to Article 4 is accompanied by instructions that enable consumers and other end-users to safely assemble, install, operate, store, maintain, repair and dispose of the product in a language that can be easily understood by consumers and other end-users, as determined by the Member State concerned. Such instructions shall be clear, understandable and legible and include at least the information specified in the delegated acts adopted pursuant to Article 4 and pursuant to Article 7(2)(b), point (ii).\nArticle 7 states additionally:\n(2) (b) (ii) information for consumers and other end-users on how to install, use, maintain and repair the product in order to minimize its impact on the environment and to ensure optimum durability, as well as on how to return or dispose of the product at end-of-life;\n(2) (b) (iii) information for treatment facilities on disassembly, recycling, or disposal at end-of-life;\n(2) (b) (iv) other information that may influence the way the product is handled by parties other than the manufacturer in order to improve performance in relation to product parameters referred to in Annex I.\n(5) (d) relevant instructions for the safe use of the product."@en ;
+   samm:characteristic :SourceCategoryEnumeration ;
+   samm:exampleValue "Legal Information" .
+
+:contentType a samm:Property ;
+   samm:preferredName "Content Type"@en ;
+   samm:description "The type of content which can be expected in the \"content\" property. Examples are a link, restricted link, pdf, excel, etc."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "URL" .
+
+:header a samm:Property ;
+   samm:preferredName "Header"@en ;
+   samm:description "The header as a short description of the document with a maximum of 100 characters."@en ;
+   samm:characteristic :HeaderTrait ;
+   samm:exampleValue "Example Document XYZ" .
+
+:label a samm:Property ;
+   samm:preferredName "Label"@en ;
+   samm:description "The human readable name of the attribute."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Maximum permitted battery power" .
+
+:description a samm:Property ;
+   samm:preferredName "Description"@en ;
+   samm:description "The description of the attribute context."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Description of an attribute" .
+
+:type a samm:Property ;
+   samm:preferredName "Type"@en ;
+   samm:description "The complex description of the type."@en ;
+   samm:characteristic :TypeCharacteristic .
+
+:data a samm:Property ;
+   samm:preferredName "Data"@en ;
+   samm:description "The content from the attribute which is a depended of the data type and typeUnit."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "23" .
+
+:children a samm:Property ;
+   samm:preferredName "children"@en ;
+   samm:description "Children of the hierarchy."@en ;
+   samm:characteristic :AdditionalDataList .
+
+:requirementName a samm:Property ;
+   samm:preferredName "Requirement Name"@en ;
+   samm:description "Name of the regulation or standard, code of conduct, specification to which the product must comply. It can be sourced from the Supplier Survey information."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "REACH regulation" .
+
+:complianceStatement a samm:Property ;
+   samm:preferredName "Compliance Statement"@en ;
+   samm:description "The statement indicates whether the product complies with the aforementioned regulations."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Hereby we declare under our sole responsibility that the product:XXX is in conformity with the provisions of the EU directives and regulations." .
+
+:complianceCountries a samm:Property ;
+   samm:preferredName "complianceCountries"@en ;
+   samm:description "List of countries whose rules and regulations the product must adhere to.\n\nThe name of the country of compliance denotes the country whose rules and regulations the product must adhere to. 2 letter code from ISO 3166."@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "UK" .
+
+:reasonsForExemption a samm:Property ;
+   samm:preferredName "Reasons For Exemption"@en ;
+   samm:description "Data providing details and justifications for an exemption from compliance with certain regulations, standards, or requirements. This information assists regulatory authorities or stakeholders in evaluating the merits of the exemption and making decisions following legal and regulatory requirements."@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "Radioactive substance" .
+
+:remarks a samm:Property ;
+   samm:preferredName "Remarks"@en ;
+   samm:description "If necessary, any remarks that provide relevant information for compliance. Further clarification supplements the compliance information, offering additional context or details to ensure thorough understanding and adherence to regulatory requirements."@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "If you need more information about the (pre-)registration status, please get in contact with our experts from the Compliance Team: www.xyz.com" .
+
+:complianceDocuments a samm:Property ;
+   samm:preferredName "Compliance Documents"@en ;
+   samm:description "Additional information about compliance in a form of a document."@en ;
+   samm:characteristic :DocumentList .
+
+:componentInformation a samm:Property ;
+   samm:preferredName "Component Information"@en ;
+   samm:description "Information about the component(s) of the product."@en ;
+   samm:characteristic :ComponentInformationCharacteristic .
+
+:materialInformation a samm:Property ;
+   samm:preferredName "Material Information"@en ;
+   samm:description "Information about the material(s) of the product."@en ;
+   samm:characteristic :MaterialInformationCharacteristic .
+
+:PassportStatusEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Passport Status Enumeration"@en ;
+   samm:description "The current status of the product passport declared through either: draft, approved, invalid or expired."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "draft" "approved" "invalid" "expired" ) .
+
+:DateTrait a samm-c:Trait ;
+   samm:preferredName "Date Trait"@en ;
+   samm:description "Trait for valid traits.."@en ;
+   samm-c:baseCharacteristic samm-c:Text ;
+   samm-c:constraint :DateConstraint .
+
+:PredecessorCharacteristic a samm:Characteristic ;
+   samm:preferredName "Predecessor Characteristic"@en ;
+   samm:description "Characteristic of the predeseccor of the actual digital product passport."@en ;
+   samm:dataType :PredecessorEntity .
+
+:IdentifierCharacteristic a samm:Characteristic ;
+   samm:preferredName "Identifier Characteristic"@en ;
+   samm:description "Characteristic for Identifiers."@en ;
+   samm:dataType xsd:string .
+
+:EconomicOperatorCharacteristic a samm:Characteristic ;
+   samm:preferredName "EconomicOperatorCharacteristic"@en ;
+   samm:description "Characteristic of the economic operator."@en ;
+   samm:dataType :EconomicOperatorEntity .
+
+:PartTypeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Part Type Characteristic"@en ;
+   samm:description "Characteristic for the part type."@en ;
+   samm:dataType :PartTypeEntity .
+
+:CodeList a samm-c:List ;
+   samm:preferredName "Code List"@en ;
+   samm:description "A list of additional codes."@en ;
+   samm:dataType :CodeEntity .
+
+:DataCarrierList a samm-c:List ;
+   samm:preferredName "Data Carrier List"@en ;
+   samm:description "List of Data Carriers of the product."@en ;
+   samm:dataType :DataCarrierEntity .
+
+:ProductImageList a samm-c:List ;
+   samm:preferredName "Product Image List"@en ;
+   samm:description "List of product images."@en ;
+   samm:dataType :ProductImageEntity .
+
+:ManufacturingCharacteristic a samm:Characteristic ;
+   samm:preferredName "Manufacturing Characteristic"@en ;
+   samm:description "Manufacturing information."@en ;
+   samm:dataType :ManufacturingEntity .
+
+:ImportCharacteristic a samm:Characteristic ;
+   samm:preferredName "Import Characteristic"@en ;
+   samm:description "Import Characteristic for the product."@en ;
+   samm:dataType :ImportEntity .
+
+:OtherOperatorList a samm-c:List ;
+   samm:preferredName "Other Operator List"@en ;
+   samm:description "List of other operators."@en ;
+   samm:dataType :OtherOperatorEntity .
+
+:ExtendedProducerResponsibilitySchemeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Extended Producer Responsibility Scheme Characteristic"@en ;
+   samm:description "Characteristic of Extended Producer Responsibility Scheme"@en ;
+   samm:dataType :ExtendedProducerResponsibilitySchemeEntity .
+
+:SparePartList a samm-c:List ;
+   samm:preferredName "Spare Part List"@en ;
+   samm:description "List of spare parts."@en ;
+   samm:dataType :SparePartEntity .
+
+:LifespanList a samm-c:List ;
+   samm:preferredName "Lifespan List"@en ;
+   samm:description "List of different life spans of a product."@en ;
+   samm:dataType :LifespanEntity .
+
+:PhysicalDimensionCharacteristic a samm:Characteristic ;
+   samm:preferredName "Physical Dimension Characteristic"@en ;
+   samm:description "Characteristic for physical dimensions with linear, mass and capacity attributes."@en ;
+   samm:dataType :PhysicalDimensionEntity .
+
+:PhysicalStateEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Physical State Enumeration"@en ;
+   samm:description "Enumeration with the values solid, liquid, gas and plasma."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "solid" "liquid" "gas" "plasma" "aerosol" ) .
+
+:OtherCharacteristicList a samm-c:List ;
+   samm:preferredName "Other Characteristic List"@en ;
+   samm:description "List of other, additional characteristics."@en ;
+   samm:dataType :OtherCharacteristicEntity .
+
+:StringList a samm-c:List ;
+   samm:preferredName "String List"@en ;
+   samm:description "List of strings."@en ;
+   samm:dataType xsd:string .
+
+:RecallInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Recall Information Characteristic"@en ;
+   samm:description "Recall information characteristic for the product."@en ;
+   samm:dataType :RecallInformationEntity .
+
+:ProductStatusEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Product Status Enumeration"@en ;
+   samm:description "Enumeration defined as original, repurposed, re-used, remanufactured or waste."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "original" "repurposed" "re-used" "remanufactured" "waste" ) .
+
+:ProductFootprintCharacteristic a samm:Characteristic ;
+   samm:preferredName "Product Footprint Characteristic"@en ;
+   samm:description "The Product Footprint Characteristic with sustainability information."@en ;
+   samm:dataType :ProductFootprintEntity .
+
+:ReusabilityCharacteristic a samm:Characteristic ;
+   samm:preferredName "Reusability Characteristic"@en ;
+   samm:description "Characteristic of the reusability of the product."@en ;
+   samm:dataType :ReusabilityEntity .
+
+:RecycleabilityPerformanceCharacteristic a samm:Characteristic ;
+   samm:preferredName "Recycleability Performance Characteristic"@en ;
+   samm:description "Characteristic for recycleability performance."@en ;
+   samm:dataType :RecycleabilityPerformanceEntity .
+
+:SourceCategoryEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Source Category Enumeration"@en ;
+   samm:description "The types of sources that can be linked in a digital product passport can vary depending on the nature of the product and the information that needs to be included. This is an enumeration of possible sources."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Applicable Standards" "Assessment Documents" "Bio-based & Biodegradability Claims" "Certifications and Compliance" "Compatibility and Accessories" "Compostable information" "Declaration of performance" "Description of Calculations Methods" "Destruction Information" "Disclosure Regarding the EU Taxonomy" "Dismantling Information" "Due Diligence Policy Report" "End of Life" "Environmental Impact" "EU Declaration of Conformity" "FAQs and Support" "Information about processes" "Instructions" "Intended Users" "Legal Information" "Link to Databases or Systems" "Managament Waste Consumer Role" "Managament Waste Impact Of Inappropriate Discarding" "Management Claims" "Manufacturer Information" "Material and Substance Information" "Meaning of Labels and Symbols" "Other" "Privacy and Data Handling" "Product Images and Videos" "Product Packaging" "Product Specifications" "Product Variations" "Purchase and Retail Information" "Recycle Information" "Refurbishment Information" "Removal Information" "Repair and Installation" "Repairability or Durability Documentation" "Report from Third-parties Verifications" "Result of Tests Reports" "Return and Disposal" "Reuse Information" "Reviews and Ratings" "Risk Mitigation Possibilities" "Safe Discharging Documentation" "Safety Information" "Service History" "Specific Mandatory Labels" "Specific Voluntary Labels" "Supply Chain Information" "Sustainability Documents" "Technical Documentation" "Third-Party Integrations" "Treatment facilities" "Usable Extinguish Agents Information" "User Manuals and Guides" "Warranty Information" "Waste Generation and Prevention" "Waste Separate Collection" ) .
+
+:HeaderTrait a samm-c:Trait ;
+   samm:preferredName "Header Trait"@en ;
+   samm:description "Trait for a restrictive header."@en ;
+   samm-c:baseCharacteristic samm-c:Text ;
+   samm-c:constraint :HeaderConstraint .
+
+:TypeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Type Characteristic"@en ;
+   samm:description "Characteristic for the data type."@en ;
+   samm:dataType :TypeEntity .
+
+:DocumentList a samm-c:List ;
+   samm:preferredName "Document List"@en ;
+   samm:description "List of documents."@en ;
+   samm:dataType :DocumentationEntity .
+
+:ComponentInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Component Information Characteristic"@en ;
+   samm:description "Characteristic of component information."@en ;
+   samm:dataType :ComponentInformationEntity .
+
+:MaterialInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Material Information Characteristic"@en ;
+   samm:description "Characteristic of the material information."@en ;
+   samm:dataType :MaterialInformationEntity .
+
+:DateConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Date Constraint"@en ;
+   samm:description "Constraint fo a timestamp in the format (yyyy-mm-dd)."@en ;
+   samm:value "^\\d{4}-\\d{2}-\\d{2}$" .
+
+:PredecessorEntity a samm:Entity ;
+   samm:preferredName "Predecessor Entity"@en ;
+   samm:description "Entity for predecessor of the actual digital product passport."@en ;
+   samm:properties ( :applicable [ samm:property :predecessorIdentifier; samm:optional true; samm:payloadName "content" ] ) .
+
+:EconomicOperatorEntity a samm:Entity ;
+   samm:preferredName "Economic Operator Entity"@en ;
+   samm:description "Entity for the information about the economis oprator."@en ;
+   samm:properties ( :economicOperatorIdentification :economicOperatorNames :economicOperatorAddress :economicOperatorContact ) .
+
+:PartTypeEntity a samm:Entity ;
+   samm:preferredName "Part Type Entity"@en ;
+   samm:description "Entity for the part type with manufacturer id and name."@en ;
+   samm:properties ( ext-information:manufacturerPartId ext-information:nameAtManufacturer ) .
+
+:CodeEntity a samm:Entity ;
+   samm:preferredName "Code Entity"@en ;
+   samm:description "Code entity with code key and value."@en ;
+   samm:properties ( [ samm:property :codeKey; samm:payloadName "key" ] [ samm:property :codeValue; samm:payloadName "value" ] [ samm:property :codeDescription; samm:optional true; samm:payloadName "description" ] ) .
+
+:DataCarrierEntity a samm:Entity ;
+   samm:preferredName "Data Carrier Entity"@en ;
+   samm:description "Data Carrier Entity with type and layout of the data carriers."@en ;
+   samm:properties ( :carrierType :carrierPositions ) .
+
+:ProductImageEntity a samm:Entity ;
+   samm:preferredName "ProductImageEntity"@en ;
+   samm:description "Entity for product images."@en ;
+   samm:properties ( :content :contentType :header ) .
+
+:ManufacturingEntity a samm:Entity ;
+   samm:preferredName "Manufacturing Entity"@en ;
+   samm:description "Manufacturing Entity with the identification of the main manufacturer and the facility location as well as the manufacturing date."@en ;
+   samm:properties ( :facilities :manufacturer [ samm:property :manufacturingDate; samm:optional true ] ) .
+
+:ImportEntity a samm:Entity ;
+   samm:preferredName "Import Entity"@en ;
+   samm:description "Import entity with attributes if applicable to the product."@en ;
+   samm:properties ( [ samm:property :importer; samm:optional true; samm:payloadName "content" ] :applicable ) .
+
+:OtherOperatorEntity a samm:Entity ;
+   samm:preferredName "Other Operator Entity"@en ;
+   samm:description "Operator with role, identification, address and contact information. "@en ;
+   samm:properties ( :otherOperatorIdenfication :otherOperatorRole :otherOperatorAddress :otherOperatorContact :otherOperatorNames ) .
+
+:ExtendedProducerResponsibilitySchemeEntity a samm:Entity ;
+   samm:preferredName "Extended Producer Responsibility Scheme Entity"@en ;
+   samm:description "Entity for Extended Producer Resposibility Scheme, including the applicability, symbols, territories and collection points."@en ;
+   samm:properties ( :applicable [ samm:property :extendedProducerResponsibilitySchemeInformation; samm:optional true; samm:payloadName "content" ] ) .
+
+:SparePartEntity a samm:Entity ;
+   samm:preferredName "Spare Part Entity"@en ;
+   samm:description "Entity for spare part information."@en ;
+   samm:properties ( :sparePartProvider ext-information:nameAtManufacturer ext-information:manufacturerPartId ) .
+
+:LifespanEntity a samm:Entity ;
+   samm:preferredName "Lifespan Entity"@en ;
+   samm:description "Entity for the lifespan of a product with type, unit and value."@en ;
+   samm:properties ( :lifeUnit :lifeValue :lifeType [ samm:property :lifeDescription; samm:optional true ] ) .
+
+:PhysicalDimensionEntity a samm:Entity ;
+   samm:preferredName "Physical Dimension Entity"@en ;
+   samm:description "Entity for physical dimensions with linear, mass and capacity attributes. Either weight or volume is mandatory."@en ;
+   samm:properties ( [ samm:property :width; samm:optional true ] [ samm:property :length; samm:optional true ] [ samm:property :diameter; samm:optional true ] [ samm:property :height; samm:optional true ] :grossWeight :grossVolume :weight :volume [ samm:property :itemQuantityInPackage; samm:optional true ] ) .
+
+:OtherCharacteristicEntity a samm:Entity ;
+   samm:preferredName "Other Characteristic Entity"@en ;
+   samm:description "Entity for other, additional characteristics."@en ;
+   samm:properties ( :otherCharacteristicName :otherCharacteristicOutcome ) .
+
+:RecallInformationEntity a samm:Entity ;
+   samm:preferredName "Recall Information Entity"@en ;
+   samm:description "Recall information entity with attributes if applicabe to the product."@en ;
+   samm:properties ( :applicable [ samm:property :recallInformationDocumentation; samm:optional true; samm:payloadName "content" ] ) .
+
+:ProductFootprintEntity a samm:Entity ;
+   samm:preferredName "Product Footprint Entity"@en ;
+   samm:description "The Product Footprint Entity with sustainability information such as the different environmental footprint types, the carbon and material footprint explicitly, applicable rules and lifecycle stages."@en ;
+   samm:properties ( [ samm:property :environmentalFootprint; samm:optional true; samm:payloadName "environmental" ] [ samm:property :carbonFootprint; samm:payloadName "carbon" ] [ samm:property :materialFootprint; samm:optional true; samm:payloadName "material" ] ) .
+
+:ReusabilityEntity a samm:Entity ;
+   samm:preferredName "Reusability Entity"@en ;
+   samm:description "Information about the reusability of the product."@en ;
+   samm:properties ( [ samm:property :reusabilityInformation; samm:optional true; samm:payloadName "content" ] :applicable ) .
+
+:RecycleabilityPerformanceEntity a samm:Entity ;
+   samm:preferredName "Recycleability Performance Entity"@en ;
+   samm:description "Entity for recycleability performance."@en ;
+   samm:properties ( :applicable [ samm:property :recycleabilityPerformaceGrade; samm:optional true; samm:payloadName "content" ] ) .
+
+:HeaderConstraint a samm-c:LengthConstraint ;
+   samm:preferredName "Header Constraint"@en ;
+   samm:description "Constraint for a maximum of 100 characters."@en ;
+   samm-c:maxValue "100"^^xsd:nonNegativeInteger .
+
+:TypeEntity a samm:Entity ;
+   samm:preferredName "Type Entity"@en ;
+   samm:description "Entity for type with unit and data type."@en ;
+   samm:properties ( [ samm:property :typeUnit; samm:optional true ] :dataType ) .
+
+:DocumentationEntity a samm:Entity ;
+   samm:preferredName "Documentation Entity"@en ;
+   samm:description "Entity for a document with a header, type and content."@en ;
+   samm:properties ( :content :contentType :header ) .
+
+:ComponentInformationEntity a samm:Entity ;
+   samm:preferredName "Component Information Entity"@en ;
+   samm:description "Entity for information about component(s)."@en ;
+   samm:properties ( :applicable [ samm:property :components; samm:optional true; samm:payloadName "content" ] ) .
+
+:MaterialInformationEntity a samm:Entity ;
+   samm:preferredName "Material Information Entity"@en ;
+   samm:description "Entity for information about the material(s) of the product."@en ;
+   samm:properties ( :materials ) .
+
+:predecessorIdentifier a samm:Property ;
+   samm:preferredName "Predecessor Identifier"@en ;
+   samm:description "Identification of the preceding product passport."@en ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
+   samm:exampleValue "urn:uuid:00000000-0000-0000-0000-000000000000" .
+
+:economicOperatorIdentification a samm:Property ;
+   samm:preferredName "Economic Operator Identification"@en ;
+   samm:description "The identification of the owner/economic operator of the passport. Proposed, according to ISO 15459, is the CIN (company identification code). Other identification numbers like the tax identification number, value added tax identification number, commercial register number and the like are also valid entries. In the Catena-X network, the BPNL is used for the identification of companies and the information stored like contact information and addresses. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex III:\n(k) the [...] unique operator identifier code of the economic operator established in the Union responsible for carrying out the tasks set out in Article 4 of Regulation (EU) 2019/1020, or Article 15 of Regulation (EU) on general product safety, or similar tasks pursuant to other EU legislation applicable to the product."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BPNL0123456789ZZ" .
+
+:economicOperatorNames a samm:Property ;
+   samm:preferredName "Economic Operator Names"@en ;
+   samm:description "Name list for the Economic Operator."@en ;
+   samm:characteristic :NameList ;
+   samm:exampleValue "ABC" .
+
+:economicOperatorAddress a samm:Property ;
+   samm:preferredName "Economic Operator Address"@en ;
+   samm:description "Full address of the economic operator."@en ;
+   samm:characteristic ext-characteristic:PostalAddress .
+
+:economicOperatorContact a samm:Property ;
+   samm:preferredName "Economic Operator Contact"@en ;
+   samm:description "Contact details of the economic operator."@en ;
+   samm:characteristic ext-information2:ContactCharacteristic .
+
+:codeKey a samm:Property ;
+   samm:preferredName "Code Key"@en ;
+   samm:description "The code key for the identification of the product. Examples are GTIN, hash, DID, ISBN, TARIC. This attribute is mentioned in the ESPR proposal from March 30th, 2022 ANNEX III:\n(b) the unique product identifier at the level indicated in the applicable delegated act adopted pursuant to Article 4;\n(c) the Global Trade Identification Number as provided for in standard ISO/IEC 15459-6 or equivalent of products or their parts;\n(d) relevant commodity codes, such as a TARIC code as defined in Council Regulation (EEC) No 2658/87."@en ;
+   samm:characteristic :IdentifierCharacteristic ;
+   samm:exampleValue "TARIC" .
+
+:codeValue a samm:Property ;
+   samm:preferredName "Code Value"@en ;
+   samm:description "The code value for the identification of the product in regard to the chosen code name."@en ;
+   samm:characteristic :IdentifierCharacteristic ;
+   samm:exampleValue "8703 24 10 00" .
+
+:codeDescription a samm:Property ;
+   samm:preferredName "Code Description"@en ;
+   samm:description "Description of the specific code. This attribute can be particularly used if \"other\" as a code key is used."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A 10th-digit customs nomenclature code." .
+
+:carrierType a samm:Property ;
+   samm:preferredName "Carrier Type"@en ;
+   samm:description "The type of data carrier such as a QR code on the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 8:\n(2) (b) the types of data carrier to be used."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "QR" .
+
+:carrierPositions a samm:Property ;
+   samm:preferredName "Carrier Positions"@en ;
+   samm:description "The positioning of data carrier on the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 8:\n(2) (c) the layout in which the data carrier shall be presented and its positioning."@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "upper-left side" .
+
+:facilities a samm:Property ;
+   samm:preferredName "Facilities"@en ;
+   samm:description "This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product."@en ;
+   samm:characteristic :FacilityList .
+
+:manufacturer a samm:Property ;
+   samm:preferredName "Manufacturer"@en ;
+   samm:description "The main manufacturer, if different from the passport owner, represented by a name, identification number, address and contact information. In the Catena-X use case, the BPNL can be stated. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(h) unique operator identifiers other than that of the manufacturer;\n(k) the name, contact details and unique operator identifier code of the economic operator established in the Union responsible for carrying out the tasks set out in Article 4 of Regulation (EU) 2019/1020, or Article 15 of Regulation (EU) [.../...] on general product safety, or similar tasks pursuant to other EU legislation applicable to the product."@en ;
+   samm:characteristic :ManufacturerCharacteristic .
+
+:manufacturingDate a samm:Property ;
+   samm:preferredName "Manufacturing Date"@en ;
+   samm:description "The timestamp in the format (yyyy-mm-dd) of the manufacturing date as the final step in production process (e.g. final quality check, ready-for-shipment event)."@en ;
+   samm:characteristic :DateTrait ;
+   samm:exampleValue "2000-01-31" .
+
+:importer a samm:Property ;
+   samm:preferredName "Importer"@en ;
+   samm:description "Information regarding the importer of the product, if different from the owner of the passport. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex III:\n(j) information related to the importer, including the information referred to in Article 23(3) and its EORI number;\nArticle 23 states:\n(3) Importers shall, for products covered by a delegated act adopted pursuant to Article 4, indicate their name, registered trade name or registered trade mark and the postal address and electronic means of communication, where they can be contacted:  (a) on the public part of the product passport, when applicable, and\n(b) on the product or, where this is not possible, on the packaging, or in a document accompanying the product."@en ;
+   samm:characteristic :ImporterCharacteristic .
+
+:otherOperatorIdenfication a samm:Property ;
+   samm:preferredName "Other Operator Identification"@en ;
+   samm:description "Identifier of the other operator. This can be a BPN."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BPNL0123456789XX" .
+
+:otherOperatorRole a samm:Property ;
+   samm:preferredName "Other Operator Role"@en ;
+   samm:description "Role of the other operator."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "distributor" .
+
+:otherOperatorAddress a samm:Property ;
+   samm:preferredName "Other Operator Address"@en ;
+   samm:description "Full address of the other operators."@en ;
+   samm:characteristic ext-characteristic:PostalAddress .
+
+:otherOperatorContact a samm:Property ;
+   samm:preferredName "Other Operator Contact"@en ;
+   samm:description "Contact details of the other operator."@en ;
+   samm:characteristic ext-information2:ContactCharacteristic .
+
+:otherOperatorNames a samm:Property ;
+   samm:preferredName "Other Operator Names"@en ;
+   samm:description "Names of the other economic operators."@en ;
+   samm:characteristic :NameList .
+
+:extendedProducerResponsibilitySchemeInformation a samm:Property ;
+   samm:preferredName "Extended Producer Responsibility Scheme Information"@en ;
+   samm:description "Information about the Extended Producer Responsibility Scheme"@en ;
+   samm:characteristic :ExtendedProducerResponsibilitySchemeInformationCharacteristic .
+
+:sparePartProvider a samm:Property ;
+   samm:preferredName "Spare Part Provider"@en ;
+   samm:description "Providers/suppliers of possible spare parts indicating contact detailes of sources for replacement spares."@en ;
+   samm:characteristic :SparePartProviderList .
+
+:lifeUnit a samm:Property ;
+   samm:preferredName "Life Unit"@en ;
+   samm:description "The unit of the respective lifespan expressed through the possible units day, month, cycle, year and runningOrOperatingHour."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:characteristic :LifeEnumeration ;
+   samm:exampleValue "unit:month" .
+
+:lifeValue a samm:Property ;
+   samm:preferredName "Life Value"@en ;
+   samm:description "The value as an integer for the respective lifespan."@en ;
+   samm:characteristic :LifeValueCharacteristic ;
+   samm:exampleValue 36 .
+
+:lifeType a samm:Property ;
+   samm:preferredName "Life Type"@en ;
+   samm:description "The type of lifespan represented with the values guaranteed lifetime, technical lifetime and mean time between failures. This attribute is mentioned in the ESPR proposal from March 30th, 2022 ANNEX I:\n(a) durability and reliability of the product or its components as expressed through the product's guaranteed lifetime, technical lifetime [or] mean time between failures [...]."@en ;
+   samm:characteristic :LifeTypeEnumeration ;
+   samm:exampleValue "guaranteed lifetime" .
+
+:lifeDescription a samm:Property ;
+   samm:preferredName "Life Description"@en ;
+   samm:description "Additional detailed description of the lifyType (e.g. shelf life as a technical lifetime)."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Shelf life (technical lifetime) is about how long the product stays reliable before it s used. The shelf life of batteries depends on the type of battery, storage conditions, and whether it's rechargeable or disposable." .
+
+:width a samm:Property ;
+   samm:preferredName "Width"@en ;
+   samm:description "The width of the item measured in a specific linear unit which can be declared in the corresponding unit attribute."@en ;
+   samm:characteristic ext-quantity:LinearCharacteristic .
+
+:length a samm:Property ;
+   samm:preferredName "Length"@en ;
+   samm:description "The length of the item measured in a specific linear unit which can be declared in the corresponding unit attribute."@en ;
+   samm:characteristic ext-quantity:LinearCharacteristic .
+
+:diameter a samm:Property ;
+   samm:preferredName "Diameter"@en ;
+   samm:description "The diameter of the item, if applicable, measured in a specific linear unit which can be declared in the corresponding unit attribute."@en ;
+   samm:characteristic ext-quantity:LinearCharacteristic .
+
+:height a samm:Property ;
+   samm:preferredName "Height"@en ;
+   samm:description "The height of the item measured in a specific linear unit which can be declared in the corresponding unit attribute."@en ;
+   samm:characteristic ext-quantity:LinearCharacteristic .
+
+:grossWeight a samm:Property ;
+   samm:preferredName "Gross Weight"@en ;
+   samm:description "The gross weight of the item measured in a specific mass unit which can be declared in the corresponding unit attribute. Gross weight refers to the total weight of a product, including the weight of the packaging. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(2) (b) (i) information on the performance of the product in relation to the product parameters referred to in Annex I;\nAnnex I (i) weight and volume of the product and its packaging, and the product-to-packaging ratio."@en ;
+   samm:characteristic ext-quantity:MassCharacteristic .
+
+:grossVolume a samm:Property ;
+   samm:preferredName "Gross Volume"@en ;
+   samm:description "The gross volume of the item, if possible, measured in a specific capacity unit which can be declared in the corresponding unit attribute. If there is no separate packing, the volume of the product shall be given. Gross volume refers to the total volume of a product, including the volume of the packaging. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(2) (b) (i) information on the performance of the product in relation to the product parameters referred to in Annex I;\nAnnex I (i) weight and volume of the product and its packaging, and the product-to-packaging ratio."@en ;
+   samm:characteristic ext-quantity:VolumeCharacteristic .
+
+:weight a samm:Property ;
+   samm:preferredName "Weight"@en ;
+   samm:description "Weight of the product measured in a specific mass unit which can be declared in the corresponding unit attribute.  This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(2) (b) (i) information on the performance of the product in relation to the product parameters referred to in Annex I;\nAnnex I (i) weight and volume of the product [...]."@en ;
+   samm:characteristic ext-quantity:MassCharacteristic .
+
+:volume a samm:Property ;
+   samm:preferredName "Volume"@en ;
+   samm:description "Volume of the product, if possible, measured in a specific capacity unit which can be declared in the corresponding unit attribute. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(2) (b) (i) information on the performance of the product in relation to the product parameters referred to in Annex I;\nAnnex I (i) weight and volume of the product [...]."@en ;
+   samm:characteristic ext-quantity:VolumeCharacteristic .
+
+:itemQuantityInPackage a samm:Property ;
+   samm:preferredName "Item Quantity In Package"@en ;
+   samm:description "Physical dimensions are properties  associated with physical quantities for purposes of classification or differentiation. These attributes are mentioned in the Regulation (EU) 2024/1781 of the European Parliament and of the Council of 13 June 2024 establishing a framework for the setting of ecodesign requirements for sustainable products, Article 7:\n(2)\n[...]\n(b) as appropriate, also require products to be accompanied by:\n(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a repairability score, a durability score, a carbon footprint or an environmental footprint;\nAnnex I \n(j) weight and volume of the product and its packaging, and the product-to-packaging ratio;\n(l) quantity, characteristics and availability of consumables needed for proper use and maintenance as expressed, inter alia, through yield, technical lifetime, ability to reuse, repair, and remanufacture, mass-resource efficiency, and interoperability.\n\nThe amout of items, if product base units may be packed into inner packs. Base units are not sold individualy, only pack are possible within value chain."@en ;
+   samm:characteristic ext-quantity:ItemQuantityCharacteristic .
+
+:otherCharacteristicName a samm:Property ;
+   samm:preferredName "Other Characteristic Name"@en ;
+   samm:description "Name of the specific characteristic associated with a product. "@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "shape" .
+
+:otherCharacteristicOutcome a samm:Property ;
+   samm:preferredName "Other Characteristic Outcome"@en ;
+   samm:description "Specific results or effects that are associated with the product."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "cubic" .
+
+:recallInformationDocumentation a samm:Property ;
+   samm:preferredName "Recall Information Documentation"@en ;
+   samm:description "Documentation of the recall information of the product."@en ;
+   samm:characteristic :DocumentList .
+
+:environmentalFootprint a samm:Property ;
+   samm:preferredName "Environmental Footprint"@en ;
+   samm:description "The environmental footprint of the product. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\nThe following parameters shall, as appropriate, and where necessary supplemented by others, be used, individually or combined, as a basis for improving the product aspects referred to in Article 5(1):\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories.\nand Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nand defined by Article 2:\n(23) 'environmental footprint' means a quantification of product environmental impacts throughout its life cycle, whether in relation to a single environmental impact category or an aggregated set of impact categories based on the Product Environmental Footprint method or other scientific methods developed by international organisations and widely tested in collaboration with different industry sectors and adopted or implemented by the Commission in other Union legislation;\n(24) 'Product Environmental Footprint method' means the life cycle assessment method to quantify the environmental impacts of products established by Recommendation (EU) 2021/2279."@en ;
+   samm:characteristic :FootprintList .
+
+:carbonFootprint a samm:Property ;
+   samm:preferredName "Carbon Footprint"@en ;
+   samm:description "The carbon footprint of the product. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\nThe following parameters shall, as appropriate, and where necessary supplemented by others, be used, individually or combined, as a basis for improving the product aspects referred to in Article 5(1):\n(m) the carbon footprint of the product;\nand Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nand defined by Article 2:\n(25) 'carbon footprint' means the sum of greenhouse gas (GHG) emissions and GHG removals in a product system, expressed as CO2 equivalents and based on a life cycle assessment using the single impact category of climate change."@en ;
+   samm:characteristic :FootprintList .
+
+:materialFootprint a samm:Property ;
+   samm:preferredName "Material Footprint"@en ;
+   samm:description "The material footprint of the product. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(ma) the material footprint of the product;\nand defined by Article 2:\n(25a) 'material footprint' refers to the total amount of raw materials extracted to meet final consumption demands."@en ;
+   samm:characteristic :FootprintList .
+
+:reusabilityInformation a samm:Property ;
+   samm:preferredName "reusabilityInformation"@en ;
+   samm:description "Information about the reusability of the product and the reuse system."@en ;
+   samm:characteristic :ReusabilityInformationCharacteristic .
+
+:recycleabilityPerformaceGrade a samm:Property ;
+   samm:preferredName "Recycleability Performace Grade"@en ;
+   samm:description "Indication of recycleability grade."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "C" .
+
+:typeUnit a samm:Property ;
+   samm:preferredName "Type Unit"@en ;
+   samm:description "Choose a unit type from the unit catalog, or if the property \"children\" is filled, leave empty."@en ;
+   samm:characteristic :UnitCatalog ;
+   samm:exampleValue "unit:volume" .
+
+:dataType a samm:Property ;
+   samm:preferredName "Data Type"@en ;
+   samm:description "Data type that describe the content of the attributes children and data. In case \"object\" is selected in the enumeration, the children field will be used in the AdditionalDataEntity instead of the \"data\" property. If it is an other type, the content will be specified in \"data\" as a string."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:characteristic :DataTypeEnumeration ;
+   samm:exampleValue "xsd:integer" .
+
+:components a samm:Property ;
+   samm:preferredName "Components"@en ;
+   samm:description "Information about the components of the product.\n\nThis attribute is mentioned in the Regulation (EU) 2024/1781 of the European Parliament and of the Council of 13 June 2024 establishing a framework for the setting of ecodesign requirements for sustainable products, amending Directive (EU) 2020/1828 and Regulation (EU) 2023/1542 and repealing Directive 2009/125/EC Article 2\n(2)  component  means a product intended to be incorporated into another product;\n\nThese are mentioned in the Regulation (EU) 2025/40: Article 3 Definitions\n(45)  unit of packaging  means a unit, including any integrated or separate components, which as a whole serves a packaging function, such as the containment, protection, handling, delivery, storage, transport or presentation of products, and includes independent units of grouped or transport packaging where they are discarded prior to the point of sale;\n\nProposal for end-of-life vehicles regulation refers to  REGULATION (EU) 2018/858 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 30 May 2018 on the approval and market surveillance of motor vehicles and their trailers, and of systems, components and separate technical units intended for such vehicles, amending Regulations (EC) No 715/2007 and (EC) No 595/2009 and repealing Directive 2007/46/EC  in Article 3 (19) \n component  means a device that is intended to be part of a vehicle, that can be type-approved independently of a vehicle and that is subject to the requirements of this Regulation or any of the regulatory acts listed in Annex II where the specific regulatory act makes express provision to that effect;  \nArticle 31 sets out the obligations concerning removed parts and components to assess their fitness for reuse, remanufacturing, refurbishment, recycling, or other treatment operations and how they should be labelled. It also provides a list of parts that should not be reused, remanufactured or refurbished."@en ;
+   samm:characteristic :ComponentList .
+
+:materials a samm:Property ;
+   samm:preferredName "Materials"@en ;
+   samm:description "Properties which are relevant for the materials of the product."@en ;
+   samm:characteristic :MaterialList .
+
+:NameList a samm-c:List ;
+   samm:preferredName "Name List"@en ;
+   samm:description "List of names or organizations (can be a name, trade mark, etc.)"@en ;
+   samm:dataType xsd:string .
+
+:FacilityList a samm-c:List ;
+   samm:preferredName "Facility List"@en ;
+   samm:description "List of facilities."@en ;
+   samm:dataType :FacilityEntity .
+
+:ManufacturerCharacteristic a samm:Characteristic ;
+   samm:preferredName "Manufacturer Characteristic"@en ;
+   samm:description "Characteristic of the manufacturer of the product."@en ;
+   samm:dataType :ManufacturerEntity .
+
+:ImporterCharacteristic a samm:Characteristic ;
+   samm:preferredName "Importer Characteristic"@en ;
+   samm:description "Characteristic with information regarding the importer."@en ;
+   samm:dataType :ImporterEntity .
+
+:ExtendedProducerResponsibilitySchemeInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Extended Producer Responsibility Scheme Information Characteristic"@en ;
+   samm:description "Characteristic of Extended Producer Responsibility Scheme Information."@en ;
+   samm:dataType :ExtendedProducerResponsibilitySchemeInformationEntity .
+
+:SparePartProviderList a samm-c:List ;
+   samm:preferredName "Spare Part Provider List"@en ;
+   samm:description "List of possible spare part providers."@en ;
+   samm:dataType :SparePartProviderEntity .
+
+:LifeEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Life Enumeration"@en ;
+   samm:description "Enumeration with the possible units day, month, cycle, year and runningOrOperatingHour."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "unit:day" "unit:month" "unit:year" "unit:cycle" "unit:runningOrOperatingHour" ) .
+
+:LifeValueCharacteristic a samm-c:Quantifiable ;
+   samm:preferredName "Life Value Characteristic"@en ;
+   samm:description "Characteristic for the life span value as an integer."@en ;
+   samm:dataType xsd:integer .
+
+:LifeTypeEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Life Type Enumeration"@en ;
+   samm:description "Enumeration with the values guaranteed lifetime, technical lifetime and mean time between failures."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "guaranteed lifetime" "technical lifetime" "mean time between failures" ) .
+
+:FootprintList a samm-c:List ;
+   samm:preferredName "Footprint List"@en ;
+   samm:description "Footprint List for the environmental footprint."@en ;
+   samm:dataType :FootprintEntity .
+
+:ReusabilityInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Reusability Information Characteristic"@en ;
+   samm:description "Characteristic of the reusability information."@en ;
+   samm:dataType :ReusabilityInformationEntity .
+
+:UnitCatalog a samm:Characteristic ;
+   samm:preferredName "Unit Catalog"@en ;
+   samm:description "Link to the unit catalog with all possible units in the format \"unit:xxx\"."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:dataType xsd:string .
+
+:DataTypeEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Data Type Enumeration"@en ;
+   samm:description "Data type that describe the content of the attributes children and data. In case \"object\" is selected in the enumeration, the children field will be used in the AdditionalDataEntity instead of the \"data\" property. If it is an other type, the content will be specified in \"data\" as a string."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:see <https://www.w3.org/2001/XMLSchema> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "array" "object" "xsd:string" "xsd:integer" "xsd:boolean" "xsd:double" "xsd:float" "xsd:byte" ) .
+
+:ComponentList a samm-c:List ;
+   samm:preferredName "Component List"@en ;
+   samm:description "List of components/parts of the product."@en ;
+   samm:dataType :ComponentEntity .
+
+:MaterialList a samm-c:List ;
+   samm:preferredName "Material List"@en ;
+   samm:description "A list of different materials in the product."@en ;
+   samm:dataType :MaterialEntity .
+
+:FacilityEntity a samm:Entity ;
+   samm:preferredName "Facility Entity"@en ;
+   samm:description "The entity for a facility with the BPNA identifier."@en ;
+   samm:properties ( :facilityIdentification :facilityAddress ) .
+
+:ManufacturerEntity a samm:Entity ;
+   samm:preferredName "Manufacturer Entity"@en ;
+   samm:description "Entity for the information of the manufacturer."@en ;
+   samm:properties ( :manufacturerIdentification :manufacturerNames :manufacturerAddress :manufacturerContact ) .
+
+:ImporterEntity a samm:Entity ;
+   samm:preferredName "Importer Entity"@en ;
+   samm:description "Entity with information regarding the importer such as the identification and the EORI."@en ;
+   samm:properties ( :eori :importerIdentification :importerNames :importerAddress :importerContact ) .
+
+:ExtendedProducerResponsibilitySchemeInformationEntity a samm:Entity ;
+   samm:preferredName "Extended Producer Responsibility Scheme Information Entity"@en ;
+   samm:description "Entity for Extended Producer Responsibility Scheme Information."@en ;
+   samm:properties ( :symbolsOfExtendedProducerResponsibilityScheme :territoriesOfApplication [ samm:property :collectionPoints; samm:optional true ] ) .
+
+:SparePartProviderEntity a samm:Entity ;
+   samm:preferredName "Spare Part Provider Entity"@en ;
+   samm:description "Entity for information about the provider company of the spare part."@en ;
+   samm:properties ( :sparePartProviderIdentification :sparePartProviderAddress :sparePartProviderContact ) .
+
+:FootprintEntity a samm:Entity ;
+   samm:preferredName "Footprint Entity"@en ;
+   samm:description "Footprint Entity for the carbon and environmental footprint with the total value, unit, impact category type, lifecycle, rulebook, declaration, performance class and the facility."@en ;
+   samm:properties ( [ samm:property :footprintValue; samm:payloadName "value" ] [ samm:property :footprintRulebook; samm:payloadName "rulebook" ] [ samm:property :footprintLifecycle; samm:payloadName "lifecycle" ] [ samm:property :footprintUnit; samm:payloadName "unit" ] [ samm:property :footprintType; samm:payloadName "type" ] [ samm:property :performanceClass; samm:optional true ] :manufacturingPlant :declaration ) .
+
+:ReusabilityInformationEntity a samm:Entity ;
+   samm:preferredName "Reusability Information Entity"@en ;
+   samm:description "Entity for the reusability information of the product."@en ;
+   samm:properties ( :reuseInfo :reuseSystem ) .
+
+:ComponentEntity a samm:Entity ;
+   samm:preferredName "Component Entity"@en ;
+   samm:description "Entity for information about the product components."@en ;
+   samm:properties ( [ samm:property :componentName; samm:optional true ] :componentCode [ samm:property :componentDescription; samm:optional true ] [ samm:property :componentLocations; samm:optional true ] :componentSortingInformation [ samm:property :componentPassportIdentifier; samm:optional true ] ) .
+
+:MaterialEntity a samm:Entity ;
+   samm:preferredName "Material Entity"@en ;
+   samm:description "Information regarding recycled and/or renewable materials in the product."@en ;
+   samm:properties ( :recycled :materialIdentifications :materialDocuments :substancesOfConcernInformation [ samm:property :materialType; samm:optional true ] [ samm:property :materialOrigin; samm:optional true ] [ samm:property :materialPassportIdentifier; samm:optional true ] [ samm:property :materialLocations; samm:optional true ] :declarableIngredient :concentrationInformation ) .
+
+:facilityIdentification a samm:Property ;
+   samm:preferredName "Facility Identification"@en ;
+   samm:description "The identifier used for a location.  In the CATENA-X use case, the BPNA can be stated. \n\nThis attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Annex III:\n(i) unique facility identifiers;\nArticle 2 Definitions: (33) 'unique facility identifier' means a unique string of characters for the identification of locations or buildings involved in the value chain of a product or used by actors involved in the value chain of a product."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BPNA1234567890AA" .
+
+:facilityAddress a samm:Property ;
+   samm:preferredName "Facility Address"@en ;
+   samm:description "Full address of the facility."@en ;
+   samm:characteristic ext-characteristic:PostalAddress .
+
+:manufacturerIdentification a samm:Property ;
+   samm:preferredName "Manufacturer Identification"@en ;
+   samm:description "The main manufacturer represented by an identification number. In the Catena-X use case, the BPNL can be stated. "@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BPNL0123456789ZZ" .
+
+:manufacturerNames a samm:Property ;
+   samm:preferredName "Manufacturer Names"@en ;
+   samm:description "Name, registered trade name or registered trade mark of the manufacturer."@en ;
+   samm:characteristic :NameList ;
+   samm:exampleValue "ABC" .
+
+:manufacturerAddress a samm:Property ;
+   samm:preferredName "Manufacturer Address"@en ;
+   samm:description "Full address of the manufacturer."@en ;
+   samm:characteristic ext-characteristic:PostalAddress .
+
+:manufacturerContact a samm:Property ;
+   samm:preferredName "Manufacturer Contact"@en ;
+   samm:description "Contact details of the manufacturer."@en ;
+   samm:characteristic ext-information2:ContactCharacteristic .
+
+:eori a samm:Property ;
+   samm:preferredName "EORI"@en ;
+   samm:description "An economic operator established in the customs territory of the Union needs, for customs purposes, an EORI number. EORI stands for economic operators registration and identification number. In this case, the importer's EORI must be provided. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex III:\n(j) information related to the importer, including the information referred to in Article 23(3) and its EORI number."@en ;
+   samm:see <https://taxation-customs.ec.europa.eu/customs-4/customs-procedures-import-and-export-0/customs-procedures/economic-operators-registration-and-identification-number-eori_en> ;
+   samm:characteristic :EoriTrait ;
+   samm:exampleValue "GB123456789000" .
+
+:importerIdentification a samm:Property ;
+   samm:preferredName "Importer Identification"@en ;
+   samm:description "The importer of the product, if different from the owner of the passport. In the Catena-X network, BPNL can be used.\n\nThis attribute is mentioned in the ESPR provisional agreement from January 9th, 2024  Annex III:\n(j) information related to the importer, including the information referred to in Article 23(3) and its EORI number;\nArticle 23 states:\n(3) Importers shall, for products covered by a delegated act adopted pursuant to Article 4, indicate their name, registered trade name or registered trade mark and the postal address and electronic means of communication, where they can be contacted:  (a) on the public part of the product passport, when applicable, and\n(b) on the product or, where this is not possible, on the packaging, or in a document accompanying the product."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BPNL0123456789ZZ" .
+
+:importerNames a samm:Property ;
+   samm:preferredName "importer Names"@en ;
+   samm:description "Name, registered trade name, or registered trademark of the importer."@en ;
+   samm:characteristic :NameList ;
+   samm:exampleValue "ABC" .
+
+:importerAddress a samm:Property ;
+   samm:preferredName "Importer Address"@en ;
+   samm:description "Full address of the importer."@en ;
+   samm:characteristic ext-characteristic:PostalAddress .
+
+:importerContact a samm:Property ;
+   samm:preferredName "Importer Contact"@en ;
+   samm:description "Contact details of the importer."@en ;
+   samm:characteristic ext-information2:ContactCharacteristic .
+
+:symbolsOfExtendedProducerResponsibilityScheme a samm:Property ;
+   samm:preferredName "Symbol Of Extended Producer Responsibility Scheme"@en ;
+   samm:description "Symbol.\nThis is mentioned in the Regulation (EU) 2025/40  \n(71) \nTo help achieve the objectives of this Regulation, consumers should be protected from misleading and confusing information about the characteristics and appropriate end-of-life treatment of packaging for which harmonised labels have been established under this Regulation. It should be possible to identify packaging included in the extended producer responsibility scheme by a corresponding symbol throughout the territory in which that scheme applies in order to signify that the producer fulfils its extended producer responsibility obligations. Such identification should be achieved only by means of a QR code or other standardised, open, digital-marking technology. That symbol should be clear and unambiguous to consumers as to the recyclability of packaging.\n\n This is mentioned in the Regulation (EU) 2025/40  Article 12:\n9.   By 12 February 2027, packaging included in an extended producer responsibility scheme may be identified throughout the territory of the Member States in which that scheme or system applies. Such identification shall be achieved only by means of a corresponding symbol in a QR code or other standardised, open, digital-marking technology in order to indicate that the producer fulfils its extended producer responsibility obligations. That symbol shall be clear and unambiguous and shall not mislead consumers or other end users as to the recyclability or reusability of the packaging.\n\n(15)  producer  means any manufacturer, importer or distributor to whom, irrespective of the selling technique used, including by means of distance contracts, one of the following applies:\n(a) the manufacturer, importer or distributor is established in a Member State and makes available for the first time from within the territory of that Member State and on that same territory transport packaging, service packaging, or primary production packaging, whether as single-use packaging or as reusable packaging; or\n(b) the manufacturer, importer or distributor is established in a Member State and makes available for the first time from within the territory of that Member State and on that same territory products packaged in packaging other than those referred to in point (a); or\n(c) the manufacturer, importer or distributor is established in a Member State or in a third country and makes available for the first time on the territory of another Member State, directly to end users, transport packaging, service packaging or primary production packaging, whether as single-use packaging or as reusable packaging; or\n(d) the manufacturer, importer or distributor is established in a Member State or in a third country and makes available for the first time on the territory of another Member State, directly to end users, products packaged in packaging other than those referred to in point (c); or\n(e)the manufacturer, importer or distributor is established in a Member State and unpacks packaged products without being an end user, unless another person is the producer as defined in point (a), (b), (c) or (d);"@en ;
+   samm:characteristic :SymbolOfExtendedProducerResponsibilitySchemeList .
+
+:territoriesOfApplication a samm:Property ;
+   samm:preferredName "Territories Of Application"@en ;
+   samm:description "Information about territories where the Extended Producer Responsibility Scheme applies. 2 letter code from ISO 3166.\n\nDIRECTIVE 2008/98/EC OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 19 November 2008 on waste and repealing certain Directives\nArticle 2 (21). extended producer responsibility scheme  means a set of measures taken by Member States to ensure that producers of products bear financial responsibility or financial and organisational responsibility for the management of the waste stage of a product s life cycle."@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "DE" .
+
+:collectionPoints a samm:Property ;
+   samm:preferredName "Collection Points"@en ;
+   samm:description "Information on collection points."@en ;
+   samm:characteristic :CollectionPointList .
+
+:sparePartProviderIdentification a samm:Property ;
+   samm:preferredName "Spare Part Provider Identification"@en ;
+   samm:description "The identifier of a spare part producer of the product. In the Catena-X network, the BPNL is used for the identification of companies and the information stored for this like contact information and addresses."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BPNL0123456789ZZ" .
+
+:sparePartProviderAddress a samm:Property ;
+   samm:preferredName "Spare Part Provider Address"@en ;
+   samm:description "Full address of the provider company of the spare part."@en ;
+   samm:characteristic ext-characteristic:PostalAddress .
+
+:sparePartProviderContact a samm:Property ;
+   samm:preferredName "Spare Part Provider Contact"@en ;
+   samm:description "Contact details of the provider company of the spare part."@en ;
+   samm:characteristic ext-information2:ContactCharacteristic .
+
+:footprintValue a samm:Property ;
+   samm:preferredName "Footprint Value"@en ;
+   samm:description "The value of the footprint of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Annex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories;\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product.\n"@en ;
+   samm:characteristic :PositiveTrait ;
+   samm:exampleValue "12.678"^^xsd:float .
+
+:footprintRulebook a samm:Property ;
+   samm:preferredName "Footprint Rulebook"@en ;
+   samm:description "The applied rulebook for the environmental footprint of the product."@en ;
+   samm:characteristic :DocumentList .
+
+:footprintLifecycle a samm:Property ;
+   samm:preferredName "Footprint Lifecycle"@en ;
+   samm:description "The lifecycle stage, to which the environmental footprint corresponds. These could be for example \"raw material acquisition and pre-processing\", \"main product production\", \"distribution\" or \"end of life and recycling\"."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "main product production" .
+
+:footprintUnit a samm:Property ;
+   samm:preferredName "Footprint Unit"@en ;
+   samm:description "The unit of measurement of the environmental impact category. For each impact category a specific unit is used. If an aggregation is used, utilize the normalization and weighting methods used in the referenced rulebook."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "kg CO2 / kWh" .
+
+:footprintType a samm:Property ;
+   samm:preferredName "Footprint Type"@en ;
+   samm:description "The type of the environmental footprint of the product. This could be one of the environmental impact categories. This attribute is mentioned in the ESPR provisional agreement from January 9th 2024 Article 7:\n(2)(b)(i) information on the performance of the product in relation to one or more of the product parameters referred to in Annex I, including a scoring of reparability or durability, carbon footprint or environmental footprint;\nAnnex I:\n(l) the environmental footprint of the product, expressed as a quantification, in accordance with the applicable delegated act, of a product's life cycle environmental impacts, whether in relation to one or more environmental impact categories or an aggregated set of impact categories.\n(m) the carbon footprint of the product;\n(ma) the material footprint of the product."@en ;
+   samm:characteristic :CategoryEnumeration ;
+   samm:exampleValue "Climate Change" .
+
+:performanceClass a samm:Property ;
+   samm:preferredName "Performance Class"@en ;
+   samm:description "The performance classification of the footprint."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A" .
+
+:manufacturingPlant a samm:Property ;
+   samm:preferredName "Manufacturing Plant"@en ;
+   samm:description "The manufacturing plant of the footprint in the specific lifecycle phase."@en ;
+   samm:characteristic :FacilityList .
+
+:declaration a samm:Property ;
+   samm:preferredName "Declaration"@en ;
+   samm:description "The footprint declaration in the format of a link "@en ;
+   samm:characteristic :DocumentList .
+
+:reuseInfo a samm:Property ;
+   samm:preferredName "Reuse Info"@en ;
+   samm:description "Information about whether product is reusable or not, and description of the type of reuse, and possibilities of the reuse."@en ;
+   samm:characteristic samm-c:Text .
+
+:reuseSystem a samm:Property ;
+   samm:preferredName "Reuse System"@en ;
+   samm:description "Information about the reuse system."@en ;
+   samm:characteristic :ReuseSystemCharacteristic .
+
+:componentName a samm:Property ;
+   samm:preferredName "Component Name"@en ;
+   samm:description "Name of the component. If the product has only one component (the product itself), a comment is enough.\n\nThis field must be used where the product consists multiple components, and where these components are made of different materials as assigned by the manufacturer of a product."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Top lid" .
+
+:componentCode a samm:Property ;
+   samm:preferredName "Component Code"@en ;
+   samm:description "An identifier assigned to the component."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "ABC123" .
+
+:componentDescription a samm:Property ;
+   samm:preferredName "Component Description"@en ;
+   samm:description "Short description of component, including function or specification. Information can include data about component type, weight."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Yellow bin" .
+
+:componentLocations a samm:Property ;
+   samm:preferredName "Component Locations"@en ;
+   samm:description "Locations or positions of the component within the product."@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "The screw cap is located at the top of the container." .
+
+:componentSortingInformation a samm:Property ;
+   samm:preferredName "Component Sorting Information"@en ;
+   samm:description "Description of how to sort the component."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Yellow waste bin is appropriate for discard this component. Group component by diameter for efficient storage. Rinse and remove food residues to ensure cleanliness." .
+
+:componentPassportIdentifier a samm:Property ;
+   samm:preferredName "Component Passport Identifier"@en ;
+   samm:description "The identifier of the component passport, which is a uuidv4."@en ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
+   samm:exampleValue "urn:uuid:550e8400-e29b-41d4-a716-446655440000" .
+
+:recycled a samm:Property ;
+   samm:preferredName "Recycled"@en ;
+   samm:description "The share of the material, which is recovered recycled content from the product. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(h) use or content of recycled materials and recovery of materials, including critical raw materials;"@en ;
+   samm:characteristic :PercentageTrait ;
+   samm:exampleValue "12.5"^^xsd:float .
+
+:materialIdentifications a samm:Property ;
+   samm:preferredName "Material Identifications"@en ;
+   samm:description "The chemical material name and identification, in accordance with the specification in the attribute for the list type. Preference is given to the IUPAC name. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 7:\n(5) (a) the name of the substances of concern present in the product, as follows:\n - name(s) in the International Union of Pure and Applied Chemistry (IUPAC) nomenclature, or another international name when IUPAC name is not available; \n- other names (usual name, trade name, abbreviation);\n- European Community (EC) number, as indicated in the European Inventory of Existing Commercial Chemical Substances (EINECS), the European List of Notified Chemical Substances (ELINCS) or the No Longer Polymer (NLP) list or assigned by the European Chemicals Agency (ECHA), if available;\n- the Chemical Abstract Service (CAS) name(s) and number(s), if available; ."@en ;
+   samm:characteristic :MaterialIdentificationList .
+
+:materialDocuments a samm:Property ;
+   samm:preferredName "Material Documents"@en ;
+   samm:description "Documentation accompanying the material."@en ;
+   samm:characteristic :DocumentList .
+
+:substancesOfConcernInformation a samm:Property ;
+   samm:preferredName "Substances of Concern Information"@en ;
+   samm:description "Information regarding substances of concern in the product. The ESPR provisional agreement from January 9th, 2024 defines:\n(52) 'hazardous substance' means a substance classified as hazardous pursuant to Article 3 of Regulation (EC) No 1272/2008."@en ;
+   samm:characteristic :SubstancesOfConcernInformationCharacteristic .
+
+:materialType a samm:Property ;
+   samm:preferredName "Material Type"@en ;
+   samm:description "Information refers to the specific category of material intentionally or unintentionally incorporated into the product. Can inform about multi-constituent substances or other aspects that can be associated with the proper identification of material or informing about Substance of Unknown or Variable composition, Complex reaction products or Biological material."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "impurity" .
+
+:materialOrigin a samm:Property ;
+   samm:preferredName "Material Origin"@en ;
+   samm:description "Country of material origin. 2 letter code from ISO 3166.\n\nAttribute is mentioned in Regulation (EU) 2017/821 of the European Parliament and of the Council of 17 May 2017 laying down supply chain due diligence obligations for Union importers of tin, tantalum and tungsten, their ores, and gold originating from conflict-affected and high-risk areas. \nArticle 4: Management system obligations\nUnion importers of minerals or metals shall:\n(a) adopt, and clearly communicate to suppliers and the public up-to-date information on, their supply chain policy for the minerals and metals potentially originating from conflict-affected and high-risk areas;\n\nThis attribute is mentioned in: COMMUNICATION FROM THE COMMISSION TO THE EUROPEAN PARLIAMENT, THE COUNCIL, THE EUROPEAN ECONOMIC AND SOCIAL COMMITTEE AND THE COMMITTEE OF THE REGIONS EU Strategy for Sustainable and Circular Textiles \n2.4.Introducing information requirements and a Digital Product Passport\n[...] To ensure consistency with this new piece of legislation, the Commission will also review the Textile Labelling Regulation, which requires textiles sold on the EU market to carry a label clearly identifying the fibre composition and indicating any non-textile parts of animal origin. As part of this review and subject to an impact assessment, the Commission will introduce mandatory disclosure of other types of information, such as sustainability and circularity parameters, products  size and, where applicable, the country where manufacturing processes take place ( made in ).\n\nDirective (EU) 2024/1760 of the European Parliament and of the Council of 13 June 2024 on corporate sustainability due diligence and amending Directive (EU) 2019/1937 and Regulation (EU) 2023/2859 also demand in non\nfinancial statement this kind of information.\n\nThis attribute often appear in different voluntary certification and labelling schemes."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "CN" .
+
+:materialPassportIdentifier a samm:Property ;
+   samm:preferredName "material Passport Identifier"@en ;
+   samm:description "The identifier of the material passport, which is a uuidv4."@en ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
+   samm:exampleValue "urn:uuid:550e8400-e29b-41d4-a716-446655440000" .
+
+:materialLocations a samm:Property ;
+   samm:preferredName "Material Locations"@en ;
+   samm:description "Locations/positions of the material within the product."@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "handle" .
+
+:declarableIngredient a samm:Property ;
+   samm:preferredName "Declarable Ingredient"@en ;
+   samm:description "Declaration of ingredients contained within a product, product part, or material as applicable.  The information required to determine product compliance with ingredients regulations, standards, and market needs. \nExamples of typical ingredient lists that could be reported depend on the regulatory standard requirements or restricted substances lists (e.g., AFIRM, GADSL), limitation of concentrations :\nCritical raw materials, Renewable Materials, Compostable Materials, Microorganisms, Alergens, Fragrances, Ingredients in surfactants ordered by concentration ranges, Textile fibers, Annex IV of the POP Regulation, declaration of articles with SVHC above 0,1%, etc., declaration regarding microplastics or nanomaterials.\n\nExamples are renewable materials:\nThe share of the material, which is from a renewable resource that can be replenished. These are the kind of resources that can be regenerated throughout time. Forest wood, for example, can be grown through reforestation. This attribute is mentioned in the Regulation (EU) 2024/1781 of the European Parliament and of the Council of 13 June 2024 establishing a framework for the setting of ecodesign requirements for sustainable products, Annex I:\n(i) use or content of sustainable renewable materials;\n\nExamples are critical raw materials: \nThis attribute is mentioned in Regulation (EU) 2024/1781 of the European Parliament and of the Council of 13 June 2024 establishing a framework for the setting of ecodesign requirements for sustainable products, Annex I:\n(h) use or content of recycled materials and recovery of materials, including critical raw materials;\nIn Annex II of the connected Regulation (EU) 2024/1252 of the European Parliament and of the Council of 11 April 2024 establishing a framework for ensuring a secure and sustainable supply of critical raw materials, a list of critical raw materials can be found."@en ;
+   samm:characteristic :DeclarableIngredientCharacteristic .
+
+:concentrationInformation a samm:Property ;
+   samm:preferredName "concentration Information"@en ;
+   samm:description "Information about the concentration of the material at the product level."@en ;
+   samm:characteristic :ConcentrationInformationCharacteristic .
+
+:EoriTrait a samm-c:Trait ;
+   samm:preferredName "Eori Trait"@en ;
+   samm:description "Trait to limit the input to the specified format of an eori."@en ;
+   samm-c:baseCharacteristic :IdentifierCharacteristic ;
+   samm-c:constraint :EoriConstraint .
+
+:SymbolOfExtendedProducerResponsibilitySchemeList a samm-c:List ;
+   samm:preferredName "Symbol Of Extended Producer Responsibility Scheme List"@en ;
+   samm:description "List of the Extended Producer Responsibility Scheme symbols"@en ;
+   samm:dataType :SymbolOfExtendedProducerResponsibilitySchemeEntity .
+
+:CollectionPointList a samm-c:List ;
+   samm:preferredName "Collection Point List"@en ;
+   samm:description "List of collection points."@en ;
+   samm:dataType :CollectionPointEntity .
+
+:PositiveTrait a samm-c:Trait ;
+   samm:preferredName "Positive Trait"@en ;
+   samm:description "Trait for positive values."@en ;
+   samm-c:baseCharacteristic :FloatValue ;
+   samm-c:constraint :PositiveRangeConstraint .
+
+:CategoryEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Category Enumeration"@en ;
+   samm:description "Enumeration of the 19 impact categories in accordance to EN15804+A2."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Climate Change Total" "Climate Change Fossil" "Climate Change Biogenic Removals and Emissions" "Climate Change Land Use and Land Use Change" "Ozone Depletion" "Acidification" "Eutrophication Aquatic Freshwater" "Eutrophication Fresh Marine" "Eutrophication Terrestrial" "Photochemical Ozone Formation" "Abiotic Depletion- Minerals and Metals" "Fossil Fuels" "Water Use" "Particulate Matter Emissions" "Ionizing Radiation, Human Health" "Eco-Toxicity" "Human Toxicity, Cancer Effects" "Human Toxicity, Non-Cancer Effects" "Land Use Related Impacts/Soil Quality" ) .
+
+:ReuseSystemCharacteristic a samm:Characteristic ;
+   samm:preferredName "Reuse System Characteristic"@en ;
+   samm:description "Characteristic of the reuse system property."@en ;
+   samm:dataType :ReuseSystemEntity .
+
+:PercentageTrait a samm-c:Trait ;
+   samm:preferredName "Percentage Trait"@en ;
+   samm:description "Trait for a positive percentage."@en ;
+   samm-c:baseCharacteristic :Share ;
+   samm-c:constraint :PercentageConstraint .
+
+:MaterialIdentificationList a samm-c:List ;
+   samm:preferredName "Material Identification List"@en ;
+   samm:description "List of Material Identifications."@en ;
+   samm:dataType :MaterialIdentificationEntity .
+
+:SubstancesOfConcernInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Substances Of Concern Information Characteristic"@en ;
+   samm:description "Characteristic of the Substances of concern Information."@en ;
+   samm:dataType :SubstancesOfConcernInformationEntity .
+
+:DeclarableIngredientCharacteristic a samm:Characteristic ;
+   samm:preferredName "Declarable Ingredient Characteristic"@en ;
+   samm:description "Charachteristic of declarable ingredient."@en ;
+   samm:dataType :DeclarableIngredientEntity .
+
+:ConcentrationInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Concentration Information Characteristic"@en ;
+   samm:description "Characteristic of the Concentration Information."@en ;
+   samm:dataType :ConcentrationInformationEntity .
+
+:EoriConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "EORI Constraint"@en ;
+   samm:description "Constraint with a pattern which ensures that the EORI number starts with two alphanumeric characters, followed by two alphabetic characters, and ends with 2 to 15 alphanumeric characters."@en ;
+   samm:value "^[A-Z]{2}[A-Z0-9]{1,18}$" .
+
+:SymbolOfExtendedProducerResponsibilitySchemeEntity a samm:Entity ;
+   samm:preferredName "Symbol Of Extended Producer Responsibility Scheme Entity"@en ;
+   samm:description "Entity for the information about Extended Producer Responsibility Scheme Symbols."@en ;
+   samm:properties ( :header :content :contentType ) .
+
+:CollectionPointEntity a samm:Entity ;
+   samm:preferredName "Collection Point Entity"@en ;
+   samm:description "Entity for information about collection points."@en ;
+   samm:properties ( :collectionPointIdentification :collectionPointAddress ) .
+
+:FloatValue a samm-c:Quantifiable ;
+   samm:preferredName "Float Value"@en ;
+   samm:description "Float number representing a positive value."@en ;
+   samm:dataType xsd:float .
+
+:PositiveRangeConstraint a samm-c:RangeConstraint ;
+   samm:preferredName "Positive Range Constraint"@en ;
+   samm:description "Constraint for only positive values."@en ;
+   samm-c:minValue "0.0"^^xsd:float ;
+   samm-c:lowerBoundDefinition samm-c:AT_LEAST ;
+   samm-c:upperBoundDefinition samm-c:LESS_THAN .
+
+:ReuseSystemEntity a samm:Entity ;
+   samm:preferredName "Reuse System Entity"@en ;
+   samm:description "Entity for the reuse system information."@en ;
+   samm:properties ( :applicable [ samm:property :reuseSystemInformation; samm:optional true; samm:payloadName "content" ] ) .
+
+:Share a samm-c:Measurement ;
+   samm:preferredName "share"@en ;
+   samm:description "The share represented in a float number in the unit percent."@en ;
+   samm:dataType xsd:float ;
+   samm-c:unit unit:percent .
+
+:PercentageConstraint a samm-c:RangeConstraint ;
+   samm:preferredName "Percentage Constraint"@en ;
+   samm:description "Range constraint for a positive percentage value."@en ;
+   samm-c:minValue "0.0"^^xsd:float ;
+   samm-c:maxValue "100.0"^^xsd:float ;
+   samm-c:lowerBoundDefinition samm-c:AT_LEAST ;
+   samm-c:upperBoundDefinition samm-c:AT_MOST .
+
+:MaterialIdentificationEntity a samm:Entity ;
+   samm:preferredName "Material Identification Entity"@en ;
+   samm:description "Entity for material identification."@en ;
+   samm:properties ( :materialName :materialId :materialListTypeId ) .
+
+:SubstancesOfConcernInformationEntity a samm:Entity ;
+   samm:preferredName "Substances Of Concern Information Entity"@en ;
+   samm:description "Entity for the Substances of Concern Information with attributes if applicable to the product."@en ;
+   samm:properties ( :applicable [ samm:property :substanceOfConcern; samm:optional true; samm:payloadName "content" ] ) .
+
+:DeclarableIngredientEntity a samm:Entity ;
+   samm:preferredName "Declarable Ingredient Entity"@en ;
+   samm:description "Entity for declarable ingredient information."@en ;
+   samm:properties ( :applicable [ samm:property :declarableIngredientLists; samm:optional true; samm:payloadName "content" ] ) .
+
+:ConcentrationInformationEntity a samm:Entity ;
+   samm:preferredName "Concentration Information Entity"@en ;
+   samm:description "Entity for Concentration Information."@en ;
+   samm:properties ( :concentration [ samm:property :concentrationRange; samm:optional true ] ) .
+
+:collectionPointIdentification a samm:Property ;
+   samm:preferredName "Collection Point Identification"@en ;
+   samm:description "The identifier used for a location."@en ;
+   samm:characteristic samm-c:Text .
+
+:collectionPointAddress a samm:Property ;
+   samm:preferredName "Collection Point Address"@en ;
+   samm:description "Full address of the collection point for reusable products."@en ;
+   samm:characteristic ext-characteristic:PostalAddress .
+
+:reuseSystemInformation a samm:Property ;
+   samm:preferredName "Reuse System Information"@en ;
+   samm:description "Documentation and identification of the reuse system."@en ;
+   samm:characteristic :ReuseSystemInformationCharacteristic .
+
+:materialName a samm:Property ;
+   samm:preferredName "Material Name"@en ;
+   samm:description "The name of the material that is present in the product."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "phenolphthalein" .
+
+:materialId a samm:Property ;
+   samm:preferredName "Material Id"@en ;
+   samm:description "The material identification, in accordance with the specification in the attribute for the list type."@en ;
+   samm:characteristic :IdentifierCharacteristic ;
+   samm:exampleValue "201-004-7" .
+
+:materialListTypeId a samm:Property ;
+   samm:preferredName "Material List Type Id"@en ;
+   samm:description "The type of standard used for the identification of the substances. Selected can be for example CAS, IUPAC or EC."@en ;
+   samm:characteristic :ListTypeIdEnumeration ;
+   samm:exampleValue "CAS" .
+
+:substanceOfConcern a samm:Property ;
+   samm:preferredName "Substance of Concern"@en ;
+   samm:description "Information regarding substance of concern in the product. Attributes are among others substance names, ids, concentration, location and hazard class. This is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 7:\n(5) (a) the name of the substances of concern present in the product, as follows:\n- name(s) in the International Union of Pure and Applied Chemistry (IUPAC) nomenclature, or another international name when IUPAC name is not available; \n- other names (usual name, trade name, abbreviation);\n- European Community (EC) number, as indicated in the European Inventory of Existing Commercial Chemical Substances (EINECS), the European List of Notified Chemical Substances (ELINCS) or the No Longer Polymer (NLP) list or assigned by the European Chemicals Agency (ECHA), if available;\n- the Chemical Abstract Service (CAS) name(s) and number(s), if available;\n(5) (b) the location of the substances of concern within the product.\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product its relevant components, or spare parts;\n(d) relevant instructions for the safe use of the product;\n(e) information relevant for disassembly, preparation for reuse, reuse, recycling and the environmentally sound management of the product at the end of its life.\nAnd in the next paragraph:\n(c) provide duly justified exemptions for substances of concern or information elements from the information requirements referred to in the first subparagraph."@en ;
+   samm:characteristic :SubstanceOfConcernCharacteristic .
+
+:declarableIngredientLists a samm:Property ;
+   samm:preferredName "Declarable Ingredient Lists"@en ;
+   samm:description "Declaration of ingredients contained within a product, product part, or material as applicable.  The information required to determine product compliance with ingredients regulations, standards, and market needs. \nExamples of typical ingredient lists that could be reported depend on the regulatory standard requirements or restricted substances lists (e.g., AFIRM, GADSL), limitation of concentrations :\nCritical raw materials, Renewable Materials, Compostable Materials, Microorganisms, Alergens, Fragrances, Ingredients in surfactants ordered by concentration ranges, Textile fibers, Annex IV of the POP Regulation, declaration of articles with SVHC above 0,1%, etc., declaration regarding microplastics or nanomaterials.\n\nExamples are renewable materials:\nThe share of the material, which is from a renewable resource that can be replenished. These are the kind of resources that can be regenerated throughout time. Forest wood, for example, can be grown through reforestation. This attribute is mentioned in the Regulation (EU) 2024/1781 of the European Parliament and of the Council of 13 June 2024 establishing a framework for the setting of ecodesign requirements for sustainable products, Annex I:\n(i) use or content of sustainable renewable materials;\n\nExamples are critical raw materials: \nThis attribute is mentioned in Regulation (EU) 2024/1781 of the European Parliament and of the Council of 13 June 2024 establishing a framework for the setting of ecodesign requirements for sustainable products, Annex I:\n(h) use or content of recycled materials and recovery of materials, including critical raw materials;\nIn Annex II of the connected Regulation (EU) 2024/1252 of the European Parliament and of the Council of 11 April 2024 establishing a framework for ensuring a secure and sustainable supply of critical raw materials, a list of critical raw materials can be found."@en ;
+   samm:characteristic :ListOfDeclarableIngredientList .
+
+:concentration a samm:Property ;
+   samm:preferredName "Concentration"@en ;
+   samm:description "Concentration of the material at the level of the product. "@en ;
+   samm:characteristic :ConcentrationCharacteristic .
+
+:concentrationRange a samm:Property ;
+   samm:preferredName "Concentration Range"@en ;
+   samm:description "The concentration range for the substance of concern. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) [...] concentration range of the substances of concern, at the level of the product [...]."@en ;
+   samm:characteristic :RangeCharacteristic .
+
+:ReuseSystemInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Reuse System Information Characteristic"@en ;
+   samm:description "Characteristic of the reuse system information."@en ;
+   samm:dataType :ReuseSystemInformationEntity .
+
+:ListTypeIdEnumeration a samm-c:Enumeration ;
+   samm:preferredName "List Type Id Enumeration"@en ;
+   samm:description "Enumeration of different systems and organizations related to the identification and classification of chemical substances in the field of chemistry. The enumeration values are EC or CAS."@en ;
+   samm:see <https://www.cas.org/cas-data/cas-registry> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "CAS" "EC" "IUPAC" "InChl" "INCI" "SMILES" ) .
+
+:SubstanceOfConcernCharacteristic a samm:Characteristic ;
+   samm:preferredName "Substance Of Concern Characteristic"@en ;
+   samm:description "Characteristic of substance of concern."@en ;
+   samm:dataType :SubstanceOfConcernEntity .
+
+:ListOfDeclarableIngredientList a samm-c:List ;
+   samm:preferredName "List Of Declarable Ingredient List"@en ;
+   samm:description "List of declarable ingredient list(s)."@en ;
+   samm:dataType :DeclarableIngredientlListEntity .
+
+:ConcentrationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Concentration Characteristic"@en ;
+   samm:description "Characteristic of the concentration ofmaterial within the product."@en ;
+   samm:dataType :ConcentrationEntity .
+
+:RangeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Range Characteristic"@en ;
+   samm:description "Range characteristic with two values, the highest and the lowest of the concentration range. Only providing the maximum range is also possible."@en ;
+   samm:dataType :RangeEntity .
+
+:ReuseSystemInformationEntity a samm:Entity ;
+   samm:preferredName "Reuse System Information Entity"@en ;
+   samm:description "Entity for the reuse system information."@en ;
+   samm:properties ( [ samm:property :reuseSystemIdentification; samm:optional true ] [ samm:property :symbolsOfDepositAndReturnSystem; samm:optional true ] [ samm:property :rotation; samm:optional true ] [ samm:property :trip; samm:optional true ] :collectionPoints [ samm:property :trackingFacilities; samm:optional true ] ) .
+
+:SubstanceOfConcernEntity a samm:Entity ;
+   samm:preferredName "Substance Of Concern Entity"@en ;
+   samm:description "Information regarding substance of concern in the product."@en ;
+   samm:properties ( :exemption :hazardClassifications :substanceOfConcernDocuments :substanceOfConcernLocations :substanceOfConcernConcentrationRange ) .
+
+:DeclarableIngredientlListEntity a samm:Entity ;
+   samm:preferredName "DeclarableIngredientlListEntity"@en ;
+   samm:description "Entity for declarable ingredient list."@en ;
+   samm:properties ( :declarableIngredientListName [ samm:property :declarableIngredientListDocumentId; samm:optional true ] :declarableIngredientDocuments ) .
+
+:ConcentrationEntity a samm:Entity ;
+   samm:preferredName "Concentration Entity"@en ;
+   samm:description "Entity for the concentration of the material within the product."@en ;
+   samm:properties ( :concentrationValue :concentrationUnit ) .
+
+:RangeEntity a samm:Entity ;
+   samm:preferredName "Range Entity"@en ;
+   samm:description "Entity for the concentration range with two values, the highest and the lowest of the concentration range."@en ;
+   samm:properties ( [ samm:property :minConcentration; samm:optional true ] :maxConcentration ) .
+
+:reuseSystemIdentification a samm:Property ;
+   samm:preferredName "Reuse System Identification"@en ;
+   samm:description "Identification of the reuse system."@en ;
+   samm:characteristic samm-c:Text .
+
+:symbolsOfDepositAndReturnSystem a samm:Property ;
+   samm:preferredName "Symbols Of Deposit And Return System"@en ;
+   samm:description "Document of the symbols of the deposit and return system."@en ;
+   samm:characteristic :SymbolOfDepositAndReturnSystemList .
+
+:rotation a samm:Property ;
+   samm:preferredName "Rotation"@en ;
+   samm:description " Rotation  means the cycle that reusable packaging accomplishes from the moment it is placed on the market together with the product it is intended to contain, protect, handle, deliver or present to the moment it is ready to be re-used within a re-use system with a view to it being supplied again to end users together with another product.\n\nThis definition is based on the following regulation:\nRegulation (EU) 2025/40 of the European Parliament and of the Council of 19 December 2024 on packaging and packaging waste, amending Regulation (EU) 2019/1020 and Directive (EU) 2019/904, and repealing Directive 94/62/EC"@en ;
+   samm:characteristic :RotationCharacteristic .
+
+:trip a samm:Property ;
+   samm:preferredName "Trip"@en ;
+   samm:description " Trip  means the transfer of packaging, from filling or loading to emptying or unloading, as part of a rotation or on its own.\n\nThis definition is based on the following regulation:\nRegulation (EU) 2025/40 of the European Parliament and of the Council of 19 December 2024 on packaging and packaging waste, amending Regulation (EU) 2019/1020 and Directive (EU) 2019/904, and repealing Directive 94/62/EC"@en ;
+   samm:characteristic :TripCharacteristic .
+
+:trackingFacilities a samm:Property ;
+   samm:preferredName "Tracking Facilities"@en ;
+   samm:description "Information about tracking facilities.\n\nThese are mentioned in the Regulation (EU) 2025/40:  \n(69) As regards reusable packaging, in order to inform end users about reusability, the availability of re-use systems and the location of collection channels, such packaging should bear a QR code or other standardised, open, digital data carrier that provides such information. The QR code or data carrier should contain information which facilitates tracking and the calculation of trips and rotations, or an average estimation if such calculations are not feasible. That label should be voluntary for open loop systems which do not have a system operator. In addition, reusable sales packaging should be clearly identified at the point of sale."@en ;
+   samm:characteristic :FacilityList .
+
+:exemption a samm:Property ;
+   samm:preferredName "Exemption"@en ;
+   samm:description "Exemptions to the substance of concern. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Article 7:\n(5) (c) provide duly justified exemptions for substances of concern or information elements from the information requirements referred to in the first subparagraph based on the technical feasibility or relevance of tracking substances of concern, the existence of analytical methods to detect and quantify them, the need to protect confidential business information or in other duly justified cases. Substances of concern within the meaning of Article 2(28), point a), shall not be exempted if they are present in products, their relevant components or spare parts in a concentration above 0,1 % weight by weight."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "shall not apply to product x containing not more than 1,5 ml of liquid" .
+
+:hazardClassifications a samm:Property ;
+   samm:preferredName "Hazard Classifications"@en ;
+   samm:description "The specification of the hazard classes. This attribute is mentioned in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(f) use of substances, and in particular the use of substances of concern, on their own, as constituents of substances or in mixtures, during the production process of products, or leading to their presence in products, including once these products become waste, and their impacts on human health and the environment;\nFurther defined is this by Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006.\nDefined in Article 2:\n1. 'hazard class' means the nature of the physical, health or environmental hazard;\n2. 'hazard category' means the division of criteria within each hazard class, specifying hazard severity;\n5. 'hazard statement' means a phrase assigned to a hazard class and category that describes the nature of the hazards of a hazardous substance or mixture, including, where appropriate, the degree of hazard;"@en ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02008R1272-20231201> ;
+   samm:characteristic :HazardClassificationList .
+
+:substanceOfConcernDocuments a samm:Property ;
+   samm:preferredName "Substance Of Concern Documents"@en ;
+   samm:description "Documentation regarding the subtance of concern."@en ;
+   samm:characteristic :DocumentList .
+
+:substanceOfConcernLocations a samm:Property ;
+   samm:preferredName "Substance Of Concern Locations"@en ;
+   samm:description "Locations of the substance of concern within the product."@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "Housing" .
+
+:substanceOfConcernConcentrationRange a samm:Property ;
+   samm:preferredName "Substance Of Concern Concentration Range"@en ;
+   samm:description "Based on the regulation: concentration range for the substance of concern."@en ;
+   samm:characteristic :RangeCharacteristic .
+
+:declarableIngredientListName a samm:Property ;
+   samm:preferredName "Declarable Ingredient List Name"@en ;
+   samm:description "Name of list with declarable ingredients."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Critical Raw Materials" .
+
+:declarableIngredientListDocumentId a samm:Property ;
+   samm:preferredName "Declarable Ingredient List Document Id"@en ;
+   samm:description "Document Id refered to Declarable Ingredient list."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "DEF456" .
+
+:declarableIngredientDocuments a samm:Property ;
+   samm:preferredName "Declarable Ingredient Documents"@en ;
+   samm:description "Documentation accompanying the Declarable Ingredient list with information related to declarable ingredients. "@en ;
+   samm:characteristic :DocumentList .
+
+:concentrationValue a samm:Property ;
+   samm:preferredName "Concentration"@en ;
+   samm:description "Concentration of the material at the level of the product. This attribute is specially mentioned for substances of concern mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product [...].\nOther substances are mentioned for the purpose of recycling in the ESPR provisional agreement from January 9th, 2024 Annex I:\n(d) design for recycling, ease and quality of recycling as expressed through: use of easily recyclable materials, safe, easy and non-destructive access to recyclable components and materials or components and materials containing hazardous substances and material composition and homogeneity, possibility for high-purity sorting, number of materials and components used, use of standard components, use of component and material coding standards for the identification of components and materials, number and complexity of processes and tools needed, ease of nondestructive disassembly and re-assembly, conditions for access to product data, conditions for access to or use of hardware and software needed.\n"@en ;
+   samm:characteristic :PositiveTrait ;
+   samm:exampleValue "5.3"^^xsd:float .
+
+:concentrationUnit a samm:Property ;
+   samm:preferredName "Material Unit"@en ;
+   samm:description "The unit of concentration chosen from an enumeration: mass percent, volume percent, parts per thousand, parts per million, parts per billion and  parts per trillion."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:characteristic :ConcentrationEnumeration ;
+   samm:exampleValue "unit:percent" .
+
+:minConcentration a samm:Property ;
+   samm:preferredName "Minimum Concentration"@en ;
+   samm:description "\nThe minimum concentration of the material at the level of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) [...] concentration range of the substances of concern, at the level of the product [...]."@en ;
+   samm:characteristic :ConcentrationCharacteristic .
+
+:maxConcentration a samm:Property ;
+   samm:preferredName "Maximum Concentration"@en ;
+   samm:description "The maximum concentration of the material at the level of the product. This attribute is mentioned in the ESPR proposal from March 30th, 2022 Article 7:\n(5) (c) the concentration, maximum concentration or concentration range of the substances of concern, at the level of the product [...]."@en ;
+   samm:characteristic :ConcentrationCharacteristic .
+
+:SymbolOfDepositAndReturnSystemList a samm-c:List ;
+   samm:preferredName "Symbol Of Deposit And Return System List"@en ;
+   samm:description "List of symbol of the Deposit and Return System."@en ;
+   samm:dataType :SymbolOfDepositAndReturnSystemEntity .
+
+:RotationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Rotation Characteristic"@en ;
+   samm:description "Characteristic of rotation."@en ;
+   samm:dataType :RotationEntity .
+
+:TripCharacteristic a samm:Characteristic ;
+   samm:preferredName "Trip Characteristic"@en ;
+   samm:description "Characteristic of trip."@en ;
+   samm:dataType :TripEntity .
+
+:HazardClassificationList a samm-c:List ;
+   samm:preferredName "Hazard Classification List"@en ;
+   samm:description "List for the hazardous material/chemical classification."@en ;
+   samm:dataType :HazardClassificationEntity .
+
+:ConcentrationEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Concentration Enumeration"@en ;
+   samm:description "Enumeration of possible units of concentration with percent, volume percent, parts per thousand, parts per million, parts per billion and parts per trillion."@en ;
+   samm:see <https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html> ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "unit:partPerMillion" "unit:percent" "unit:percentVolume" "unit:partPerThousand" "unit:partPerTrillionUs" "unit:partPerBillionUs" ) .
+
+:SymbolOfDepositAndReturnSystemEntity a samm:Entity ;
+   samm:preferredName "Symbol Of Deposit And Return System Entity"@en ;
+   samm:description "Entity for the symbol information of the Deposit and Return System."@en ;
+   samm:properties ( :header :content :contentType ) .
+
+:RotationEntity a samm:Entity ;
+   samm:preferredName "Rotation Entity"@en ;
+   samm:description "Entity for rotation information."@en ;
+   samm:properties ( :calculationKey :calculationValue ) .
+
+:TripEntity a samm:Entity ;
+   samm:preferredName "Trip Entity"@en ;
+   samm:description "Entity for trip information."@en ;
+   samm:properties ( :calculationKey :calculationValue ) .
+
+:HazardClassificationEntity a samm:Entity ;
+   samm:preferredName "Hazard Classification Entity"@en ;
+   samm:description "Entity for the hazard classification."@en ;
+   samm:properties ( :hazardCategory :hazardClass :hazardStatement ) .
+
+:calculationKey a samm:Property ;
+   samm:preferredName "Calculation Key"@en ;
+   samm:description "Key for calculation of trips/rotations."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "cycles calculated" .
+
+:calculationValue a samm:Property ;
+   samm:preferredName "Calculation Value"@en ;
+   samm:description "Dynamic value for calculation trips/rotations."@en ;
+   samm:characteristic :PositiveTrait ;
+   samm:exampleValue "100"^^xsd:float .
+
+:hazardCategory a samm:Property ;
+   samm:preferredName "Hazard Category"@en ;
+   samm:description "The hazard category of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n2. 'hazard category' means the division of criteria within each hazard class, specifying hazard severity."@en ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02008R1272-20231201> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "category 1A" .
+
+:hazardClass a samm:Property ;
+   samm:preferredName "Hazard Class"@en ;
+   samm:description "The hazard class of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n1. 'hazard class' means the nature of the physical, health or environmental hazard."@en ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02008R1272-20231201> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Skin corrosion" .
+
+:hazardStatement a samm:Property ;
+   samm:preferredName "Hazard Statement"@en ;
+   samm:description "The hazard statement of the substance of concern. Defined in Article 2 of Regulation (EC) No 1272/2008 of the European Parliament and of the Council of 16 December 2008 on classification, labelling and packaging of substances and mixtures, amending and repealing Directives 67/548/EEC and 1999/45/EC, and amending Regulation (EC) No 1907/2006:\n5. 'hazard statement' means a phrase assigned to a hazard class and category that describes the nature of the hazards of a hazardous substance or mixture, including, where appropriate, the degree of hazard."@en ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02008R1272-20231201> ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Causes severe skin burns and eye damage." .
+

--- a/io.catenax.generic.digital_product_passport/7.0.0/metadata.json
+++ b/io.catenax.generic.digital_product_passport/7.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}


### PR DESCRIPTION
## Description
Please refer to issue #891 for the example JSON.  New attributes have been added to ensure compliance with regulatory requirements. Contact Persons : @thorstendikmann and @SmietJa 

Closes #891 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
