### PR TITLE
Update/io.catenax.battery.battery pass /6.1.0

### DIFF
--- a/io.catenax.battery.battery_pass/3.0.0/metadata.json
+++ b/io.catenax.battery.battery_pass/3.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{ "status" : "deprecated"} 

--- a/io.catenax.battery.battery_pass/3.0.1/metadata.json
+++ b/io.catenax.battery.battery_pass/3.0.1/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{ "status" : "deprecated"} 

--- a/io.catenax.battery.battery_pass/4.0.0/metadata.json
+++ b/io.catenax.battery.battery_pass/4.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{ "status" : "deprecated"} 

--- a/io.catenax.battery.battery_pass/6.1.0/BatteryPass.ttl
+++ b/io.catenax.battery.battery_pass/6.1.0/BatteryPass.ttl
@@ -1,13 +1,14 @@
 #######################################################################
-# Copyright (c) 2022-2024 BASF SE
-# Copyright (c) 2022-2024 BMW AG
-# Copyright (c) 2024-2024 CGI Deutschland B.V. & Co. KG
-# Copyright (c) 2022-2024 Henkel AG & Co. KGaA
-# Copyright (c) 2022-2023 Robert Bosch GmbH
-# Copyright (c) 2022-2024 SAP SE
-# Copyright (c) 2022-2024 T-Systems International GmbH
-# Copyright (c) 2022-2024 ZF Friedrichshafen AG
-# Copyright (c) 2022-2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2022 BASF SE
+# Copyright (c) 2022 BMW AG
+# Copyright (c) 2022 Henkel AG & Co. KGaA
+# Copyright (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 T-Systems International GmbH
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2024 CGI Deutschland B.V. & Co. KG
+# Copyright (c) 2025 Catena-X Automotive Network e.V.
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.battery.battery_pass/6.1.0/BatteryPass.ttl
+++ b/io.catenax.battery.battery_pass/6.1.0/BatteryPass.ttl
@@ -41,8 +41,8 @@
    samm:events ( ) .
 
 :specVersion a samm:Property ;
-   samm:preferredName "Digital Product Passport Specification Version"@en ;
-   samm:description "Specification of the BPP format/data model (name and version number), which is used."@en ;
+   samm:preferredName "Battery Product Passport Specification Version"@en ;
+   samm:description "Specification of the BatteryPass format/data model (name and version number), which is used."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "urn:io.catenax.battery.battery_pass:6.1.0" .
 

--- a/io.catenax.battery.battery_pass/6.1.0/BatteryPass.ttl
+++ b/io.catenax.battery.battery_pass/6.1.0/BatteryPass.ttl
@@ -1,0 +1,1143 @@
+#######################################################################
+# Copyright (c) 2022-2024 BASF SE
+# Copyright (c) 2022-2024 BMW AG
+# Copyright (c) 2024-2024 CGI Deutschland B.V. & Co. KG
+# Copyright (c) 2022-2024 Henkel AG & Co. KGaA
+# Copyright (c) 2022-2023 Robert Bosch GmbH
+# Copyright (c) 2022-2024 SAP SE
+# Copyright (c) 2022-2024 T-Systems International GmbH
+# Copyright (c) 2022-2024 ZF Friedrichshafen AG
+# Copyright (c) 2022-2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.battery.battery_pass:6.0.0#> .
+@prefix ext-passport: <urn:samm:io.catenax.generic.digital_product_passport:6.1.0#> .
+
+
+:BatteryPass a samm:Aspect ;
+   samm:preferredName "Battery Passport"@en ;
+   samm:description "The battery pass describes information collected during the lifecycle of a battery. The battery passport is heavily based on the Regulation (EU) 2023/1542 of the European Parliament and of the Council of 12 July 2023 concerning batteries and waste batteries, amending Directive 2008/98/EC and Regulation (EU) 2019/1020 and repealing Directive 2006/66/EC.\nAdditionally attributes come from the Proposal for Ecodesign for Sustainable Products Regulation."@en ;
+   samm:see <https://environment.ec.europa.eu/publications/proposal-ecodesign-sustainable-products-regulation_en> ;
+   samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R1542&qid=1693215264963> ;
+   samm:properties ( :identification :operation :characteristics :sustainability :materials :performance :conformity :safety [ samm:property :sources; samm:optional true ] ext-passport:metadata ext-passport:commercial ext-passport:handling ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:identification a samm:Property ;
+   samm:preferredName "Identification"@en ;
+   samm:description "Battery identification involves specific battery identifiers, including those assigned locally by the manufacturer. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1)(a) refers to AnnexVi PartA (2) refers to Article 38 (6):\nbattery batch number or serial number or product number or another element allowing their identification."@en ;
+   samm:characteristic :IdentificationCharacteristic .
+
+:operation a samm:Property ;
+   samm:preferredName "Operation"@en ;
+   samm:description "General operation information includes details such as the manufacturer's identification and the date of production. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1) (a) and refers to ANNEX VI Part A which refers to Article 38:\n7. Manufacturers shall indicate on the battery their name, registered trade name or registered trade mark, their postal address, indicating a single contact point, and, if available, web and e-mail address. \nFrom Annex XIII (1) (a) and found in ANNEX VI Part A :\n3. the place of manufacture (geographical location of a battery manufacturing plant).\n4. the date of manufacture (month and year)."@en ;
+   samm:characteristic :OperationCharacteristic .
+
+:characteristics a samm:Property ;
+   samm:preferredName "Characteristics"@en ;
+   samm:description "Characteristics of the battery, such as the warranty and the physical dimensions."@en ;
+   samm:characteristic :CharacteristicsElement .
+
+:sustainability a samm:Property ;
+   samm:preferredName "Sustainability"@en ;
+   samm:description "Sustainability includes information on the carbon footprint, sustainability documents and the status of the battery."@en ;
+   samm:characteristic :SustainabilityCharacteristic .
+
+:materials a samm:Property ;
+   samm:preferredName "Materials"@en ;
+   samm:description "Chemical materials relevant for the composition of the battery. These include active, hazardous and critical materials."@en ;
+   samm:characteristic :ChemicalMaterialCharacteristic .
+
+:performance a samm:Property ;
+   samm:preferredName "Performance"@en ;
+   samm:description "Performance attributes of the battery including rated and dynamic values."@en ;
+   samm:characteristic :PerformanceCharacteristic .
+
+:conformity a samm:Property ;
+   samm:preferredName "Conformity"@en ;
+   samm:description "Conformity documents for the battery passport."@en ;
+   samm:characteristic :ConformityCharacteristic .
+
+:safety a samm:Property ;
+   samm:preferredName "Safety"@en ;
+   samm:description "Safety information on the battery. Included are the attributes safety measurements, meaning of labels, safe discharging and dismantling. These are all documents. Additionally information about usable extinguish agent can be provided."@en ;
+   samm:characteristic :SafetyCharacteristic .
+
+:sources a samm:Property ;
+   samm:preferredName "Sources"@en ;
+   samm:description "Consider additional available sources to enhance the content of the battery passport."@en ;
+   samm:characteristic ext-passport:SourceList .
+
+:IdentificationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Identification Characteristic"@en ;
+   samm:description "Battery identification involves specific battery identifiers, including those assigned locally by the manufacturer."@en ;
+   samm:dataType :IdentificationEntity .
+
+:OperationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Operation Characteristic"@en ;
+   samm:description "Characteristic includes details for operational data."@en ;
+   samm:dataType :OperationEntity .
+
+:CharacteristicsElement a samm:Characteristic ;
+   samm:preferredName "Characteristics ELement"@en ;
+   samm:description "Characteristic for the product characteristics."@en ;
+   samm:dataType :CharacteristicsEntity .
+
+:SustainabilityCharacteristic a samm:Characteristic ;
+   samm:preferredName "Sustainability Characteristic"@en ;
+   samm:description "Characteristic for sustainability attributes."@en ;
+   samm:dataType :SustainabilityEntity .
+
+:ChemicalMaterialCharacteristic a samm:Characteristic ;
+   samm:preferredName "Chemical Material Characteristic"@en ;
+   samm:description "Chemical Material Characteristic for the battery."@en ;
+   samm:dataType :ChemicalMaterialEntity .
+
+:PerformanceCharacteristic a samm:Characteristic ;
+   samm:preferredName "Performance Characteristic"@en ;
+   samm:description "Performance Characteristic for the battery."@en ;
+   samm:dataType :PerformanceEntity .
+
+:ConformityCharacteristic a samm:Characteristic ;
+   samm:preferredName "Conformity Characteristic"@en ;
+   samm:description "Characteristic for conformity documents."@en ;
+   samm:dataType :ConformityEntity .
+
+:SafetyCharacteristic a samm:Characteristic ;
+   samm:preferredName "Safety Characteristic"@en ;
+   samm:description "Safety Characteristic for mostly safety documents."@en ;
+   samm:dataType :SafetyEntity .
+
+:IdentificationEntity a samm:Entity ;
+   samm:preferredName "Identification Entity"@en ;
+   samm:description "Entity for the identification of the battery."@en ;
+   samm:properties ( [ samm:property :batteryCategory; samm:payloadName "category" ] :idDmc [ samm:property :batteryChemistry; samm:payloadName "chemistry" ] ext-passport:identification ) .
+
+:OperationEntity a samm:Entity ;
+   samm:preferredName "Operation Entity"@en ;
+   samm:description "Entity which includes details such as the manufacturer's identification and the date of production. The date of the putting into service is optional."@en ;
+   samm:properties ( [ samm:property :intoServiceDate; samm:optional true ] ext-passport:manufacturer ) .
+
+:CharacteristicsEntity a samm:Entity ;
+   samm:preferredName "Characteristics Entity"@en ;
+   samm:description "Entity for the product characteristics."@en ;
+   samm:properties ( :warranty :physicalDimension ) .
+
+:SustainabilityEntity a samm:Entity ;
+   samm:preferredName "Sustainability Entity"@en ;
+   samm:description "Entity which includes information on the carbon footprint, sustainability documents and the status of the battery."@en ;
+   samm:properties ( [ samm:property :sustainabilityDocuments; samm:payloadName "documents" ] :carbonFootprint [ samm:property ext-passport:state; samm:payloadName "status" ] ) .
+
+:ChemicalMaterialEntity a samm:Entity ;
+   samm:preferredName "Chemical Material Entity"@en ;
+   samm:description "Chemical Material Entity for the battery. Included are active, hazardous and critical materials as well as a material symbol. This is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Article 13:\n5. All batteries containing more than 0,002 % cadmium or more than 0,004 % lead, shall be marked with the chemical symbol for the metal concerned: Cd or Pb."@en ;
+   samm:properties ( [ samm:property :activeMaterials; samm:payloadName "active" ] [ samm:property :hazardousSubstance; samm:payloadName "hazardous" ] [ samm:property :materialComposition; samm:payloadName "composition" ] ) .
+
+:PerformanceEntity a samm:Entity ;
+   samm:preferredName "Performance Entity"@en ;
+   samm:description "Performance Entity with attributes of the battery including rated and dynamic values."@en ;
+   samm:properties ( [ samm:property :ratedPerformance; samm:payloadName "rated" ] [ samm:property :dynamicPerformance; samm:payloadName "dynamic" ] ) .
+
+:ConformityEntity a samm:Entity ;
+   samm:preferredName "Conformity Entity"@en ;
+   samm:description "Entity for conformity documents."@en ;
+   samm:properties ( [ samm:property :declarationOfConformityId; samm:optional true ] :declarationOfConformity :resultOfTestReport :thirdPartyAssurance :dueDiligencePolicy ) .
+
+:SafetyEntity a samm:Entity ;
+   samm:preferredName "Safety Entity"@en ;
+   samm:description "Entity with the attributes safety measurements, meaning of labels, safe discharging and dismantling. These are all documents. Additionally information about usable extinguish agent can be provided."@en ;
+   samm:properties ( :usableExtinguishAgent :safetyMeasures :meaningOfLabels [ samm:property :safeDischarging; samm:optional true ] :dismantling [ samm:property :removalFromAppliance; samm:optional true ] ) .
+
+:batteryCategory a samm:Property ;
+   samm:preferredName "Battery Category"@en ;
+   samm:description "The battery category, which can be a portable battery; starting, lighting and ignition battery (SLI); light means of transport battery (LMT); electric vehicle battery (EV), industrial battery and incorporated battery. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1) (a) and refers to ANNEX VI Part A:\n2. the battery category and information identifying the battery in accordance with Article 38(6)."@en ;
+   samm:characteristic :CategoryEnumeration ;
+   samm:exampleValue "EV" .
+
+:idDmc a samm:Property ;
+   samm:preferredName "Id DMC"@en ;
+   samm:description "The unique identifier of the product, when it is placed on the market. Through this identifier a web link can be accessed. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Article 77:\n3. The battery passport shall be accessible through the QR code referred to in Article 13(6) which links to a unique identifier that the economic operator placing the battery on the market shall attribute to it. The QR code and the unique identifier shall comply with the ISO/IEC standards 15459-1:2014, 15459-2:2015, 15459-3:2014, 15459-4:2014, 15459-5:2014 and 15459-6:2014 or their equivalent.\nDefined is the QR code in Article 3:\n(24) \"QR code\" means a machine-readable matrix code that links to information as required by this Regulation.\n(66) \"unique identifier\" means a unique string of characters for the identification of batteries that also enables a web link to the battery passport."@en ;
+   samm:characteristic ext-passport:IdentifierCharacteristic ;
+   samm:exampleValue "34567890" .
+
+:batteryChemistry a samm:Property ;
+   samm:preferredName "Battery Chemistry"@en ;
+   samm:description "Battery chemistry refers to the specific chemical composition and reactions that occur within a battery to produce and store electrical energy. The chemistry has to be stated as detailed as possible for example: the Nickel Cobalt Manganese battery 'NCM'. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1) (a) and refers to ANNEX VI Part A:\n7. the chemestry."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Nickel Cobalt Manganese (NCM)".
+
+:intoServiceDate a samm:Property ;
+   samm:preferredName "Into Service Date"@en ;
+   samm:description "Putting into service is the transition from a state of readiness to actual use or operation. The date should be formatted as yyyy-mm-dd. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex VII Part B: \n1.the date of manufacture of the battery and, where appropriate, the date of putting into service;\nDefined is \"putting into service\" in Article 3:\n(18) \"putting into service\" means the first use, for its intended purpose, in the Union, of a battery, without having been previously placed on the market."@en ;
+   samm:characteristic ext-passport:DateTrait .
+
+:warranty a samm:Property ;
+   samm:preferredName "Warranty"@en ;
+   samm:description "The warranty of the battery. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in ANNEX XIII:\n(m) period for which the commercial warranty for the calendar life applies."@en ;
+   samm:characteristic :WarrantyCharacteristic .
+
+:physicalDimension a samm:Property ;
+   samm:preferredName "Physical Dimension"@en ;
+   samm:description "The weight of the battery. For calculation of the energy density, the volume is also needed. The energy density of a battery is measured in watt-hours per kilogram (Wh/kg) and watt-hours per liter (Wh/L). These measures indicate how much energy a battery can store relative to its weight and volume, respectively. Other measurements are optional.These are mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1)(a) and refers to Annex VI Part A:\n5. the weight."@en ;
+   samm:characteristic :PhysicalDimensionCharacteristic .
+
+:sustainabilityDocuments a samm:Property ;
+   samm:preferredName "sustainability Documents"@en ;
+   samm:description "Sustainability documents of the battery."@en ;
+   samm:characteristic :SustainabilityDocumentCharacteristic .
+
+:carbonFootprint a samm:Property ;
+   samm:preferredName "Carbon Footprint"@en ;
+   samm:description "The carbon footprint of the battery calculated as kg of carbon dioxide equivalent per one kWh of the total energy provided by the battery over its expected service life. Relevant attributes are the value, the unit, the referenced rulebook, the lifecycle where applied, the declaration, the performance class, the type (PCF), the declaration and the facility. These attributes are mentioned in the Battery regulation 2023/1542 from 12 July 2023 in several places.\nAnnex XIII (1) (c) refers to Article 7 (2) which refers to Article 7 (1)(d):\n1. For electric vehicle batteries, rechargeable industrial batteries with a capacity greater than 2 kWh and LMT batteries a carbon footprint declaration shall be drawn up for each battery model per manufacturing plant, in accordance with the implementing act referred to in the fourth subparagraph and containing, at least, the following information:\n[...] (d) the carbon footprint of the battery, calculated as kg of carbon dioxide equivalent per one kWh of the total energy provided by the battery over its expected service life;\nAnd as well in Article 7:\n2. Electric vehicle batteries, rechargeable industrial batteries with a capacity greater than 2 kWh and LMT batteries shall bear a conspicuous, clearly legible and indelible label indicating the carbon footprint of the battery referred to in paragraph 1, first subparagraph, point (d) and declaring the carbon footprint performance class to which the relevant battery model per manufacturing plant corresponds.\nFurther specified in Annex XIII (1) (c) and refers to Article 7 (1):\n[...] The Commission shall, by 18 February 2024 for electric vehicle batteries, 18 February 2025 for rechargeable industrial batteries, except those with external storage, 18 February 2027 for LMT batteries and 18 February 2029 for industrial batteries with external storage, adopt:\n(a) a delegated act in accordance with Article 89 to supplement this Regulation by establishing the methodology for the calculation and verification of the carbon footprint of the battery referred to in the first subparagraph, point (d), in accordance with the essential elements set out in Annex II;\nThese parameters are defined by Article 3:\n(21) \"carbon footprint\" means the sum of greenhouse gas emissions and greenhouse gas removals in a product system, expressed as carbon dioxide equivalents and based on a Product Environmental Footprint (PEF) study using the single impact category of climate change;\nand defined by Annex II (2):\n(e) \"life cycle\" means the consecutive and interlinked stages of a product system, from raw material acquisition or generation from natural resources to final disposal (ISO 14040:2006 or an equivalent standard)."@en ;
+   samm:characteristic ext-passport:FootprintList .
+
+:activeMaterials a samm:Property ;
+   samm:preferredName "Active Materials"@en ;
+   samm:description "The active materials included in the battery. Mandatory are nickel, lithium, cobalt and lead. Others are optional. Defined by the Battery regulation 2023/1542 from 12 July 2023 in Article 3 Definitions:\n(5) ‘active material’ means a material which reacts chemically to produce electric energy when the battery cell discharges or to store electric energy when the battery is being charged."@en ;
+   samm:characteristic :ActiveMaterialsCharacteristic .
+
+:hazardousSubstance a samm:Property ;
+   samm:preferredName "Hazardous Substance"@en ;
+   samm:description "Hazardous substances like lead, cadmium and mercury."@en ;
+   samm:characteristic :HazardousSubstanceCharacteristic .
+
+:materialComposition a samm:Property ;
+   samm:preferredName "Material Composition"@en ;
+   samm:description "The materials which are necessary to describe the material composition, especially if they are active, critical or hazardous. This can be redundant to the specifically mentioned active or hazardous materials. This is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(b) the material composition of the battery, including its chemistry, hazardous substances present in the battery, other than mercury, cadmium or lead, and critical raw materials present in the battery; \n(f) the share of renewable content.\nand in Annex XIII (2):\n(a) detailed composition, including materials used in the cathode, anode and electrolyte;\nDefinition from Article 3:\n(52) \"hazardous substance\" means a substance classified as hazardous pursuant to Article 3 of Regulation (EC) No 1272/2008:\nA substance or a mixture fulfilling the criteria relating to physical hazards, health hazards or environmental hazards, laid down in Parts 2 to 5 of Annex I is hazardous and shall be classified in relation to the respective hazard classes provided for in that Annex.\nWhere, in Annex I, hazard classes are differentiated on the basis of the route of exposure or the nature of the effects, the substance or mixture shall be classified in accordance with such differentiation.\nDefined in Article 2 of Regulation (EC) No 1272/2008:\n1. hazard class\" means the nature of the physical, health or environmental hazard."@en ;
+   samm:characteristic :MaterialCompositionList .
+
+:ratedPerformance a samm:Property ;
+   samm:preferredName "Rated Performance"@en ;
+   samm:description "Rated performance values of the battery such as voltage, round trip efficiency, energy, resistance, power, capacity, temperature ranges and self-discharging rate."@en ;
+   samm:characteristic :RatedPerformanceCharacteristic .
+
+:dynamicPerformance a samm:Property ;
+   samm:preferredName "Dynamic Performance"@en ;
+   samm:description "Dynamic performance values of the battery."@en ;
+   samm:characteristic :DynamicPerformanceCharacteristic .
+
+:declarationOfConformityId a samm:Property ;
+   samm:preferredName "Declaration of Conformity Id"@en ;
+   samm:description "Identification number of the EU declaration of conformity. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(r) the EU declaration of conformity referred to in Article 18."@en ;
+   samm:characteristic ext-passport:IdentifierCharacteristic ;
+   samm:exampleValue "0978234-34567890-01" .
+
+:declarationOfConformity a samm:Property ;
+   samm:preferredName "Declaration of Conformity"@en ;
+   samm:description "The EU Declaration of Conformity is a document in which the manufacturer or their authorized representative declares that the battery complies with all relevant European Union product safety directives and regulations. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(r) the EU declaration of conformity referred to in Article 18."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:resultOfTestReport a samm:Property ;
+   samm:preferredName "Result of Test Report"@en ;
+   samm:description "The result of tests reports refers to the results of various tests conducted with the battery, testing its life cycle, life span, c-rate and various other aspects. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(l) temperature range the battery can withstand when not in use (reference test);\nand Annex XIII (3):\nresults of test reports proving compliance with the requirements laid down in this Regulation or any delegated or implementing act adopted pursuant to this Regulation."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:thirdPartyAssurance a samm:Property ;
+   samm:preferredName "Third Party Assurance"@en ;
+   samm:description "A summary report from third-parties, covering the verifications. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1) (d) refers to the Article 52:\n3. The economic operator referred to in Article 48(1) shall on an annual basis review and make publicly available, including on the internet, a report on its battery due diligence policy. [...], as well as a summary report of the third-party verifications carried out in accordance with Article 51, including the name of the notified body, with due regard for business confidentiality and other competitive concerns. That report shall also cover, where relevant, access to information, public participation in decision-making and access to justice in environmental matters in relation to the sourcing, processing and trading of the raw materials present in batteries."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:dueDiligencePolicy a samm:Property ;
+   samm:preferredName "Due Diligence Policy"@en ;
+   samm:description "A report containing the information concerning the due diligence policy, a set of procedures and guidelines the organization follows to thoroughly assess and evaluate the various aspects of the battery. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1) (d) refers to the Article 52:\n3. The economic operator referred to in Article 48(1) shall on an annual basis review and make publicly available, including on the internet, a report on its battery due diligence policy. That report shall contain, in a manner that is easily comprehensible for end-users and clearly identifies the batteries concerned, the data and information on steps taken by that economic operator to comply with the requirements laid down in Articles 49 and 50, including findings of significant adverse impacts in the risk categories listed in point 2 of Annex X, and how they have been addressed, as well as a summary report of the third-party verifications carried out in accordance with Article 51, including the name of the notified body, with due regard for business confidentiality and other competitive concerns. That report shall also cover, where relevant, access to information, public participation in decision-making and access to justice in environmental matters in relation to the sourcing, processing and trading of the raw materials present in batteries."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:usableExtinguishAgent a samm:Property ;
+   samm:preferredName "Usable Extinguish Agent"@en ;
+   samm:description "The usable extinguish agents for the battery in case of a fire. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1)(a) and refers to Annex VI Part A\n9. usable extinguishing agent."@en ;
+   samm:characteristic :ExtinguishAgentList .
+
+:safetyMeasures a samm:Property ;
+   samm:preferredName "Safety Measures"@en ;
+   samm:description "Safety instruction in the form of a documentation. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (2):\n(d) safety measures."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:meaningOfLabels a samm:Property ;
+   samm:preferredName "Meaning of Labels"@en ;
+   samm:description "Documentation on the meaning of labels on a battery which provide information to help users understand the various symbols, markings, and information present on the battery's label. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1)(s) and refers to Article 74 (1):\n(e) the meaning of the labels and symbols on batteries in accordance with Article 13 or printed on their packaging or in the documents accompanying batteries [...]."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:safeDischarging a samm:Property ;
+   samm:preferredName "Safe Discharging"@en ;
+   samm:description "Safe discharging documentation explaining for example the setting of a minimum voltage threshold for the battery. Discharging a battery below this threshold can lead to damage, reduced capacity, and safety hazards."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:dismantling a samm:Property ;
+   samm:preferredName "Dismantling"@en ;
+   samm:description "Dismantling refers to the proper way of dismantling the battery itself. It refers to the process of taking apart the battery for various purposes, such as recycling, disposal, or examination of its components. This attribute is mentioned in the Battery Regulation 2023/1542 from 12 July 2023 in Annex XIII (2) (c) dismantling information, including at least:\n- exploded diagrams of the battery system/pack showing the location of battery cells,\n- disassembly sequences,\n- type and number of fastening techniques to be unlocked,\n- tools required for disassembly,\n- warnings if risk of damaging parts exist,\n- amount of cells used and layout."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:removalFromAppliance a samm:Property ;
+   samm:preferredName "Removal From Appliance"@en ;
+   samm:description "Removal refers to the proper process of disassembling a battery from an appliance, typically for purposes such as repairs, replacements, or disposal."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:CategoryEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Category Enumeration"@en ;
+   samm:description "Enumeration with the values, portable battery; starting, lighting and ignition battery (SLI); light means of transport battery (LMT); electric vehicle battery (EV), industrial battery and incorporated battery."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "SLI" "LMT" "EV" "industrial" "portable" "incorporated" ) .
+
+:WarrantyCharacteristic a samm:Characteristic ;
+   samm:preferredName "Warranty Characteristic"@en ;
+   samm:description "Characteristic for the warranty."@en ;
+   samm:dataType :WarrantyEntity .
+
+:PhysicalDimensionCharacteristic a samm:Characteristic ;
+   samm:preferredName "Physical Dimension Characteristic"@en ;
+   samm:description "Characteristic for the physical dimensions."@en ;
+   samm:dataType :PhysicalDimensionEntity .
+
+:SustainabilityDocumentCharacteristic a samm:Characteristic ;
+   samm:preferredName "Sustainability Document Characteristic"@en ;
+   samm:description "Characteristic for sustainability documents of the battery."@en ;
+   samm:dataType :SustainabilityDocumentEntity .
+
+:ActiveMaterialsCharacteristic a samm:Characteristic ;
+   samm:preferredName "Active Materials Characteristic"@en ;
+   samm:description "Characteristic for the active materials."@en ;
+   samm:dataType :ActiveMaterialEntity .
+
+:HazardousSubstanceCharacteristic a samm:Characteristic ;
+   samm:preferredName "Hazardous Substance Characteristic"@en ;
+   samm:description "Hazardous Substance Characteristic for the battery chemical materials."@en ;
+   samm:dataType :HazardousSubstanceEntity .
+
+:MaterialCompositionList a samm-c:List ;
+   samm:preferredName "Material Composition List"@en ;
+   samm:description "List for the material composition."@en ;
+   samm:dataType :MaterialCompositionEntity .
+
+:RatedPerformanceCharacteristic a samm:Characteristic ;
+   samm:preferredName "Rated Performance Characteristic"@en ;
+   samm:description "Characteristic for rated performance values of the battery."@en ;
+   samm:dataType :RatedPerformanceEntity .
+
+:DynamicPerformanceCharacteristic a samm:Characteristic ;
+   samm:preferredName "Dynamic Performance Characteristic"@en ;
+   samm:description "Characteristic for dynamic performance values of the battery."@en ;
+   samm:dataType :DynamicPerformanceEntity .
+
+:ExtinguishAgentList a samm-c:List ;
+   samm:preferredName "Extinguish Agent List"@en ;
+   samm:description "List of extinguish agents."@en ;
+   samm:dataType :ExtinguishAgentEntity .
+
+:WarrantyEntity a samm:Entity ;
+   samm:preferredName "Warranty Entity"@en ;
+   samm:description "Entity for the warranty with a value and unit."@en ;
+   samm:properties ( ext-passport:lifeValue ext-passport:lifeUnit ) .
+
+:PhysicalDimensionEntity a samm:Entity ;
+   samm:preferredName "Physical Dimension Entity"@en ;
+   samm:description "Entity for the physical dimension with weight, volume and other optional values."@en ;
+   samm:properties ( [ samm:property ext-passport:height; samm:optional true ] [ samm:property ext-passport:length; samm:optional true ] [ samm:property ext-passport:width; samm:optional true ] ext-passport:weight ) .
+
+:SustainabilityDocumentEntity a samm:Entity ;
+   samm:preferredName "Sustainability Document Entity"@en ;
+   samm:description "Sustainability Document Entity which encapsulates relevant information in the form of documents."@en ;
+   samm:properties ( :separateCollection :wastePrevention [ samm:property :euTaxonomyDisclosureStatement; samm:optional true ] [ samm:property :sustainabilityReport; samm:optional true ] ) .
+
+:ActiveMaterialEntity a samm:Entity ;
+   samm:preferredName "Active Material Entity"@en ;
+   samm:description "Entity for the active materials included in the battery. Mandatory are nickel, lithium, cobalt and lead."@en ;
+   samm:properties ( :nickel :lithium :cobalt :lead [ samm:property :otherActiveMaterials; samm:optional true; samm:payloadName "other" ] ) .
+
+:HazardousSubstanceEntity a samm:Entity ;
+   samm:preferredName "Hazardous Substance Entity"@en ;
+   samm:description "Hazardous Substance Entity for hazardous chemical materials."@en ;
+   samm:properties ( [ samm:property :hazardousCadmium; samm:payloadName "cadmium" ] [ samm:property :hazardousMercury; samm:payloadName "mercury" ] [ samm:property :otherHazardousMaterial; samm:optional true; samm:payloadName "other" ] :lead ) .
+
+:MaterialCompositionEntity a samm:Entity ;
+   samm:preferredName "Material Composition Entity"@en ;
+   samm:description "Entity for the material composition."@en ;
+   samm:properties ( [ samm:property ext-passport:materialIdentification; samm:payloadName "id" ] ext-passport:concentration [ samm:property ext-passport:materialUnit; samm:payloadName "unit" ] ext-passport:critical ext-passport:documentation ext-passport:recycled ext-passport:location ext-passport:renewable ) .
+
+:RatedPerformanceEntity a samm:Entity ;
+   samm:preferredName "Rated Performance Entity"@en ;
+   samm:description "Entity for rated performance values of the battery."@en ;
+   samm:properties ( :voltage [ samm:property :ratedRoundTripEfficiency; samm:payloadName "roundTripEfficiency" ] [ samm:property :ratedEnergy; samm:optional true; samm:payloadName "energy" ] [ samm:property :ratedResistance; samm:payloadName "resistance" ] [ samm:property :ratedPower; samm:payloadName "power" ] [ samm:property :ratedCapacity; samm:payloadName "capacity" ] [ samm:property :performanceDocument; samm:optional true ] [ samm:property :performanceTemperature; samm:payloadName "temperature" ] :selfDischargingRate [ samm:property :testReport; samm:optional true ] :lifetime ) .
+
+:DynamicPerformanceEntity a samm:Entity ;
+   samm:preferredName "Dynamic Performance Entity"@en ;
+   samm:description "Entity for dynamic performance values of the battery."@en ;
+   samm:properties ( :stateOfCharge :fullCycles [ samm:property :performanceDocument; samm:optional true ] :selfDischargingRate [ samm:property :dynamicPower; samm:payloadName "power" ] [ samm:property :dynamicCapacity; samm:payloadName "capacity" ] [ samm:property :dynamicRoundTripEfficiency; samm:payloadName "roundTripEfficiency" ] [ samm:property :dynamicInternalResistance; samm:payloadName "resistance" ] [ samm:property :dynamicEnergy; samm:payloadName "energy" ] [ samm:property :negativeEvents; samm:optional true ] [ samm:property :operatingEnvironment; samm:optional true ] ) .
+
+:ExtinguishAgentEntity a samm:Entity ;
+   samm:preferredName "Extinguish Agent Entity"@en ;
+   samm:description "Entity for the extinguish agents."@en ;
+   samm:properties ( [ samm:property :agentDocument; samm:optional true; samm:payloadName "document" ] [ samm:property :usableExtinguishingMedia; samm:payloadName "media" ] :fireClass ) .
+
+:separateCollection a samm:Property ;
+   samm:preferredName "Separate Collection"@en ;
+   samm:description "Documentation about separate collection of batteries involve information on how to properly collect, handle, and recycle batteries to ensure environmental sustainability and compliance with regulations. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1) (s), refers to  Article 74:\n1. In addition to the information referred to in Article 8a(2) of Directive 2008/98/EC, producers or, where appointed in accordance with Article 57(1), producer responsibility organisations shall make available to end-users and distributors the following information regarding the prevention and management of waste batteries with regard to the categories of batteries that they supply within the territory of a Member State:\n(a) the role of end-users in contributing to waste prevention, including by information on good practices and recommendations concerning the use of batteries aimed at extending their use phase and the possibilities of re-use, preparation for re-use, preparation for repurposing, repurposing and remanufacturing;\n(b) the role of end-users in contributing to the separate collection of waste batteries in accordance with their obligations under Article 64 to allow their treatment;\n(c) the separate collection, take-back and collection points, preparation for re-use, preparation for repurposing and treatment available for waste batteries;\n(d) the necessary safety instructions to handle waste batteries, including in relation to the risks associated with, and the handling of, batteries containing lithium;\n(e) the meaning of the labels and symbols on batteries in accordance with Article 13 or printed on their packaging or in the documents accompanying batteries; and\n(f) the impact of substances, in particular hazardous substances, present in batteries on the environment and on human health or the safety of persons, including the impact due to inappropriate discarding of waste batteries, such as littering or discarding as unsorted municipal waste."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:wastePrevention a samm:Property ;
+   samm:preferredName "Waste Prevention"@en ;
+   samm:description "Documentation about waste prevention for batteries which include guidelines, recommendations, and information on minimizing the environmental impact associated with the use and disposal of batteries. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1) (s), refers to  Article 74 (1) which call Article 8a of Directive 2008/98/EC:\n2. Member States shall take the necessary measures to ensure that the waste holders targeted by the extended producer responsibility schemes established in accordance with Article 8 (1), are informed about waste prevention measures, centres for re-use and preparing for re-use, take-back and collection systems, and the prevention of littering. Member States shall also take measures to create incentives for the waste holders to assume their responsibility to deliver their waste into the separate collection systems in place, notably, where appropriate, through economic incentives or regulations."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:euTaxonomyDisclosureStatement a samm:Property ;
+   samm:preferredName "EU Taxonomy Disclosure Statement"@en ;
+   samm:description "Optional disclosure regarding the EU taxonomy, with the choice to voluntarily provide the EU Taxonomy disclosure through the battery passport."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:sustainabilityReport a samm:Property ;
+   samm:preferredName "Sustainability Report"@en ;
+   samm:description "Voluntarily making the Sustainability Report available via the battery passport. A report containing the information concerning the sustainability in form of a document."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:nickel a samm:Property ;
+   samm:preferredName "Nickel"@en ;
+   samm:description "Information about the percentage of recovered nickel from waste. These attribute are mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1)(e) refers to Article 8:\n1. From 18 August 2028 or 24 months after the date of entry into force of the delegated act referred to in the third subparagraph, whichever is the latest, industrial batteries with a capacity greater than 2 kWh, except those with exclusively external storage, electric vehicle batteries and SLI batteries that contain cobalt, lead, lithium or nickel in active materials, shall be accompanied by documentation containing information about the percentage share of cobalt, lithium or nickel that is present in active materials and that has been recovered from battery manufacturing waste or post-consumer waste, and the percentage share of lead that is present in the battery and that has been recovered from waste, for each battery model per year and per manufacturing plant."@en ;
+   samm:characteristic :MaterialActive .
+
+:lithium a samm:Property ;
+   samm:preferredName "Lithium"@en ;
+   samm:description "Information about the percentage of recovered lithium from waste. These attribute are mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1)(e) refers to Article 8:\n1. From 18 August 2028 or 24 months after the date of entry into force of the delegated act referred to in the third subparagraph, whichever is the latest, industrial batteries with a capacity greater than 2 kWh, except those with exclusively external storage, electric vehicle batteries and SLI batteries that contain cobalt, lead, lithium or nickel in active materials, shall be accompanied by documentation containing information about the percentage share of cobalt, lithium or nickel that is present in active materials and that has been recovered from battery manufacturing waste or post-consumer waste, and the percentage share of lead that is present in the battery and that has been recovered from waste, for each battery model per year and per manufacturing plant."@en ;
+   samm:characteristic :MaterialActive .
+
+:cobalt a samm:Property ;
+   samm:preferredName "Cobalt"@en ;
+   samm:description "Information about the percentage of recovered cobalt from waste. These attribute are mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1)(e) refers to Article 8:\n1. From 18 August 2028 or 24 months after the date of entry into force of the delegated act referred to in the third subparagraph, whichever is the latest, industrial batteries with a capacity greater than 2 kWh, except those with exclusively external storage, electric vehicle batteries and SLI batteries that contain cobalt, lead, lithium or nickel in active materials, shall be accompanied by documentation containing information about the percentage share of cobalt, lithium or nickel that is present in active materials and that has been recovered from battery manufacturing waste or post-consumer waste, and the percentage share of lead that is present in the battery and that has been recovered from waste, for each battery model per year and per manufacturing plant."@en ;
+   samm:characteristic :MaterialActive .
+
+:lead a samm:Property ;
+   samm:preferredName "Lead"@en ;
+   samm:description "Information about the lead in the battery. As this is an active and hazardous material, all properties for hazardous as well as active materials are required. These attribute are mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1)(e) refers to Article 8:\n1. From 18 August 2028 or 24 months after the date of entry into force of the delegated act referred to in the third subparagraph, whichever is the latest, industrial batteries with a capacity greater than 2 kWh, except those with exclusively external storage, electric vehicle batteries and SLI batteries that contain cobalt, lead, lithium or nickel in active materials, shall be accompanied by documentation containing information about the percentage share of cobalt, lithium or nickel that is present in active materials and that has been recovered from battery manufacturing waste or post-consumer waste, and the percentage share of lead that is present in the battery and that has been recovered from waste, for each battery model per year and per manufacturing plant.\nAnd for hazardous materials this is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1) (a) refers to Annex VI Part A: \n8. the hazardous substances present in the battery, other than mercury, cadmium or lead;\nAdditionally in Article 13:\n5. All batteries containing more than 0,002 % cadmium or more than 0,004 % lead, shall be marked with the chemical symbol for the metal concerned: Cd or Pb.\nDefined in Article 3:\n(52) \"hazardous substance\" means a substance classified as hazardous pursuant to Article 3 of Regulation (EC) No 1272/2008."@en ;
+   samm:characteristic :LeadCharacteristic .
+
+:otherActiveMaterials a samm:Property ;
+   samm:preferredName "Other Active Materials"@en ;
+   samm:description "Other active materials in the battery."@en ;
+   samm:characteristic :OtherActiveMaterialsList .
+
+:hazardousCadmium a samm:Property ;
+   samm:preferredName "Hazardous Cadmium"@en ;
+   samm:description "Information about the presence of cadmium in the battery. Therefore, a concentration and the location within the battery has to be given. This is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1) (a) refers to Annex VI Part A: \n8. the hazardous substances present in the battery, other than mercury, cadmium or lead;\nDefined in Article 3:\n(52) \"hazardous substance\" means a substance classified as hazardous pursuant to Article 3 of Regulation (EC) No 1272/2008.\nAdditionally in Article 13:\n5. All batteries containing more than 0,002 % cadmium or more than 0,004 % lead, shall be marked with the chemical symbol for the metal concerned: Cd or Pb."@en ;
+   samm:characteristic :HazardousCharacteristic .
+
+:hazardousMercury a samm:Property ;
+   samm:preferredName "Hazardous Mercury"@en ;
+   samm:description "Information about the presence of mercury in the battery. Therefore, a concentration and the location within the battery has to be given. This is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1) (a) refers to Annex VI Part A: \n8. the hazardous substances present in the battery, other than mercury, cadmium or lead;\nDefined in Article 3:\n(52) \"hazardous substance\" means a substance classified as hazardous pursuant to Article 3 of Regulation (EC) No 1272/2008."@en ;
+   samm:characteristic :HazardousCharacteristic .
+
+:otherHazardousMaterial a samm:Property ;
+   samm:preferredName "Other Hazardous Material"@en ;
+   samm:description "Other hazardous materials."@en ;
+   samm:characteristic :OtherHazardousMaterialList .
+
+:voltage a samm:Property ;
+   samm:preferredName "Voltage"@en ;
+   samm:description "Voltage values are mandatory for the battery, with the option to include temperature values voluntarily. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(h) minimal, nominal and maximum voltage, with temperature ranges when relevant."@en ;
+   samm:characteristic :VoltageCharacteristic .
+
+:ratedRoundTripEfficiency a samm:Property ;
+   samm:preferredName "Rated Round Trip Efficiency"@en ;
+   samm:description "The efficiency value of a battery refers to the ratio of useful output energy to the input energy, expressed as a percentage. With the option to include temperature values voluntarily."@en ;
+   samm:characteristic :RatedRoundTripEfficiencyCharacteristic .
+
+:ratedEnergy a samm:Property ;
+   samm:preferredName "Rated Energy"@en ;
+   samm:description "Representation of the total amount of energy that the battery can store and subsequently deliver during its discharge cycle. It is necessary to calculate the SOCE."@en ;
+   samm:characteristic :RatedEnergyCharacteristic .
+
+:ratedResistance a samm:Property ;
+   samm:preferredName "Rated Resistance"@en ;
+   samm:description "Rated resistance of the battery on the level of the pack, module (optional) and cell."@en ;
+   samm:characteristic :RatedResistanceCharacteristic .
+
+:ratedPower a samm:Property ;
+   samm:preferredName "Rated Power"@en ;
+   samm:description "The power value is the rate at which energy is delivered or consumed. It is measured in watts (W) and represents how quickly energy is transferred. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4)(a) refers to Article 10(1), refers to Annex IV Part A: \t\n2. Power (in W) and power fade (in %).\nDefinition from Annex IV:\n(3) \"Power\" means the amount of energy that a battery is capable of providing over a given period under reference conditions."@en ;
+   samm:characteristic :RatedPowerCharacteristic .
+
+:ratedCapacity a samm:Property ;
+   samm:preferredName "Rated Capacity"@en ;
+   samm:description "Capacity value refers to the amount of electric charge that a battery can store and subsequently deliver when needed. It is a fundamental characteristic of a battery and is expressed in ampere-hours. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(g) rated capacity (in Ah);\nand in Annex XIII (4)(a) referring to Article 10 (1) and referring to Annex IV Part A:\n1. Rated capacity (in Ah) and capacity fade (in %). \nAnd in Annex XIII (1)(a) referring to Annex VI Part A:\n6. the capacity;\nDefinition from Annex IV:\n(1) \"Rated capacity\" means the total number of ampere-hours (Ah) that can be withdrawn from a fully charged battery under reference conditions."@en ;
+   samm:characteristic :RatedCapacityCharacteristic .
+
+:performanceDocument a samm:Property ;
+   samm:preferredName "Performance Document"@en ;
+   samm:description "The performance document lists information regarding the performance of the battery. This can be an overview about several rated performance attributes. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (3):\n[...] results of test reports proving compliance with the requirements laid down in this Regulation or any delegated or implementing act adopted pursuant to this Regulation.\nAnd Annex XIII (4)(a) refers to Article 10(1) and refer to Annex IV Part B:\n5. Any calculations performed with the measured parameters, if applicable."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:performanceTemperature a samm:Property ;
+   samm:preferredName "Performance Temperature"@en ;
+   samm:description "The battery temperatures. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(l) temperature range the battery can withstand when not in use (reference test)."@en ;
+   samm:characteristic :PerformanceTemperatureCharacteristic .
+
+:selfDischargingRate a samm:Property ;
+   samm:preferredName "Self Discharging Rate"@en ;
+   samm:description "The self-discharge rate of a battery refers to the rate at which the battery loses its stored energy when not in use. It's the discharge of the battery that occurs internally without any external load recorded in percentage for every month. This attribute is mentioned in the Battery Regulation 2023/1542 from 12 July 2023 in Annex XIII (4) (b) refers to Article 14, refers to Annex VII Part A:\n4. the evolution of self-discharging rates."@en ;
+   samm:characteristic :PercentMeasurement ;
+   samm:exampleValue "0.25"^^xsd:double .
+
+:testReport a samm:Property ;
+   samm:preferredName "Test Report"@en ;
+   samm:description "The test reports refer to the testing conducted during the determination of the rated values of the battery. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (3):\n[...] results of test reports proving compliance with the requirements laid down in this Regulation or any delegated or implementing act adopted pursuant to this Regulation.\nAnd Annex XIII (4)(a) refers to Article 10(1) and refer to Annex IV Part B:\n5. Any calculations performed with the measured parameters, if applicable."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:lifetime a samm:Property ;
+   samm:preferredName "Lifetime"@en ;
+   samm:description "Attributes for the lifetime evaluation of a battery."@en ;
+   samm:characteristic :LifeCycleCharacteristic .
+
+:stateOfCharge a samm:Property ;
+   samm:preferredName "State of Charge"@en ;
+   samm:description "State of Charge (SOC) refers to the amount of energy remaining in a battery at a given point in time, expressed as a percentage of the total capacity. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4):\n(d) information and data resulting from its use, including the number of charging and discharging cycles and negative events, such as accidents, as well as periodically recorded information on the operating environmental conditions, including temperature, and on the state of charge."@en ;
+   samm:characteristic :RecordCharacteristic .
+
+:fullCycles a samm:Property ;
+   samm:preferredName "Full Cycles"@en ;
+   samm:description "Full cycles include the cumulative and equivalent count of complete charge and discharge cycles experienced by the battery over its entire life. This attribute is mentioned in the Battery Regulation 2023/1542 from 12 July 2023 in Annex XIII (4) (d) information and data resulting from its use, including the number of charging and discharging cycles and negative events, such as accidents, as well as periodically recorded information on the operating environmental conditions, including temperature, and on the state of charge.\nAnd in AnnexVII Part B:\n5. the number of full equivalent charge-discharge cycles."@en ;
+   samm:characteristic :FullCycleCharacteristic .
+
+:dynamicPower a samm:Property ;
+   samm:preferredName "Dynamic Power"@en ;
+   samm:description "Values that describe dynamically captured power values."@en ;
+   samm:characteristic :DynamicPowerCharacteristic .
+
+:dynamicCapacity a samm:Property ;
+   samm:preferredName "Dynamic Capacity"@en ;
+   samm:description "Values that describe dynamically captured capacity values."@en ;
+   samm:characteristic :DynamicCapacityCharacteristic .
+
+:dynamicRoundTripEfficiency a samm:Property ;
+   samm:preferredName "Dynamic Round Trip Efficiency"@en ;
+   samm:description "Dynamic round trip efficiency values."@en ;
+   samm:characteristic :DynamicRoundTripEfficiencyCharacteristic .
+
+:dynamicInternalResistance a samm:Property ;
+   samm:preferredName "Dynamic Internal Resistance"@en ;
+   samm:description "Values that describe dynamically captured internal resistance values."@en ;
+   samm:characteristic :DynamicInternalResistanceCharacteristic .
+
+:dynamicEnergy a samm:Property ;
+   samm:preferredName "Dynamic Energy"@en ;
+   samm:description "Values that describe dynamically captured energy values."@en ;
+   samm:characteristic :DynamicEnergyCharacteristic .
+
+:negativeEvents a samm:Property ;
+   samm:preferredName "Negative Events"@en ;
+   samm:description "Mandatory if applicable. Negative events refers to several possible events influencing the battery's condition and lifetime such as extreme temperatures. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4):\n(d) information and data resulting from its use, including the number of charging and discharging cycles and negative events, such as accidents, as well as periodically recorded information on the operating environmental conditions, including temperature, and on the state of charge.\nAnd Annex VII Part B:\n4. the tracking of harmful events, such as the number of deep discharge events, time spent in extreme temperatures, time spent charging in extreme temperatures."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:operatingEnvironment a samm:Property ;
+   samm:preferredName "Operating Environment"@en ;
+   samm:description "Mandatory if applicable. The operating environment refers to the conditions in which the battery is designed to function optimally. The environment includes factors such as temperature, humidity, pressure, and other external conditions that can impact the performance, safety, and lifespan of the battery. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4):\n(d) information and data resulting from its use, including the number of charging and discharging cycles and negative events, such as accidents, as well as periodically recorded information on the operating environmental conditions, including temperature, and on the state of charge.\nAnd Annex VII Part B:\n4. the tracking of harmful events, such as the number of deep discharge events, time spent in extreme temperatures, time spent charging in extreme temperatures."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:agentDocument a samm:Property ;
+   samm:preferredName "Agent Document"@en ;
+   samm:description "Documentation about the extinguishing agent."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:usableExtinguishingMedia a samm:Property ;
+   samm:preferredName "Usable Extinguishing Media"@en ;
+   samm:description "The agent used to extinguish a fire, based on the fire class. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1)(a) and refers to Annex VI Part A:\n9. usable extinguishing agent."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Dry Powder" .
+
+:fireClass a samm:Property ;
+   samm:preferredName "Fire Class"@en ;
+   samm:description "Safety classification based on the chemistry and construction of the battery. It determines the means of handling a fire caused by the battery. Possible values are A, B and C and a combination of these."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "A, B" .
+
+:MaterialActive a samm:Characteristic ;
+   samm:preferredName "Material Active"@en ;
+   samm:description "Characteristic to describe the active material."@en ;
+   samm:dataType :MaterialActiveEntity .
+
+:LeadCharacteristic a samm:Characteristic ;
+   samm:preferredName "Lead Characteristic"@en ;
+   samm:description "Characteristic for specific hazardous/active lead information."@en ;
+   samm:dataType :LeadEntity .
+
+:OtherActiveMaterialsList a samm-c:List ;
+   samm:preferredName "Other Active Materials List"@en ;
+   samm:description "List of other active materials."@en ;
+   samm:dataType :OtherActiveMaterialsEntity .
+
+:HazardousCharacteristic a samm:Characteristic ;
+   samm:preferredName "Hazardous Characteristic"@en ;
+   samm:description "Material attributes for hazardous materials."@en ;
+   samm:dataType :HazardousEntity .
+
+:OtherHazardousMaterialList a samm-c:List ;
+   samm:preferredName "Other Hazardous Material List"@en ;
+   samm:description "List of other hazardous materials."@en ;
+   samm:dataType :OtherHazardousMaterialEntity .
+
+:VoltageCharacteristic a samm:Characteristic ;
+   samm:preferredName "Voltage Characteristic"@en ;
+   samm:description "Characteristic for voltage values."@en ;
+   samm:dataType :VoltageEntity .
+
+:RatedRoundTripEfficiencyCharacteristic a samm:Characteristic ;
+   samm:preferredName "Rated Round Trip Efficiency Characteristic"@en ;
+   samm:description "Characteristic for the rated round trip efficiency."@en ;
+   samm:dataType :RatedRoundTripEfficiencyEntity .
+
+:RatedEnergyCharacteristic a samm:Characteristic ;
+   samm:preferredName "Rated Energy Characteristic"@en ;
+   samm:description "Characteristic for the rated energy."@en ;
+   samm:dataType :RatedEnergyEntity .
+
+:RatedResistanceCharacteristic a samm:Characteristic ;
+   samm:preferredName "Rated Resistance Characteristic"@en ;
+   samm:description "Characteristic for rated resistance values of the battery on different levels."@en ;
+   samm:dataType :RatedResistanceEntity .
+
+:RatedPowerCharacteristic a samm:Characteristic ;
+   samm:preferredName "Rated Power Characteristic"@en ;
+   samm:description "Characteristic for rated power values."@en ;
+   samm:dataType :RatedPowerEntity .
+
+:RatedCapacityCharacteristic a samm:Characteristic ;
+   samm:preferredName "Rated Capacity Characteristic"@en ;
+   samm:description "Characteristic for rated capacity values."@en ;
+   samm:dataType :RatedCapacityEntity .
+
+:PerformanceTemperatureCharacteristic a samm:Characteristic ;
+   samm:preferredName "Performance Temperature Characteristic"@en ;
+   samm:description "Characteristic for temperature values."@en ;
+   samm:dataType :PerformanceTemperatureEntity .
+
+:PercentMeasurement a samm-c:Measurement ;
+   samm:preferredName "Percent Measurement"@en ;
+   samm:description "Measurement in percent as double."@en ;
+   samm:dataType xsd:double ;
+   samm-c:unit unit:percent .
+
+:LifeCycleCharacteristic a samm:Characteristic ;
+   samm:preferredName "Life Cycle Characteristic"@en ;
+   samm:description "Life Cycle Characteristic with attributes for the lifetime evaluation of a battery."@en ;
+   samm:dataType :LifeCycleEntity .
+
+:RecordCharacteristic a samm:Characteristic ;
+   samm:preferredName "Record Characteristic"@en ;
+   samm:description "Characteristic for a dynamic record with a value and timestamp."@en ;
+   samm:dataType :RecordEntity .
+
+:FullCycleCharacteristic a samm:Characteristic ;
+   samm:preferredName "Full Cycle Characteristic"@en ;
+   samm:description "Characteristic for dynamic cycle values."@en ;
+   samm:dataType :FullCycleEntity .
+
+:DynamicPowerCharacteristic a samm:Characteristic ;
+   samm:preferredName "Dynamic Power Characteristic"@en ;
+   samm:description "Characteristic for dynamic power values."@en ;
+   samm:dataType :DynamicPowerEntity .
+
+:DynamicCapacityCharacteristic a samm:Characteristic ;
+   samm:preferredName "Dynamic Capacity Characteristic"@en ;
+   samm:description "Characteristic for dynamic capacity values."@en ;
+   samm:dataType :DynamicCapacityEntity .
+
+:DynamicRoundTripEfficiencyCharacteristic a samm:Characteristic ;
+   samm:preferredName "Dynamic Round Trip Efficiency Characteristic"@en ;
+   samm:description "Characteristic for dynamic round trip efficiency values."@en ;
+   samm:dataType :DynamicRoundTripEfficiencyEntity .
+
+:DynamicInternalResistanceCharacteristic a samm:Characteristic ;
+   samm:preferredName "Dynamic Internal Resistance Characteristic"@en ;
+   samm:description "Characteristic for dynamic internal resistance values."@en ;
+   samm:dataType :DynamicInternalResistanceEntity .
+
+:DynamicEnergyCharacteristic a samm:Characteristic ;
+   samm:preferredName "Dynamic Energy Characteristic"@en ;
+   samm:description "Characteristic for dynamic energy values."@en ;
+   samm:dataType :DynamicEnergyEntity .
+
+:MaterialActiveEntity a samm:Entity ;
+   samm:preferredName "Material Active Entity"@en ;
+   samm:description "The information on the active material with the recycled share, location and supporting document(s)."@en ;
+   samm:properties ( ext-passport:location ext-passport:recycled ext-passport:documentation ext-passport:critical ) .
+
+:LeadEntity a samm:Entity ;
+   samm:preferredName "Lead Entity"@en ;
+   samm:description "Entity for lead."@en ;
+   samm:properties ( :impactOfSubstances ext-passport:critical ext-passport:documentation ext-passport:recycled ext-passport:location ext-passport:concentration ext-passport:materialUnit ) .
+
+:OtherActiveMaterialsEntity a samm:Entity ;
+   samm:preferredName "Other Active Materials Entity"@en ;
+   samm:description "Entity for other active materials."@en ;
+   samm:properties ( ext-passport:location ext-passport:recycled ext-passport:documentation ext-passport:critical ext-passport:materialIdentification ) .
+
+:HazardousEntity a samm:Entity ;
+   samm:preferredName "Hazardous Entity"@en ;
+   samm:description "Material Entity to describe the material composition for hazardous materials."@en ;
+   samm:properties ( :impactOfSubstances ext-passport:concentration ext-passport:location ext-passport:materialUnit ext-passport:critical ext-passport:documentation ) .
+
+:OtherHazardousMaterialEntity a samm:Entity ;
+   samm:preferredName "Other HazardousMaterial Entity"@en ;
+   samm:description "Entity for other hazardous materials."@en ;
+   samm:properties ( :impactOfSubstances ext-passport:materialUnit ext-passport:concentration ext-passport:materialIdentification ext-passport:documentation ext-passport:critical ext-passport:location ) .
+
+:VoltageEntity a samm:Entity ;
+   samm:preferredName "Voltage Entity"@en ;
+   samm:description "Entity for voltage values."@en ;
+   samm:properties ( [ samm:property :minVoltage; samm:payloadName "min" ] [ samm:property :maxVoltage; samm:payloadName "max" ] [ samm:property :nominalVoltage; samm:payloadName "nominal" ] [ samm:property :testingTemperature; samm:optional true; samm:payloadName "temperature" ] ) .
+
+:RatedRoundTripEfficiencyEntity a samm:Entity ;
+   samm:preferredName "Rated Round Trip Efficiency Entity"@en ;
+   samm:description "Entity for the rated round trip efficiency."@en ;
+   samm:properties ( :depthOfDischarge [ samm:property :initialRoundTripEfficiency; samm:payloadName "initial" ] [ samm:property :roundTripEfficiency50Percent; samm:payloadName "50PercentLife" ] [ samm:property :testingTemperature; samm:optional true; samm:payloadName "temperature" ] ) .
+
+:RatedEnergyEntity a samm:Entity ;
+   samm:preferredName "Rated Energy Entity"@en ;
+   samm:description "Entity for the rated energy."@en ;
+   samm:properties ( [ samm:property :energyValue; samm:payloadName "value" ] [ samm:property :testingTemperature; samm:optional true; samm:payloadName "temperature" ] ) .
+
+:RatedResistanceEntity a samm:Entity ;
+   samm:preferredName "Rated Resistance Entity"@en ;
+   samm:description "Entity for rated resistance values of the battery on different levels."@en ;
+   samm:properties ( [ samm:property :cellResistance; samm:payloadName "cell" ] [ samm:property :moduleResistance; samm:optional true; samm:payloadName "module" ] [ samm:property :packResistance; samm:payloadName "pack" ] [ samm:property :testingTemperature; samm:optional true; samm:payloadName "temperature" ] ) .
+
+:RatedPowerEntity a samm:Entity ;
+   samm:preferredName "Rated Power Entity"@en ;
+   samm:description "Entity for rated power values."@en ;
+   samm:properties ( [ samm:property :powerValue; samm:payloadName "value" ] [ samm:property :capabilityAt20SoC; samm:payloadName "at20SoC" ] [ samm:property :capabilityAt80SoC; samm:payloadName "at80SoC" ] [ samm:property :testingTemperature; samm:optional true; samm:payloadName "temperature" ] ) .
+
+:RatedCapacityEntity a samm:Entity ;
+   samm:preferredName "Rated Capacity Entity"@en ;
+   samm:description "Entity for rated capacity values."@en ;
+   samm:properties ( [ samm:property :capacityValue; samm:payloadName "value" ] [ samm:property :capacityThresholdExhaustion; samm:payloadName "thresholdExhaustion" ] [ samm:property :testingTemperature; samm:optional true; samm:payloadName "temperature" ] ) .
+
+:PerformanceTemperatureEntity a samm:Entity ;
+   samm:preferredName "Performance Temperature Entity"@en ;
+   samm:description "Entity for temperature values."@en ;
+   samm:properties ( [ samm:property :lowerTemperatureBoundary; samm:payloadName "lower" ] [ samm:property :upperTemperatureBoundary; samm:payloadName "upper" ] ) .
+
+:LifeCycleEntity a samm:Entity ;
+   samm:preferredName "Life Cycle Entity"@en ;
+   samm:description "Life Cycle Entity with attributes for the lifetime evaluation of a battery such as expected years and cycles, if applicable."@en ;
+   samm:properties ( :expectedYears [ samm:property :testReport; samm:payloadName "report" ] :cycleLifeTesting ) .
+
+:RecordEntity a samm:Entity ;
+   samm:preferredName "Record Entity"@en ;
+   samm:description "Entity for a dynamic record with a value and timestamp."@en ;
+   samm:properties ( [ samm:property :percentValue; samm:payloadName "value" ] [ samm:property :dataRecordTime; samm:payloadName "time" ] ) .
+
+:FullCycleEntity a samm:Entity ;
+   samm:preferredName "Full Cycle Entity"@en ;
+   samm:description "Entity for dynamic cycle values."@en ;
+   samm:properties ( [ samm:property :dataRecordTime; samm:payloadName "time" ] [ samm:property :cycles; samm:payloadName "value" ] ) .
+
+:DynamicPowerEntity a samm:Entity ;
+   samm:preferredName "Dynamic Power Entity"@en ;
+   samm:description "Entity for dynamic power values."@en ;
+   samm:properties ( [ samm:property :powerFade; samm:payloadName "fade" ] [ samm:property :remainingPower; samm:payloadName "remaining" ] ) .
+
+:DynamicCapacityEntity a samm:Entity ;
+   samm:preferredName "Dynamic Capacity Entity"@en ;
+   samm:description "Entity for dynamic capacity values."@en ;
+   samm:properties ( [ samm:property :capacityFade; samm:payloadName "fade" ] [ samm:property :capacityThroughput; samm:payloadName "throughput" ] [ samm:property :remainingCapacity; samm:payloadName "capacity" ] ) .
+
+:DynamicRoundTripEfficiencyEntity a samm:Entity ;
+   samm:preferredName "Dynamic Round Trip Efficiency Entity"@en ;
+   samm:description "Entity for dynamic round trip efficiency values."@en ;
+   samm:properties ( [ samm:property :roundTripEfficiencyFade; samm:payloadName "fade" ] [ samm:property :remainingRoundTripEfficiency; samm:payloadName "remaining" ] ) .
+
+:DynamicInternalResistanceEntity a samm:Entity ;
+   samm:preferredName "Dynamic Internal Resistance Entity"@en ;
+   samm:description "Entity for dynamic internal resistance values."@en ;
+   samm:properties ( [ samm:property :resistanceIncrease; samm:payloadName "increase" ] [ samm:property :remainingResistance; samm:payloadName "remaining" ] ) .
+
+:DynamicEnergyEntity a samm:Entity ;
+   samm:preferredName "Dynamic Energy Entity"@en ;
+   samm:description "Entity for dynamic energy values."@en ;
+   samm:properties ( :soce [ samm:property :remainingEnergy; samm:payloadName "remaining" ] [ samm:property :energyThroughput; samm:optional true; samm:payloadName "throughput" ] ) .
+
+:impactOfSubstances a samm:Property ;
+   samm:preferredName "Impact of Substances"@en ;
+   samm:description "An accumulation of documents that refer to the impact, especially hazardous substances, on the battery. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1) (s), refers to  Article 74:\n1. In addition to the information referred to in Article 8a(2) of Directive 2008/98/EC, producers or, where appointed in accordance with Article 57(1), producer responsibility organisations shall make available to end-users and distributors the following information regarding the prevention and management of waste batteries with regard to the categories of batteries that they supply within the territory of a Member State:\n[...]\n(f) the impact of substances, in particular hazardous substances, present in batteries on the environment and on human health or the safety of persons, including the impact due to inappropriate discarding of waste batteries, such as littering or discarding as unsorted municipal waste."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:minVoltage a samm:Property ;
+   samm:preferredName "Minimum Voltage"@en ;
+   samm:description "Minimum voltage refers to the lowest voltage the battery is able to reach. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(h) minimal, nominal and maximum voltage, with temperature ranges when relevant."@en ;
+   samm:characteristic :VoltMeasurement ;
+   samm:exampleValue "2.5"^^xsd:double .
+
+:maxVoltage a samm:Property ;
+   samm:preferredName "Maximum Voltage"@en ;
+   samm:description "Maximum voltage refers to the highest voltage the battery is able to reach. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(h) minimal, nominal and maximum voltage, with temperature ranges when relevant."@en ;
+   samm:characteristic :VoltMeasurement ;
+   samm:exampleValue "4.2"^^xsd:double .
+
+:nominalVoltage a samm:Property ;
+   samm:preferredName "Nominal Voltage"@en ;
+   samm:description "Nominal voltage is a standardized or average voltage value assigned to the battery. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(h) minimal, nominal and maximum voltage, with temperature ranges when relevant."@en ;
+   samm:characteristic :VoltMeasurement ;
+   samm:exampleValue "3.7"^^xsd:double .
+
+:testingTemperature a samm:Property ;
+   samm:preferredName "Testing Temperature"@en ;
+   samm:description "Temperature refers to the temperature of the battery during it's cycle-life testing or as boundary condition for other rated values in celsius."@en ;
+   samm:characteristic :DegreeMeasurement ;
+   samm:exampleValue "20.0"^^xsd:double .
+
+:depthOfDischarge a samm:Property ;
+   samm:preferredName "Depth of Discharge"@en ;
+   samm:description "Depth of discharge is a measure used to quantify the extent to which the battery has been discharged relative to its maximum capacity during its cycle-life testing. It represents the percentage of the total available capacity that has been drained or used during a particular discharge cycle. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4)  (a) refers to Article 10 (1), refers to Annex IV Part B:\n3. Depth of discharge in the cycle-life test."@en ;
+   samm:characteristic :PercentMeasurement ;
+   samm:exampleValue "90.5"^^xsd:double .
+
+:initialRoundTripEfficiency a samm:Property ;
+   samm:preferredName "Initial Round Trip Efficiency"@en ;
+   samm:description "The efficiency value of a battery refers to the ratio of useful output energy to the input energy, expressed as a percentage. It quantifies how effectively a battery can convert and deliver stored energy during the discharge process relative to the energy input during charging. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(n) initial round trip energy efficiency and at 50 % of cycle-life."@en ;
+   samm:characteristic :PercentMeasurement ;
+   samm:exampleValue "96.0"^^xsd:double .
+
+:roundTripEfficiency50Percent a samm:Property ;
+   samm:preferredName "Round Trip Efficiency 50 Percent"@en ;
+   samm:description "The round trip efficiency at 50 percent refers to the efficiency of a rechargeable battery's energy storage and retrieval process when the battery has undergone approximately half of its expected number of charge-discharge cycles. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(n) initial round trip energy efficiency and at 50 % of cycle-life."@en ;
+   samm:characteristic :PercentMeasurement ;
+   samm:exampleValue "89.0"^^xsd:double .
+
+:energyValue a samm:Property ;
+   samm:preferredName "Energy Value"@en ;
+   samm:description "Value describing the energy in a specific measurement period, expressed in kilowatt-hours."@en ;
+   samm:characteristic :KilowattHourMeasurement ;
+   samm:exampleValue "0.5"^^xsd:double .
+
+:cellResistance a samm:Property ;
+   samm:preferredName "Cell Resistance"@en ;
+   samm:description "Cell resistance refers to the internal resistance of an individual battery cell in ohms. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(o) internal battery cell and pack resistance;\nDefinition from Annex IV:\n(5) \"Internal resistance\" means the opposition to the flow of current within a cell or a battery under reference conditions, that is, the sum of electronic resistance and ionic resistance to the contribution to total effective resistance including inductive/capacitive properties."@en ;
+   samm:characteristic :OhmMeasurement ;
+   samm:exampleValue "0.025"^^xsd:double .
+
+:moduleResistance a samm:Property ;
+   samm:preferredName "Module Resistance"@en ;
+   samm:description "The module resistance in ohms includes the internal resistance of each cell within the module as well as the resistance introduced by interconnecting components such as busbars, connectors, and thermal management systems."@en ;
+   samm:characteristic :OhmMeasurement ;
+   samm:exampleValue "0.2"^^xsd:double .
+
+:packResistance a samm:Property ;
+   samm:preferredName "Pack Resistance"@en ;
+   samm:description "Pack resistance refers to the overall electrical resistance within a battery pack in ohms. This resistance is a combination of the individual resistances in various components within the pack, including the electrodes, connectors, and other conductive elements. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(o) internal battery cell and pack resistance;\nDefinition from Annex IV:\n(5) \"Internal resistance\" means the opposition to the flow of current within a cell or a battery under reference conditions, that is, the sum of electronic resistance and ionic resistance to the contribution to total effective resistance including inductive/capacitive properties."@en ;
+   samm:characteristic :OhmMeasurement ;
+   samm:exampleValue "0.55"^^xsd:double .
+
+:powerValue a samm:Property ;
+   samm:preferredName "Power Value"@en ;
+   samm:description "Value describing the power in a specific measurement period, expressed in watt."@en ;
+   samm:characteristic :WattMeasurement ;
+   samm:exampleValue "40000.0"^^xsd:double .
+
+:capabilityAt20SoC a samm:Property ;
+   samm:preferredName "Capability at 20 SoC"@en ;
+   samm:description "Capability at 20% SoC refers to the battery's capability at 80% State of Charge. This measurement is indicative of the immediate available energy in the battery. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4)(a) refers to Article 10 (1), refers to Annex IV Part B:\t\n4. Power capability at 80 % and 20 % state of charge."@en ;
+   samm:characteristic :WattMeasurement ;
+   samm:exampleValue "35000.0"^^xsd:double .
+
+:capabilityAt80SoC a samm:Property ;
+   samm:preferredName "Capability at 80 SoC"@en ;
+   samm:description "Capability at 80% SoC refers to the battery's capability at 80% State of Charge. This measurement is indicative of the immediate available energy in the battery. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4)(a) refers to Article 10 (1), refers to Annex IV Part B:\t\n4. Power capability at 80 % and 20 % state of charge"@en ;
+   samm:characteristic :WattMeasurement ;
+   samm:exampleValue "39000.0"^^xsd:double .
+
+:capacityValue a samm:Property ;
+   samm:preferredName "Capacity Value"@en ;
+   samm:description "Value describing the capacity in a specific measurement period, expressed in ampere-hours."@en ;
+   samm:characteristic :AmpereHourMeasurement ;
+   samm:exampleValue "4.0"^^xsd:double .
+
+:capacityThresholdExhaustion a samm:Property ;
+   samm:preferredName "Capacity Threshold Exhaustion"@en ;
+   samm:description "Capacity threshold exhaustion refers to the condition where a battery's capacity diminishes to a level that is considered unacceptable for its intended use. The capacity threshold is a predetermined level below which the battery is considered to be no longer effective or reliable for the specific application. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(k) capacity threshold for exhaustion (only for electric vehicle batteries)."@en ;
+   samm:characteristic :PercentMeasurement ;
+   samm:exampleValue "80.0"^^xsd:double .
+
+:lowerTemperatureBoundary a samm:Property ;
+   samm:preferredName "Lower Temperature Boundary"@en ;
+   samm:description "The lower temperature boundary (in Celsius) refers to the minimum temperature at which a battery can effectively operate. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(l) temperature range the battery can withstand when not in use (reference test)."@en ;
+   samm:characteristic :DegreeMeasurement ;
+   samm:exampleValue "-18.0"^^xsd:double .
+
+:upperTemperatureBoundary a samm:Property ;
+   samm:preferredName "Upper Temperature Boundary"@en ;
+   samm:description "The upper temperature boundary (in Celsius) refers to the minimum temperature at which a battery can effectively operate. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(l) temperature range the battery can withstand when not in use (reference test)."@en ;
+   samm:characteristic :DegreeMeasurement ;
+   samm:exampleValue "60.0"^^xsd:double .
+
+:expectedYears a samm:Property ;
+   samm:preferredName "Expected Years"@en ;
+   samm:description "The expected years refer to the expected life-time of the battery before it starts heavily degrading in its capacity and c-rate in calendar years. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4) (a) refers to the Article 10 (1) refers to Annex IV Part A: \n5. The expected life-time of the battery under the reference conditions for which it has been designed, in terms of cycles, except for non-cycle applications, and calendar years."@en ;
+   samm:characteristic :IntegerCharacteristic ;
+   samm:exampleValue 8 .
+
+:cycleLifeTesting a samm:Property ;
+   samm:preferredName "Cycle Life Testing"@en ;
+   samm:description "The cycle life testing of the battery."@en ;
+   samm:characteristic :CycleLifeCharacteristic .
+
+:percentValue a samm:Property ;
+   samm:preferredName "Percent Value"@en ;
+   samm:description "A value as a percentage in the form of a double."@en ;
+   samm:characteristic :PercentMeasurement ;
+   samm:exampleValue "50.0"^^xsd:double .
+
+:dataRecordTime a samm:Property ;
+   samm:preferredName "Data Record Time"@en ;
+   samm:description "The entry date and time corresponding to when a specific parameter was measured. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4):\n(d) information and data resulting from its use, including the number of charging and discharging cycles and negative events, such as accidents, as well as periodically recorded information on the operating environmental conditions, including temperature, and on the state of charge."@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-12-07T10:39:13.576+01:00"^^xsd:dateTime .
+
+:cycles a samm:Property ;
+   samm:preferredName "Cycles"@en ;
+   samm:description "Cycle refers to one complete charging and discharging sequence. Either during the battery's cycle-life testing or as full equivalent while in use."@en ;
+   samm:characteristic :IntegerCharacteristic ;
+   samm:exampleValue 1500 .
+
+:powerFade a samm:Property ;
+   samm:preferredName "PowerFade"@en ;
+   samm:description "Power fade refers to a reduction in the power of the battery system over time expressed as a percentage in reference to the initial value. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4)(a) refers to Article 10 (1), refers to Annex IV Part A: \t\n2. Power (in W) and power fade (in %).\nDefinition from Annex IV:\n(4) \"Power fade\" means the decrease over time and upon usage in the amount of power that a battery can deliver at the rated voltage."@en ;
+   samm:characteristic :RecordCharacteristic .
+
+:remainingPower a samm:Property ;
+   samm:preferredName "Remaining Power"@en ;
+   samm:description "The remaining power capability in the battery expressed in watt. This attribute is mentioned in the Battery Regulation 2023/1542 from 12 July 2023 in Annex XIII (4) (b) refers to Article 14, refers to Annex VII Part A:\n2. where possible, the remaining power capability;\nDefinition from Annex IV:\n(3) \"Power\" means the amount of energy that a battery is capable of providing over a given period under reference\nconditions."@en ;
+   samm:characteristic :RemainingPowerCharacteristic .
+
+:capacityFade a samm:Property ;
+   samm:preferredName "Capacity Fade"@en ;
+   samm:description "Capacity fade refers to a reduction in the capacity of the battery system over time expressed as a percentage in reference to the initial value. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4)(a) refers to Article 10(1) and refer to Annex IV Part A: \n1. Rated capacity (in Ah) and capacity fade (in %).\nDefinition from Annex IV:\n(2) \"Capacity fade\" means the decrease over time and upon usage in the amount of charge that a battery can deliver at the rated voltage, with respect to the original rated capacity."@en ;
+   samm:characteristic :RecordCharacteristic .
+
+:capacityThroughput a samm:Property ;
+   samm:preferredName "Capacity Throughput"@en ;
+   samm:description "Capacity throughput refers to the total amount of energy that a battery has delivered over its lifetime. It represents the cumulative energy discharge and recharge cycles a battery has undergone. Capacity throughput is expressed in ampere-hours. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex VII Part B: \n3. the capacity throughput."@en ;
+   samm:characteristic :CapacityCharacteristic .
+
+:remainingCapacity a samm:Property ;
+   samm:preferredName "Remaining Capacity"@en ;
+   samm:description "The remaining capacity in the battery expressed in ampere hours. This attribute is mentioned in the Battery Regulation 2023/1542 from 12 July 2023 in Annex XIII (4) (b) refers to Article 14, refers to Annex VII Part A:\n1. the remaining capacity.\n"@en ;
+   samm:characteristic :CapacityCharacteristic .
+
+:roundTripEfficiencyFade a samm:Property ;
+   samm:preferredName "Round Trip Efficiency Fade"@en ;
+   samm:description "Round trip efficiency fade refers to a reduction in the round trip efficiency of the battery system over time expressed as a percentage in reference to the initial value. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4)(a) refers to Article 10(1) and refers to Annex IV: \n4. Where applicable, energy round trip efficiency and its fade (in %).\nDefinition from Annex IV:\n(6) \"Energy round trip efficiency\" means the ratio of the net energy delivered by a battery during a discharge test to the total energy required to restore the initial state of charge by a standard charge."@en ;
+   samm:characteristic :RecordCharacteristic .
+
+:remainingRoundTripEfficiency a samm:Property ;
+   samm:preferredName "Remaining Round Trip Efficiency"@en ;
+   samm:description "The remaining round trip efficiency in the battery expressed as percentage. This attribute is mentioned in the Battery Regulation 2023/1542 from 12 July 2023 in Annex XIII (4) (b) refers to Article 14, refers to Annex VII Part A:\n3. where possible, the remaining round trip efficiency.\nDefinition from Annex IV:\n(6) \"Energy round trip efficiency\" means the ratio of the net energy delivered by a battery during a discharge test to the total energy required to restore the initial state of charge by a standard charge."@en ;
+   samm:characteristic :RecordCharacteristic .
+
+:resistanceIncrease a samm:Property ;
+   samm:preferredName "Resistance Increase"@en ;
+   samm:description "The increase as percentage in the battery resistance on the level of the pack, module (optional) and cell."@en ;
+   samm:characteristic :ResistanceIncreaseCharacteristic .
+
+:remainingResistance a samm:Property ;
+   samm:preferredName "Remaining Resistance"@en ;
+   samm:description "The remaining resistance in ohms in the battery on the level of the pack, module (optional) and cell."@en ;
+   samm:characteristic :RemainingResistanceCharacteristic .
+
+:soce a samm:Property ;
+   samm:preferredName "SOCE"@en ;
+   samm:description "The state of certified energy (SOCE) refers to the current measured or on-board usable battery energy (UBE) performance expressed as a percentage. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4)(b) refers to Article 14) and refers to Annex VII Part A: \nstate of certified energy (SOCE)."@en ;
+   samm:characteristic :RecordCharacteristic .
+
+:remainingEnergy a samm:Property ;
+   samm:preferredName "Remaining Energy"@en ;
+   samm:description "The remaining energy in the battery expressed in kilowatt-hours."@en ;
+   samm:characteristic :EnergyCharacteristic .
+
+:energyThroughput a samm:Property ;
+   samm:preferredName "Energy Throughput"@en ;
+   samm:description "Energy throughput refers to the total amount of energy that passes through a system over a specific period. This measure encompasses both the energy input (during charging) and the energy output (during discharging). Energy throughput is expressed in kilowatt-hours. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex VII Part B: \n2. the energy throughput."@en ;
+   samm:characteristic :EnergyCharacteristic .
+
+:VoltMeasurement a samm-c:Measurement ;
+   samm:preferredName "Volt Measurement"@en ;
+   samm:description "Measurement for volt as a double."@en ;
+   samm:dataType xsd:double ;
+   samm-c:unit unit:volt .
+
+:DegreeMeasurement a samm-c:Measurement ;
+   samm:preferredName "Degree Measurement"@en ;
+   samm:description "Degree measurement in celsius."@en ;
+   samm:dataType xsd:double ;
+   samm-c:unit unit:degreeCelsius .
+
+:KilowattHourMeasurement a samm-c:Measurement ;
+   samm:preferredName "Kilowatt Hour Measurement"@en ;
+   samm:description "Measurement for the energy expressed in kilowatt hours as double."@en ;
+   samm:dataType xsd:double ;
+   samm-c:unit unit:kilowattHour .
+
+:OhmMeasurement a samm-c:Measurement ;
+   samm:preferredName "Ohm Measurement"@en ;
+   samm:description "Measurement in ohms as double."@en ;
+   samm:dataType xsd:double ;
+   samm-c:unit unit:ohm .
+
+:WattMeasurement a samm-c:Measurement ;
+   samm:preferredName "Watt Measurement"@en ;
+   samm:description "Measurement in watt as double."@en ;
+   samm:dataType xsd:double ;
+   samm-c:unit unit:watt .
+
+:AmpereHourMeasurement a samm-c:Measurement ;
+   samm:preferredName "Ampere Hour Measurement"@en ;
+   samm:description "Measurement for the capacity expressed in ampere hours as double."@en ;
+   samm:dataType xsd:double ;
+   samm-c:unit unit:ampereHour .
+
+:IntegerCharacteristic a samm:Characteristic ;
+   samm:preferredName "Integer Characteristic"@en ;
+   samm:description "Characteristic for an integer value."@en ;
+   samm:dataType xsd:integer .
+
+:CycleLifeCharacteristic a samm:Characteristic ;
+   samm:preferredName "Cycle Life Characteristic"@en ;
+   samm:description "Cycle Life Characteristic for the battery lifetime testing."@en ;
+   samm:dataType :CycleLifeEntity .
+
+:RemainingPowerCharacteristic a samm:Characteristic ;
+   samm:preferredName "Remaining Power Characteristic"@en ;
+   samm:description "Characteristic for the remaining power."@en ;
+   samm:dataType :RemainingPowerEntity .
+
+:CapacityCharacteristic a samm:Characteristic ;
+   samm:preferredName "Capacity Characteristic"@en ;
+   samm:description "Characteristic for dynamic capacity values such as the throughput and the remaining capacity."@en ;
+   samm:dataType :CapacityEntity .
+
+:ResistanceIncreaseCharacteristic a samm:Characteristic ;
+   samm:preferredName "Resistance Increase Characteristic"@en ;
+   samm:description "Characteristic for the increase of the battery resistance."@en ;
+   samm:dataType :ResistanceIncreaseEntity .
+
+:RemainingResistanceCharacteristic a samm:Characteristic ;
+   samm:preferredName "Remaining Resistance Characteristic"@en ;
+   samm:description "Characteristic for the remaining battery resistance."@en ;
+   samm:dataType :RemainingResistanceEntity .
+
+:EnergyCharacteristic a samm:Characteristic ;
+   samm:preferredName "Energy Characteristic"@en ;
+   samm:description "Characteristic for energy values expressed in a timestamp and a kilowatt-hours value."@en ;
+   samm:dataType :EnergyEntity .
+
+:CycleLifeEntity a samm:Entity ;
+   samm:preferredName "Cycle Life Entity"@en ;
+   samm:description "Cycle Life Characteristic for the battery lifetime testing with the cycles, temperature, depth of discharge and applied c-rates."@en ;
+   samm:properties ( [ samm:property :testingTemperature; samm:payloadName "temperature" ] :cycles :depthOfDischarge :appliedChargeRate :appliedDischargeRate ) .
+
+:RemainingPowerEntity a samm:Entity ;
+   samm:preferredName "Remaining Power Entity"@en ;
+   samm:description "Entity for the remaining power."@en ;
+   samm:properties ( [ samm:property :dataRecordTime; samm:payloadName "time" ] [ samm:property :powerValue; samm:payloadName "value" ] ) .
+
+:CapacityEntity a samm:Entity ;
+   samm:preferredName "Capacity Entity"@en ;
+   samm:description "Entity for dynamic capacity values such as the throughput and the remaining capacity."@en ;
+   samm:properties ( [ samm:property :dataRecordTime; samm:payloadName "time" ] [ samm:property :capacityValue; samm:payloadName "value" ] ) .
+
+:ResistanceIncreaseEntity a samm:Entity ;
+   samm:preferredName "Resistance Increase Entity"@en ;
+   samm:description "Entity for the increase of the battery resistance."@en ;
+   samm:properties ( [ samm:property :packResistanceIncrease; samm:payloadName "pack" ] [ samm:property :moduleResistanceIncrease; samm:optional true; samm:payloadName "module" ] [ samm:property :cellResistanceIncrease; samm:payloadName "cell" ] ) .
+
+:RemainingResistanceEntity a samm:Entity ;
+   samm:preferredName "Remaining Resistance Entity"@en ;
+   samm:description "Entity for the remaining battery resistance."@en ;
+   samm:properties ( [ samm:property :remainingPackResistance; samm:payloadName "pack" ] [ samm:property :remainingModuleResistance; samm:optional true; samm:payloadName "module" ] [ samm:property :remainingCellResistance; samm:payloadName "cell" ] ) .
+
+:EnergyEntity a samm:Entity ;
+   samm:preferredName "Energy Entity"@en ;
+   samm:description "Entity for energy values expressed in a timestamp and a kilowatt-hours value."@en ;
+   samm:properties ( [ samm:property :dataRecordTime; samm:payloadName "time" ] [ samm:property :energyValue; samm:payloadName "value" ] ) .
+
+:appliedChargeRate a samm:Property ;
+   samm:preferredName "Applied Charge Rate"@en ;
+   samm:description "The applied charge rate (c rate) refers to the rate at which a battery is charged. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(p) c-rate of relevant cycle-life test;\nand Annex XIII (4)(a) refers to Article 10(1) refers to Annex IV Part B:\n1. Applied discharge rate and charge rate."@en ;
+   samm:characteristic :CRateCharacteristic ;
+   samm:exampleValue "3"^^xsd:double .
+
+:appliedDischargeRate a samm:Property ;
+   samm:preferredName "Applied Discharge Rate"@en ;
+   samm:description "The applied discharge rate (c rate) refers to the rate at which a battery is discharged. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (1):\n(p) c-rate of relevant cycle-life test;\nand Annex XIII (4)(a) refers to Article 10(1) refers to Annex IV Part B:\n1. Applied discharge rate and charge rate."@en ;
+   samm:characteristic :CRateCharacteristic ;
+   samm:exampleValue "4"^^xsd:double .
+
+:packResistanceIncrease a samm:Property ;
+   samm:preferredName "Pack Resistance Increase"@en ;
+   samm:description "Pack resistance increase refers to the overall electrical resistance within a battery pack. This resistance is a combination of the individual resistances in various components within the pack, including the electrodes, connectors, and other conductive elements. The rise in the pack resistance is expressed as a percentage in reference to the initial value.\nThis attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4)(a) refers to Article 10(1) and refers to Annex IV Part A: \n3. Internal resistance (in \") and internal resistance increase (in %).\nDefinition from Annex IV:\n(5) \"Internal resistance\" means the opposition to the flow of current within a cell or a battery under reference conditions, that is, the sum of electronic resistance and ionic resistance to the contribution to total effective resistance including inductive/capacitive properties."@en ;
+   samm:characteristic :RecordCharacteristic .
+
+:moduleResistanceIncrease a samm:Property ;
+   samm:preferredName "module Resistance Increase"@en ;
+   samm:description "The module resistance increase includes the internal resistance of each cell within the module as well as the resistance introduced by interconnecting components such as busbars, connectors, and thermal management systems. The rise in the module resistance is expressed as a percentage in reference to the initial value."@en ;
+   samm:characteristic :RecordCharacteristic .
+
+:cellResistanceIncrease a samm:Property ;
+   samm:preferredName "Cell Resistance Increase"@en ;
+   samm:description "Cell resistance increase refers to the internal resistance of an individual battery cell. The rise in the cell resistance is expressed as a percentage in reference to the initial value. This attribute is mentioned in the Battery regulation 2023/1542 from 12 July 2023 in Annex XIII (4)(a) refers to Article 10(1) and refers to Annex IV Part A: \n3. Internal resistance (in ohms) and internal resistance increase (in %).\nDefinition from Annex IV:\n(5) \"Internal resistance\" means the opposition to the flow of current within a cell or a battery under reference conditions, that is, the sum of electronic resistance and ionic resistance to the contribution to total effective resistance including inductive/capacitive properties."@en ;
+   samm:characteristic :RecordCharacteristic .
+
+:remainingPackResistance a samm:Property ;
+   samm:preferredName "Remaining Pack Resistance"@en ;
+   samm:description "Pack resistance refers to the overall electrical resistance within a battery pack. This resistance is a combination of the individual resistances in various components within the pack, including the electrodes, connectors, and other conductive elements. This attribute is mentioned in the Battery Regulation 2023/1542 from 12 July 2023 in Annex XIII (4) (b) refers to Article 14, refers to Annex VII Part A:\n5. where possible, the ohmic resistance."@en ;
+   samm:characteristic :RemainingResistanceCharacteristicRecord .
+
+:remainingModuleResistance a samm:Property ;
+   samm:preferredName "Remaining Module Resistance"@en ;
+   samm:description "Module resistance in ohms includes the internal resistance of each cell within the module as well as the resistance introduced by interconnecting components such as busbars, connectors, and thermal management systems."@en ;
+   samm:characteristic :RemainingResistanceCharacteristicRecord .
+
+:remainingCellResistance a samm:Property ;
+   samm:preferredName "Remaining Cell Resistance"@en ;
+   samm:description "Cell resistance refers to the internal resistance of an individual battery cell expressed in ohms. This attribute is mentioned in the Battery Regulation 2023/1542 from 12 July 2023 in Annex XIII (4) (b) refers to Article 14, refers to Annex VII Part A:\n5. where possible, the ohmic resistance."@en ;
+   samm:characteristic :RemainingResistanceCharacteristicRecord .
+
+:CRateCharacteristic a samm:Characteristic ;
+   samm:preferredName "C Rate Characteristic"@en ;
+   samm:description "The C-rate, also known as the charge/discharge rate, quantifies how quickly a battery is charged or discharged in relation to its capacity. It is dimensionless."@en ;
+   samm:dataType xsd:double .
+
+:RemainingResistanceCharacteristicRecord a samm:Characteristic ;
+   samm:preferredName "Remaining Resistance Characteristic Record"@en ;
+   samm:description "Characteristic for the remaining battery resistance."@en ;
+   samm:dataType :RemainingResistanceEntityRecord .
+
+:RemainingResistanceEntityRecord a samm:Entity ;
+   samm:preferredName "Remaining Resistance Entity Record"@en ;
+   samm:description "Entity for the remaining battery resistance with a timestamp and value."@en ;
+   samm:properties ( [ samm:property :dataRecordTime; samm:payloadName "time" ] [ samm:property :remainingResistanceValue; samm:payloadName "value" ] ) .
+
+:remainingResistanceValue a samm:Property ;
+   samm:preferredName "Remaining Resistance Value"@en ;
+   samm:description "The remaining resistance value expressed in ohms."@en ;
+   samm:characteristic :OhmsMeasurement ;
+   samm:exampleValue "0.3"^^xsd:double .
+
+:OhmsMeasurement a samm-c:Measurement ;
+   samm:preferredName "Ohms Measurement"@en ;
+   samm:description "Measurement for ohm as double."@en ;
+   samm:dataType xsd:double ;
+   samm-c:unit unit:ohm .
+

--- a/io.catenax.battery.battery_pass/6.1.0/BatteryPass.ttl
+++ b/io.catenax.battery.battery_pass/6.1.0/BatteryPass.ttl
@@ -28,7 +28,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <urn:samm:io.catenax.battery.battery_pass:6.0.0#> .
-@prefix ext-passport: <urn:samm:io.catenax.generic.digital_product_passport:6.1.0#> .
+@prefix ext-passport: <urn:samm:io.catenax.generic.digital_product_passport:5.0.0#> .
 
 
 :BatteryPass a samm:Aspect ;
@@ -36,9 +36,15 @@
    samm:description "The battery pass describes information collected during the lifecycle of a battery. The battery passport is heavily based on the Regulation (EU) 2023/1542 of the European Parliament and of the Council of 12 July 2023 concerning batteries and waste batteries, amending Directive 2008/98/EC and Regulation (EU) 2019/1020 and repealing Directive 2006/66/EC.\nAdditionally attributes come from the Proposal for Ecodesign for Sustainable Products Regulation."@en ;
    samm:see <https://environment.ec.europa.eu/publications/proposal-ecodesign-sustainable-products-regulation_en> ;
    samm:see <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R1542&qid=1693215264963> ;
-   samm:properties ( :identification :operation :characteristics :sustainability :materials :performance :conformity :safety [ samm:property :sources; samm:optional true ] ext-passport:metadata ext-passport:commercial ext-passport:handling ) ;
+   samm:properties ([ samm:property :specVersion; samm:optional true ]  :identification :operation :characteristics :sustainability :materials :performance :conformity :safety [ samm:property :sources; samm:optional true ] ext-passport:metadata ext-passport:commercial ext-passport:handling ) ;
    samm:operations ( ) ;
    samm:events ( ) .
+
+:specVersion a samm:Property ;
+   samm:preferredName "Digital Product Passport Specification Version"@en ;
+   samm:description "Specification of the BPP format/data model (name and version number), which is used."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "urn:io.catenax.battery.battery_pass:6.1.0" .
 
 :identification a samm:Property ;
    samm:preferredName "Identification"@en ;

--- a/io.catenax.battery.battery_pass/6.1.0/metadata.json
+++ b/io.catenax.battery.battery_pass/6.1.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.battery.battery_pass/RELEASE_NOTES.md
+++ b/io.catenax.battery.battery_pass/RELEASE_NOTES.md
@@ -1,53 +1,71 @@
 # Changelog
+
 All notable changes to this model will be documented in this file.
 
-## [Unreleased]
-## [6.0.0] - 2024-05-21
+## [6.1.0] - 2025-10-30
+
 ### Changed
+
+- Updated to io.catenax.generic.digital_product_passport:6.1.0 as the new basis
+
+## [6.0.0] - 2024-05-21
+
+### Changed
+
 - connection update to @prefix ext-passport: <urn:samm:io.catenax.generic.digital_product_passport:5.0.0#>
 - declarationOfConformityId is a string instead of a document list
 - example values for doubles are now doubles and not integers
 - corrected description texts with typos
 
 ### Added
+
 - added commercial from ext-passport
 
-
 ## [5.0.0] - 2024-03-04
+
 ### Changed
+
 - import of the new samm:io.catenax.generic.digital_product_passport:4.0.0
 - deletion of either-or possibilities
 
 ## [4.0.0] - 2023-12-11
+
 ### Changed
+
 - changed to SAMM
 - fundamental changes in the structure
 - references to the Digital Product Passport which references multiple other shared models
 
 ## [3.0.1] - 2023-01-15
+
 ### Added
+
 n/a
 
 ### Changed
+
 - several smaller fixes according to technical committee feedback
 
 ### Removed
+
 n/a
 
 ## [3.0.0] - 2022-12-05
+
 ### Added
+
 - added „componentsSupplierName“
 - attribute "ComponentsPartNumber" was changed to a collection
 
 ### Changed
+
 n/a
 
 ### Removed
 
 ## [2.0.0] - 2022-09-07
+
 ### Added
+
 - attributes describing battery or its condition in more detail
 - set namespace to io.catenax
-
-
-

--- a/io.catenax.battery.battery_pass/RELEASE_NOTES.md
+++ b/io.catenax.battery.battery_pass/RELEASE_NOTES.md
@@ -6,7 +6,7 @@ All notable changes to this model will be documented in this file.
 
 ### Changed
 
-- Updated to io.catenax.generic.digital_product_passport:6.1.0 as the new basis
+- new attribute added: specVersion (Optional)
 
 ## [6.0.0] - 2024-05-21
 


### PR DESCRIPTION
This PR adds the optional property `specVersion` to the BPP Aspect Model. This is fully compatible with v6.0.0.

In addition this PR deprecates the outdated versions < 5.0.0

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
