### PR TITLE
timeseries reference: update 

### DIFF
--- a/io.catenax.time_series_reference/2.0.0/TimeSeriesReference.ttl
+++ b/io.catenax.time_series_reference/2.0.0/TimeSeriesReference.ttl
@@ -37,6 +37,12 @@
    samm:operations ( ) ;
    samm:events ( ) .
 
+:decimalSeparator a samm:Property ;
+   samm:preferredName "Decimal Separator"@en ;
+   samm:description "Indicates whether a dot or comma is used to separate the decimal place in the source file."@en ;
+   samm:characteristic :DecimalSeparator ;
+   samm:exampleValue "dot" .
+
 :sourceFile a samm:Property ;
    samm:preferredName "Source File"@en ;
    samm:description "Contains the URI to the referenced time series file."@en ;
@@ -58,6 +64,12 @@
    samm:preferredName "Payload"@en ;
    samm:description "Contains the information about variable names and their units as well as the name of the time column. Optionally information on the cycle column may be provided."@en ;
    samm:characteristic :PayloadCharacteristic .
+
+:DecimalSeparator a samm-c:Enumeration ;
+   samm:preferredName "Decimal Separator"@en ;
+   samm:description "Indicates whether a dot or comma is used to separate the decimal place in the source file."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "dot" "comma" ) .
 
 :ResourcePath a samm:Characteristic ;
    samm:preferredName "Resource Path"@en ;
@@ -99,9 +111,14 @@
       :units
       :variableNames
       :timeColumnName
-      :value
       [ samm:property :cycleColumn ; samm:optional true ]
+      :value
    ) .
+
+:units a samm:Property ;
+   samm:preferredName "Units"@en ;
+   samm:description "Lists the unit for each datapoint."@en ;
+   samm:characteristic :UnitsListCharacteristic .
 
 :UnitsListCharacteristic a samm-c:List ;
    samm:preferredName "Units List Characteristic"@en ;
@@ -144,10 +161,10 @@
       "t"
    ) .
 
-:units a samm:Property ;
-   samm:preferredName "Units"@en ;
-   samm:description "Lists the unit for each datapoint."@en ;
-   samm:characteristic :UnitsListCharacteristic .
+:cycleColumn a samm:Property ;
+   samm:preferredName "Cycle Column"@en ;
+   samm:description "The variable name that specifies the operational cycle ID in the source file."@en ;
+   samm:characteristic :CycleColumnChoice .
 
 :CycleColumnChoice a samm-c:Enumeration ;
    samm:preferredName "Cycle Column Name"@en ;
@@ -161,30 +178,13 @@
       "Cycle"
    ) .
 
-:DecimalSeparator a samm-c:Enumeration ;
-   samm:preferredName "Decimal Separator"@en ;
-   samm:description "Indicates whether a dot or comma is used to separate the decimal place in the source file."@en ;
-   samm:dataType xsd:string ;
-   samm-c:values ( "dot" "comma" ) .
-
-:decimalSeparator a samm:Property ;
-   samm:preferredName "Decimal Separator"@en ;
-   samm:description "Indicates whether a dot or comma is used to separate the decimal place in the source file."@en ;
-   samm:characteristic :DecimalSeparator ;
-   samm:exampleValue "dot" .
-
-:ValueCharacteristic a samm:Characteristic ;
-   samm:preferredName "Value Characteristic"@en ;
-   samm:description "The value recorded at a given point in time"@en ;
-   samm:dataType xsd:string .
-
 :value a samm:Property ;
    samm:preferredName "value"@en ;
    samm:description "Recorded value aligned with the time"@en ;
    samm:extends samm-e:value ;
    samm:characteristic :ValueCharacteristic . 
 
-:cycleColumn a samm:Property ;
-   samm:preferredName "Cycle Column"@en ;
-   samm:description "The variable name that carries the operational cycle ID in the source file."@en ;
-   samm:characteristic :CycleColumnChoice .
+:ValueCharacteristic a samm:Characteristic ;
+   samm:preferredName "Value Characteristic"@en ;
+   samm:description "The value recorded at a given point in time"@en ;
+   samm:dataType xsd:string .

--- a/io.catenax.time_series_reference/2.0.0/TimeSeriesReference.ttl
+++ b/io.catenax.time_series_reference/2.0.0/TimeSeriesReference.ttl
@@ -1,10 +1,10 @@
 # ######################################################################
-# Copyright (c) 2022 Allgemeine Deutsche Automobil-Club (ADAC) e.V
-# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft
-# Copyright (c) 2022 Deutsches Zentrum für Luft- und Raumfahrt e. V. (DLR)
-# Copyright (c) 2022 Siemens AG
-# Copyright (c) 2022 ZF Friedrichshafen AG
-# Copyright (c) 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2025 Allgemeine Deutsche Automobil-Club (ADAC) e.V
+# Copyright (c) 2025 Bayerische Motoren Werke Aktiengesellschaft
+# Copyright (c) 2025 Deutsches Zentrum für Luft- und Raumfahrt e. V. (DLR)
+# Copyright (c) 2025 Siemens AG
+# Copyright (c) 2025 ZF Friedrichshafen AG
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
 # 
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -17,6 +17,7 @@
 # SPDX-License-Identifier: CC-BY-4.0
 # ######################################################################
 
+
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.2.0#> .
@@ -27,7 +28,7 @@
 
 :TimeSeriesReference a samm:Aspect ;
    samm:properties (
-      :decimalSeperator
+      :decimalSeparator
       :sourceFile
       :fileExtension
       :delimiter
@@ -36,12 +37,6 @@
    samm:operations ( ) ;
    samm:events ( ) .
 
-:decimalSeperator a samm:Property ;
-   samm:preferredName "Decimal Seperator"@en ;
-   samm:description "Indicates whether a dot, comma or semicolon is used to separate the decimal place in the source file."@en ;
-   samm:characteristic :DecimalSeperator ;
-   samm:exampleValue "dot" .
-
 :sourceFile a samm:Property ;
    samm:preferredName "Source File"@en ;
    samm:description "Contains the URI to the referenced time series file."@en ;
@@ -49,7 +44,7 @@
 
 :fileExtension a samm:Property ;
    samm:preferredName "File Extension"@en ;
-   samm:description "Indicates whether csv, none or txt is used as file extension."@en ;
+   samm:description "Indicates which of csv, xlsx, none, txt, dat, data, parquet, mdf or mf4 is used as file extension."@en ;
    samm:characteristic :FileExtension ;
    samm:exampleValue "csv" .
 
@@ -61,12 +56,8 @@
 
 :payload a samm:Property ;
    samm:preferredName "Payload"@en ;
-   samm:description "Contains the information about variable names and their units as well as the name of the time column."@en ;
+   samm:description "Contains the information about variable names and their units as well as the name of the time column. Optionally information on the cycle column may be provided."@en ;
    samm:characteristic :PayloadCharacteristic .
-
-:DecimalSeperator a samm-c:Enumeration ;
-   samm:dataType xsd:string ;
-   samm-c:values ( "comma" "dot" ) .
 
 :ResourcePath a samm:Characteristic ;
    samm:preferredName "Resource Path"@en ;
@@ -74,6 +65,8 @@
    samm:dataType xsd:anyURI .
 
 :FileExtension a samm-c:Enumeration ;
+   samm:preferredName "File Extension"@en ;
+   samm:description "Indicates which of csv, xlsx, none, txt, dat, data, parquet, mdf or mf4 is used as file extension."@en ;
    samm:dataType xsd:string ;
    samm-c:values (
       "csv"
@@ -88,18 +81,35 @@
    ) .
 
 :Delimiter a samm-c:Enumeration ;
+   samm:preferredName "Delimiter"@en ;
+   samm:description "Indicates whether a semicolon, comma or tab is used as a delimiter between datapoints for csv or txt file extensions."@en ;
    samm:dataType xsd:string ;
    samm-c:values ( "semicolon" "comma" "tab" ) .
 
 :PayloadCharacteristic a samm-c:TimeSeries ;
-   samm:preferredName "payload characteristic"@en ;
+   samm:preferredName "Payload Characteristic"@en ;
+   samm:description "Contains the information about variable names and their units as well as the name of the time column. Optionally information on the cycle column may be provided."@en ;
    samm:dataType :PayloadEntity .
 
+:PayloadEntity a samm:Entity ;
+   samm:extends samm-e:TimeSeriesEntity ;
+   samm:preferredName "Payload Entity"@en ;
+   samm:description "Contains the information about variable names and their units as well as the name of the time column."@en ;
+   samm:properties (
+      :units
+      :variableNames
+      :timeColumnName
+      :value
+      [ samm:property :cycleColumn ; samm:optional true ]
+   ) .
+
 :UnitsListCharacteristic a samm-c:List ;
+   samm:preferredName "Units List Characteristic"@en ;
    samm:description "Lists the unit for each datapoint."@en ;
    samm:dataType :Unit .
 
 :Unit a samm:Entity ;
+   samm:preferredName "Unit"@en ;
    samm:description "The unit of a column."@en ;
    samm:properties ( :unit ) .
 
@@ -114,6 +124,7 @@
    samm:characteristic :VariableListCharacteristic .
 
 :VariableListCharacteristic a samm-c:List ;
+   samm:preferredName "Variable List Characteristic"@en ;
    samm:description "Lists the name for each datapoint."@en ;
    samm:dataType xsd:string .
 
@@ -133,34 +144,47 @@
       "t"
    ) .
 
-:PayloadEntity a samm:Entity ;
-   samm:extends samm-e:TimeSeriesEntity ;
-   samm:preferredName "payload entity"@en ;
-   samm:description "Contains the information about variable names and their units as well as the name of the time column."@en ;
-   samm:properties (
-      :units
-      :variableNames
-      :timeColumnName
-      [ samm:extends samm-e:value; samm:characteristic :Characteristic1 ]
-      [ samm:property :cycleColumnName; samm:optional true ]
-   ) .
-
 :units a samm:Property ;
    samm:preferredName "Units"@en ;
    samm:description "Lists the unit for each datapoint."@en ;
    samm:characteristic :UnitsListCharacteristic .
 
-:Characteristic1 a samm:Characteristic ;
-   samm:dataType xsd:string .
-
-:cycleColumnName a samm:Property ;
-   samm:preferredName "Cycle Column Name"@en ;
-   samm:description "Specifies the name of the Variable Names entry which contains the operational cycle ID."@en ;
-   samm:characteristic :CycleColumnChoice .
-
 :CycleColumnChoice a samm-c:Enumeration ;
    samm:preferredName "Cycle Column Name"@en ;
    samm:description "Specifies the name of the cycle column variable."@en ;
    samm:dataType xsd:string ;
-   samm-c:values ( "Cycle" "cycle" "cycle_id" ) .
+   samm-c:values (
+      "Cycle_ID"
+      "cycle_id"
+      "CycleID"
+      "cycle"
+      "Cycle"
+   ) .
 
+:DecimalSeparator a samm-c:Enumeration ;
+   samm:preferredName "Decimal Separator"@en ;
+   samm:description "Indicates whether a dot or comma is used to separate the decimal place in the source file."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "dot" "comma" ) .
+
+:decimalSeparator a samm:Property ;
+   samm:preferredName "Decimal Separator"@en ;
+   samm:description "Indicates whether a dot or comma is used to separate the decimal place in the source file."@en ;
+   samm:characteristic :DecimalSeparator ;
+   samm:exampleValue "dot" .
+
+:ValueCharacteristic a samm:Characteristic ;
+   samm:preferredName "Value Characteristic"@en ;
+   samm:description "The value recorded at a given point in time"@en ;
+   samm:dataType xsd:string .
+
+:value a samm:Property ;
+   samm:preferredName "value"@en ;
+   samm:description "Recorded value aligned with the time"@en ;
+   samm:extends samm-e:value ;
+   samm:characteristic :ValueCharacteristic . 
+
+:cycleColumn a samm:Property ;
+   samm:preferredName "Cycle Column"@en ;
+   samm:description "The variable name that carries the operational cycle ID in the source file."@en ;
+   samm:characteristic :CycleColumnChoice .

--- a/io.catenax.time_series_reference/2.0.0/TimeSeriesReference.ttl
+++ b/io.catenax.time_series_reference/2.0.0/TimeSeriesReference.ttl
@@ -1,0 +1,166 @@
+# ######################################################################
+# Copyright (c) 2022 Allgemeine Deutsche Automobil-Club (ADAC) e.V
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft
+# Copyright (c) 2022 Deutsches Zentrum für Luft- und Raumfahrt e. V. (DLR)
+# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+# 
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+# 
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+# 
+# SPDX-License-Identifier: CC-BY-4.0
+# ######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.2.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.time_series_reference:2.0.0#> .
+
+:TimeSeriesReference a samm:Aspect ;
+   samm:properties (
+      :decimalSeperator
+      :sourceFile
+      :fileExtension
+      :delimiter
+      :payload
+   ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:decimalSeperator a samm:Property ;
+   samm:preferredName "Decimal Seperator"@en ;
+   samm:description "Indicates whether a dot, comma or semicolon is used to separate the decimal place in the source file."@en ;
+   samm:characteristic :DecimalSeperator ;
+   samm:exampleValue "dot" .
+
+:sourceFile a samm:Property ;
+   samm:preferredName "Source File"@en ;
+   samm:description "Contains the URI to the referenced time series file."@en ;
+   samm:characteristic :ResourcePath .
+
+:fileExtension a samm:Property ;
+   samm:preferredName "File Extension"@en ;
+   samm:description "Indicates whether csv, none or txt is used as file extension."@en ;
+   samm:characteristic :FileExtension ;
+   samm:exampleValue "csv" .
+
+:delimiter a samm:Property ;
+   samm:preferredName "Delimiter"@en ;
+   samm:description "Indicates whether a semicolon, comma or tab is used as a delimiter between datapoints for csv or txt file extensions."@en ;
+   samm:characteristic :Delimiter ;
+   samm:exampleValue "semicolon" .
+
+:payload a samm:Property ;
+   samm:preferredName "Payload"@en ;
+   samm:description "Contains the information about variable names and their units as well as the name of the time column."@en ;
+   samm:characteristic :PayloadCharacteristic .
+
+:DecimalSeperator a samm-c:Enumeration ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "comma" "dot" ) .
+
+:ResourcePath a samm:Characteristic ;
+   samm:preferredName "Resource Path"@en ;
+   samm:description "The path of a resource."@en ;
+   samm:dataType xsd:anyURI .
+
+:FileExtension a samm-c:Enumeration ;
+   samm:dataType xsd:string ;
+   samm-c:values (
+      "csv"
+      "txt"
+      "dat"
+      "data"
+      "none"
+      "parquet"
+      "mdf"
+      "mf4"
+      "xlsx"
+   ) .
+
+:Delimiter a samm-c:Enumeration ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "semicolon" "comma" "tab" ) .
+
+:PayloadCharacteristic a samm-c:TimeSeries ;
+   samm:preferredName "payload characteristic"@en ;
+   samm:dataType :PayloadEntity .
+
+:UnitsListCharacteristic a samm-c:List ;
+   samm:description "Lists the unit for each datapoint."@en ;
+   samm:dataType :Unit .
+
+:Unit a samm:Entity ;
+   samm:description "The unit of a column."@en ;
+   samm:properties ( :unit ) .
+
+:unit a samm:Property ;
+   samm:preferredName "Unit"@en ;
+   samm:description "The unit of a column."@en ;
+   samm:characteristic samm-c:UnitReference .
+
+:variableNames a samm:Property ;
+   samm:preferredName "Variable Names"@en ;
+   samm:description "Lists the name for each datapoint."@en ;
+   samm:characteristic :VariableListCharacteristic .
+
+:VariableListCharacteristic a samm-c:List ;
+   samm:description "Lists the name for each datapoint."@en ;
+   samm:dataType xsd:string .
+
+:timeColumnName a samm:Property ;
+   samm:preferredName "Time Column Name"@en ;
+   samm:description "Specifies the name of the Variable Names entry which contains the time column."@en ;
+   samm:characteristic :TimeColumnChoice .
+
+:TimeColumnChoice a samm-c:Enumeration ;
+   samm:preferredName "time column name"@en ;
+   samm:description "Specifies the name of the time columns variable."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values (
+      "Time"
+      "TIME"
+      "time"
+      "t"
+   ) .
+
+:PayloadEntity a samm:Entity ;
+   samm:extends samm-e:TimeSeriesEntity ;
+   samm:preferredName "payload entity"@en ;
+   samm:description "Contains the information about variable names and their units as well as the name of the time column."@en ;
+   samm:properties (
+      :units
+      :variableNames
+      :timeColumnName
+      [ samm:extends samm-e:value; samm:characteristic :Characteristic1 ]
+      [ samm:property :cycleColumnName; samm:optional true ]
+   ) .
+
+:units a samm:Property ;
+   samm:preferredName "Units"@en ;
+   samm:description "Lists the unit for each datapoint."@en ;
+   samm:characteristic :UnitsListCharacteristic .
+
+:Characteristic1 a samm:Characteristic ;
+   samm:dataType xsd:string .
+
+:cycleColumnName a samm:Property ;
+   samm:preferredName "Cycle Column Name"@en ;
+   samm:description "Specifies the name of the Variable Names entry which contains the operational cycle ID."@en ;
+   samm:characteristic :CycleColumnChoice .
+
+:CycleColumnChoice a samm-c:Enumeration ;
+   samm:preferredName "Cycle Column Name"@en ;
+   samm:description "Specifies the name of the cycle column variable."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Cycle" "cycle" "cycle_id" ) .
+

--- a/io.catenax.time_series_reference/2.0.0/metadata.json
+++ b/io.catenax.time_series_reference/2.0.0/metadata.json
@@ -1,0 +1,3 @@
+{
+    "status": "release"
+}

--- a/io.catenax.time_series_reference/RELEASE_NOTES.md
+++ b/io.catenax.time_series_reference/RELEASE_NOTES.md
@@ -1,7 +1,22 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
-## [Unreleased]
+## [2.0.0] - 2025-10-31
+
+### Added
+
+- Added mandatory property `value`
+- Added optional property `cycleColumn` to reference the variable name that carries the operational cycle ID in the source file.
+- Support for additional file extensions: parquet, mdf, xlsx, mf4
+ 
+### Changed
+
+- Updated model for samm compliance
+- DecimalSeperator -> DecimalSeparator in property and characteristic names
+- parquet, mdf, xlsx, mf4 as fileExtension
+- updated description of payload
+- payload characteristic to Payload Characteristic as preferred name
+- payload entity to Payload Entity as preferred name
 
 ## [1.0.0] - 2023-03-20
 ### Added


### PR DESCRIPTION
## Description

Update the model for TimeSeriesReference

Closes #843 

cc: @jSchuetz88 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
