### PR TITLE
[Bugfix] io.catenax.single_level_bom_as_specified:2.0.1

### DIFF
--- a/io.catenax.single_level_bom_as_specified/2.0.1/SingleLevelBomAsSpecified.ttl
+++ b/io.catenax.single_level_bom_as_specified/2.0.1/SingleLevelBomAsSpecified.ttl
@@ -115,7 +115,7 @@
 :ChildItemEntity a samm:Entity;
     samm:preferredName "Child Item Entity"@en;
     samm:description "Encapsulates the properties describing the child item"@en;
-    samm:properties (:childItemCategory :childassetId).
+    samm:properties (:childItemCategory :item :childassetId).
 
 :item a samm:Property;
     samm:preferredName "Item"@en;
@@ -142,9 +142,10 @@
         [samm:property :itemQuantity; samm:optional "true"^^xsd:boolean]
         [samm:property :itemDescription; samm:optional "true"^^xsd:boolean]
         [samm:property :itemClassification; samm:optional "true"^^xsd:boolean]
-        [samm:property :lastModifiedOn; samm:optional "true"^^xsd:boolean]
-        [samm:property :createdOn; samm:optional "true"^^xsd:boolean] 
-        [samm:property :itemPositioning; samm:optional "true"^^xsd:boolean]).
+        [samm:property :lastModifiedOn;samm:optional "true"^^xsd:boolean]
+        [samm:property :createdOn; samm:optional "true"^^xsd:boolean]
+        [samm:property :itemPositioning;samm:optional "true"^^xsd:boolean]
+    ).
 
 :itemVersion a samm:Property;
     samm:preferredName "Item Version"@en;
@@ -176,7 +177,7 @@
 :ItemQuantityEntity a samm:Entity;
     samm:preferredName "Item Quantity Entity"@en;
     samm:description "The entity encapsulating the properties describing the quantity of a item."@en;
-    samm:properties (:measurementUnit :quantityNumber :measurementUnit :quantityNumber).
+    samm:properties (:measurementUnit :quantityNumber).
 
 :ItemClassificationCharacteristic a samm-c:Set;
     samm:preferredName "Item Classification Characteristic"@en;

--- a/io.catenax.single_level_bom_as_specified/2.0.1/SingleLevelBomAsSpecified.ttl
+++ b/io.catenax.single_level_bom_as_specified/2.0.1/SingleLevelBomAsSpecified.ttl
@@ -4,6 +4,7 @@
 # Copyright (c) 2022 Volkswagen AG
 # Copyright (c) 2022 Robert Bosch GmbH
 # Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2025 Catena-X Automotive Network e.V.
 # Copyright (c) 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -24,7 +25,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix : <urn:samm:io.catenax.single_level_bom_as_specified:2.0.0#>.
+@prefix : <urn:samm:io.catenax.single_level_bom_as_specified:2.0.1#>.
 
 :SingleLevelBomAsSpecified a samm:Aspect;
     samm:preferredName "Single Level BOM as Specified"@en;
@@ -32,174 +33,173 @@
     samm:properties (:assetId :childItems :manufacturerId);
     samm:operations ();
     samm:events ().
+
 :assetId a samm:Property;
     samm:preferredName "assetID"@en;
     samm:description "A unique reference to an asset which could be registered within Catena-X DataSpace"@en;
     samm:characteristic :assetIdTrait;
     samm:exampleValue "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d".
+
 :manufacturerId a samm:Property;
     samm:preferredName "Manufacturer ID"@en;
     samm:description "The ID of the initial issuer of the single level BoMAsSpecified"@en;
     samm:characteristic samm-c:Text;
     samm:exampleValue "BPNL1234567890LR".
+
 :assetIdTrait a samm-c:Trait;
     samm-c:baseCharacteristic samm-c:Text;
     samm-c:constraint :Uuidv4RegularExpression.
+
 :Uuidv4RegularExpression a samm-c:RegularExpressionConstraint;
     samm:preferredName "Regular Expression for the assetID"@en;
     samm:description "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens)."@en;
     samm:value "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)".
+
 :childassetId a samm:Property;
     samm:preferredName "Child assetId"@en;
     samm:description "Describes the Catena-X ID of the child part"@en;
     samm:characteristic samm-c:Text;
     samm:exampleValue "urn:uuid:218b26f4-4a0b-4a7f-b2c1-d248927718bf ".
+
 :lastModifiedOn a samm:Property;
     samm:preferredName "Last Modified On"@en;
     samm:description "The time the item was modified the last time"@en;
     samm:characteristic samm-c:Timestamp;
     samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime.
+
 :createdOn a samm:Property;
     samm:preferredName "Created On"@en;
     samm:description "The time the item was created on"@en;
     samm:characteristic samm-c:Timestamp;
     samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime.
+
 :measurementUnit a samm:Property;
     samm:preferredName "Measurement Unit"@en;
     samm:description "Unit of measurement for the quantity of serialized objects."@en;
     samm:characteristic samm-c:UnitReference;
     samm:exampleValue "unit:kW"^^samm:curie.
+
 :quantityNumber a samm:Property;
     samm:preferredName "Quantity Number"@en;
     samm:description "The number of objects related to the measurement unit."@en;
     samm:characteristic :NumberOfObjects;
     samm:exampleValue "350"^^xsd:double.
+
 :NumberOfObjects a samm:Characteristic;
     samm:preferredName "Number of Objects"@en;
     samm:description "Quantifiable number of objects in reference to the measurementUnit."@en;
     samm:dataType xsd:double.
+
 :key a samm:Property;
     samm:preferredName "Key"@en;
     samm:description "Key within the classification."@en;
     samm:characteristic samm-c:Text;
     samm:exampleValue "BMW:PartFamily".
+
 :value a samm:Property;
     samm:preferredName "Value"@en;
     samm:description "Value within the classification."@en;
     samm:characteristic samm-c:Text;
     samm:exampleValue "STEEWHL".
+
 :childItems a samm:Property;
     samm:preferredName "Child Items"@en;
     samm:description "The child Items of the observed parent item"@en;
     samm:characteristic :ChildItemCharacteristic.
+
 :ChildItemCharacteristic a samm-c:Set;
     samm:preferredName "Child Item Characteristic"@en;
     samm:description "The characteristic of the child item property"@en;
     samm:dataType :ChildItemEntity.
+
 :ChildItemEntity a samm:Entity;
     samm:preferredName "Child Item Entity"@en;
     samm:description "Encapsulates the properties describing the child item"@en;
-    samm:properties (:childItemCategory :item :childItemCategory :item :childassetId).
+    samm:properties (:childItemCategory :childassetId).
+
 :item a samm:Property;
     samm:preferredName "Item"@en;
     samm:description "The description of the part in the primary language of the production facility of the product owner."@en;
     samm:characteristic :ItemCharacteristic.
+
 :ownerItemId a samm:Property;
     samm:preferredName "Owner Item ID"@en;
     samm:description "This is the key field of the component which usually keeps the part numbers used in after-sales, e.g. when repairing broken parts and searching for a replacement. This ownerPartId itself isn't usually bound to one part version, with the assumption that all part versions with the same ownerPartId are mutually interchangeable."@en;
     samm:characteristic :assetIdTrait;
     samm:exampleValue "urn:uuid:b4741433-92bb-4027-9a02-bbc64a58d193".
+
 :ItemCharacteristic a samm-c:Set;
     samm:preferredName "Item Characteristic"@en;
     samm:description "Characteristic of the item."@en;
     samm:dataType :ItemEntity.
+
 :ItemEntity a samm:Entity;
     samm:preferredName "Item Entity"@en;
     samm:description "Entity encapsulating the properies describing a item"@en;
-    samm:properties (:ownerItemId [
-  samm:property :itemVersion;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :itemQuantity;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :itemDescription;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :itemClassification;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :lastModifiedOn;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :createdOn;
-  samm:optional "true"^^xsd:boolean
-] :ownerItemId [
-  samm:property :itemVersion;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :itemQuantity;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :itemDescription;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :itemClassification;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :lastModifiedOn;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :createdOn;
-  samm:optional "true"^^xsd:boolean
-] [
-  samm:property :itemPositioning;
-  samm:optional "true"^^xsd:boolean
-]).
+    samm:properties (
+        :ownerItemId
+        [samm:property :itemVersion; samm:optional "true"^^xsd:boolean]
+        [samm:property :itemQuantity; samm:optional "true"^^xsd:boolean]
+        [samm:property :itemDescription; samm:optional "true"^^xsd:boolean]
+        [samm:property :itemClassification; samm:optional "true"^^xsd:boolean]
+        [samm:property :lastModifiedOn; samm:optional "true"^^xsd:boolean]
+        [samm:property :createdOn; samm:optional "true"^^xsd:boolean] 
+        [samm:property :itemPositioning; samm:optional "true"^^xsd:boolean]).
+
 :itemVersion a samm:Property;
     samm:preferredName "Item Version"@en;
     samm:description "This is the version of the item. The engineering will at times supercede an older item version by a newer one, which might have different material aspects, physical dimensions etc., still maintaining compatibility."@en;
     samm:characteristic samm-c:Text;
     samm:exampleValue "05".
+
 :itemQuantity a samm:Property;
     samm:preferredName "Item Quantity"@en;
     samm:description "This is the quantity how often this item is in the item."@en;
     samm:characteristic :ItemQuantityCharacteristic.
+
 :itemDescription a samm:Property;
     samm:preferredName "Item Description"@en;
     samm:description "The description of the item in the primary language of the production facility of the product owner."@en;
     samm:characteristic samm-c:Text;
     samm:exampleValue "The steering wheel is nice and round".
+
 :itemClassification a samm:Property;
     samm:preferredName "Item Classification"@en;
     samm:description "The item classification."@en;
     samm:characteristic :ItemClassificationCharacteristic.
+
 :ItemQuantityCharacteristic a samm:Characteristic;
     samm:preferredName "Item Quantity Characteristic"@en;
     samm:description "The characteristic of the item quantity."@en;
     samm:dataType :ItemQuantityEntity.
+
 :ItemQuantityEntity a samm:Entity;
     samm:preferredName "Item Quantity Entity"@en;
     samm:description "The entity encapsulating the properties describing the quantity of a item."@en;
     samm:properties (:measurementUnit :quantityNumber :measurementUnit :quantityNumber).
+
 :ItemClassificationCharacteristic a samm-c:Set;
     samm:preferredName "Item Classification Characteristic"@en;
     samm:description "The characteristic of the item classification."@en;
     samm:dataType :ItemClassificationEntity.
+
 :ItemClassificationEntity a samm:Entity;
     samm:preferredName "Item Classification Entity"@en;
     samm:description "The entity encapsulating the properties of the item classification."@en;
     samm:properties (:key :value).
+
 :childItemCategory a samm:Property;
     samm:preferredName "Child Item Category"@en;
     samm:description "The BomAsSpecified defines the view of the OEM or producer of the whole product, e.g. the OEM of a vehicle. It is free of any supplier-related information and specifies the promised and guaranteed content of the whole product to the end customer. This \"top-down\" view is in contrast to the \"bottom-up\" view of the SingleLevelBoMAsPlanned, though several sub-aspects are shared. The BomAsSpecified is merely one aspect, which is attached to the twin of the whole product and itself does neither introduce further twins nor reference them. Instead it merely comprises all functional information required by dismantlers, workshops or requestors for used parts to search for and to make a match on the market place."@en;
     samm:characteristic samm-c:Text;
     samm:exampleValue "e.g. vehicle, winter wheels, bicycle rack".
+
 :itemPositioning a samm:Property;
     samm:preferredName "Item Positioning"@en;
     samm:description "Some parts are intended to be used on either the left or right side, e.g. mirrors, hence this entity describes on which side a part is to be used"@en;
     samm:characteristic :ItemPositioningCharacteristic;
     samm:exampleValue "left".
+
 :ItemPositioningCharacteristic a samm-c:Enumeration;
     samm:preferredName "Item Positioning Characteristic"@en;
     samm:description "Describes the characteristic of the left or right mark entity with its possible values (left or right)"@en;

--- a/io.catenax.single_level_bom_as_specified/2.0.1/SingleLevelBomAsSpecified.ttl
+++ b/io.catenax.single_level_bom_as_specified/2.0.1/SingleLevelBomAsSpecified.ttl
@@ -20,7 +20,6 @@
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.0.0#>.
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.0.0#>.
-@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.0.0#>.
 @prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.0.0#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.

--- a/io.catenax.single_level_bom_as_specified/2.0.1/metadata.json
+++ b/io.catenax.single_level_bom_as_specified/2.0.1/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.single_level_bom_as_specified/RELEASE_NOTES.md
+++ b/io.catenax.single_level_bom_as_specified/RELEASE_NOTES.md
@@ -2,7 +2,11 @@
 
 All notable changes to this model will be documented in this file.
 
-## [Unreleased]
+## [2.0.1] - 2025-10-09
+
+### Changed
+
+- fixed modelling error which prevented the successfull validation of the payload
 
 ## [2.0.0] - 2023-08-28
 


### PR DESCRIPTION
This PR fixes a validation issue for `urn:samm:io.catenax.single_level_bom_as_specified:2.0.0` which was caused by a modelling error. As the payload remains unchained, this is done as a patch.

Closes
- #401 
- #716 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
