### PR TITLE
[Deprecate] io.catenax.certificate_of_destruction:1.0.0

### DIFF
--- a/io.catenax.certificate_of_destruction/1.0.1/metadata.json
+++ b/io.catenax.certificate_of_destruction/1.0.1/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "deprecated"}


### PR DESCRIPTION
This PR adds the missing metadata.json to the io.catenax.certificate_of_destruction aspect model.