### PR TITLE
Create TransmissionPass:3.1.0

### DIFF
--- a/io.catenax.transmission.transmission_pass/2.0.0/metadata.json
+++ b/io.catenax.transmission.transmission_pass/2.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{ "status" : "deprecated" } 

--- a/io.catenax.transmission.transmission_pass/3.1.0/TransmissionPass.ttl
+++ b/io.catenax.transmission.transmission_pass/3.1.0/TransmissionPass.ttl
@@ -1,13 +1,14 @@
 #######################################################################
-# Copyright (c) 2023-2024 BASF SE
-# Copyright (c) 2023-2024 BMW AG
-# Copyright (c) 2024 CGI Deutschland B.V. & Co. KG
-# Copyright (c) 2023-2024 Henkel AG & Co. KGaA
+# Copyright (c) 2023 BASF SE
+# Copyright (c) 2023 BMW AG
+# Copyright (c) 2023 Henkel AG & Co. KGaA
 # Copyright (c) 2023 Robert Bosch GmbH
-# Copyright (c) 2023-2024 SAP SE
-# Copyright (c) 2023-2024 T-Systems International GmbH
-# Copyright (c) 2023-2024 ZF Friedrichshafen AG
-# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2023 SAP SE
+# Copyright (c) 2023 T-Systems International GmbH
+# Copyright (c) 2023 ZF Friedrichshafen AG
+# Copyright (c) 2024 CGI Deutschland B.V. & Co. KG
+# Copyright (c) 2025 Catena-X Automotive Network e.V.
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.transmission.transmission_pass/3.1.0/TransmissionPass.ttl
+++ b/io.catenax.transmission.transmission_pass/3.1.0/TransmissionPass.ttl
@@ -1,0 +1,405 @@
+#######################################################################
+# Copyright (c) 2023-2024 BASF SE
+# Copyright (c) 2023-2024 BMW AG
+# Copyright (c) 2024 CGI Deutschland B.V. & Co. KG
+# Copyright (c) 2023-2024 Henkel AG & Co. KGaA
+# Copyright (c) 2023 Robert Bosch GmbH
+# Copyright (c) 2023-2024 SAP SE
+# Copyright (c) 2023-2024 T-Systems International GmbH
+# Copyright (c) 2023-2024 ZF Friedrichshafen AG
+# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.transmission.transmission_pass:3.1.0#> .
+@prefix ext-passport: <urn:samm:io.catenax.generic.digital_product_passport:5.0.0#> .
+
+:TransmissionPass a samm:Aspect ;
+   samm:preferredName "Transmission Pass"@en ;
+   samm:description "The transmission passport corresponds to the digital product passport information required by the proposed Ecodesign Regulation (ESPR-2022) and describes the data that is collected and available during the lifespan of a transmission."@en ;
+   samm:properties ( [ samm:property :specVersion; samm:optional true ] [ samm:property :productSpecificParameters; samm:payloadName "specific" ] [ samm:property :productGenericParameters; samm:payloadName "generic" ] ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:specVersion a samm:Property ;
+   samm:preferredName "Transmission Passport Specification Version"@en ;
+   samm:description "Specification of the Transmission Pass format/data model (name and version number), which is used."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "urn:io.catenax.transmission.transmission_pass:3.1.0" .
+
+:productSpecificParameters a samm:Property ;
+   samm:preferredName "Product Specific Parameters"@en ;
+   samm:description "Product specific parameters of the transmission."@en ;
+   samm:characteristic :SpecificCharacteristic .
+
+:productGenericParameters a samm:Property ;
+   samm:preferredName "Product Generic Parameters"@en ;
+   samm:description "The product generic parameters. These are defined by the Digital Product Passport proposal from the ESPR. The main basis is provided by the document \"Proposal for a REGULATION OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL establishing a framework for setting ecodesign requirements for sustainable products and repealing Directive 2009/125/EC\" from March 30th, 2022. The latest version of the document was the provisional agreement between the EU Council and the Parliament from January 9th, 2024."@en ;
+   samm:characteristic :GenericCharacteristic .
+
+:SpecificCharacteristic a samm:Characteristic ;
+   samm:preferredName "Specific Characteristic"@en ;
+   samm:description "The Characteristic to describe product specific parameters of the transmission."@en ;
+   samm:dataType :SpecificEntity .
+
+:GenericCharacteristic a samm:Characteristic ;
+   samm:preferredName "Generic Characteristic"@en ;
+   samm:description "Characteristic for the product generic parameters."@en ;
+   samm:dataType :GenericEntity .
+
+:SpecificEntity a samm:Entity ;
+   samm:preferredName "Specific Entity"@en ;
+   samm:description "The entity describing various product specific parameters of the transmission."@en ;
+   samm:properties ( :driveType :torque :power [ samm:property :torqueConverter; samm:optional true ] [ samm:property :speedResistance; samm:optional true ] :standardGearRatio :spreading :oil :electricalPerformance [ samm:property :serviceHistory; samm:optional true ] ) .
+
+:GenericEntity a samm:Entity ;
+   samm:preferredName "Generic Entity"@en ;
+   samm:description "Entity for the product generic parameters."@en ;
+   samm:properties ( :characteristics ext-passport:metadata ext-passport:identification ext-passport:operation ext-passport:handling ext-passport:commercial ext-passport:materials ext-passport:sustainability ext-passport:sources ) .
+
+:driveType a samm:Property ;
+   samm:preferredName "Drive Type"@en ;
+   samm:description "A list of the type of transmission drive. For example combustion, full hybrid, mild hybrid, plug-in hybrid or purely electric drive (battery or fuelcell)."@en ;
+   samm:characteristic :DriveTypeTrait ;
+   samm:exampleValue "full hybrid" .
+
+:torque a samm:Property ;
+   samm:preferredName "Torque Performance"@en ;
+   samm:description "The maximum input torque in newton meters (the operating characteristics of the transmission)."@en ;
+   samm:characteristic :TorqueNewtonMetre ;
+   samm:exampleValue "500"^^xsd:nonNegativeInteger .
+
+:power a samm:Property ;
+   samm:preferredName "Power"@en ;
+   samm:description "The maximum power in kilowatt (the operating characteristics of the transmission)."@en ;
+   samm:characteristic :KilowattMeasurement ;
+   samm:exampleValue "300"^^xsd:nonNegativeInteger .
+
+:torqueConverter a samm:Property ;
+   samm:preferredName "Torque Converter"@en ;
+   samm:description "A list of the used transmission damper technology (depending on the transmission type). For example NW 200 TTD and NW 200 ZDW"@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "NW 200 TTD" .
+
+:speedResistance a samm:Property ;
+   samm:preferredName "Speed Resistance"@en ;
+   samm:description "The permissible maximum input speed in the respective gear depending on the transmission type."@en ;
+   samm:characteristic :SpeedResistanceList .
+
+:standardGearRatio a samm:Property ;
+   samm:preferredName "Standard Gear Ratio"@en ;
+   samm:description "The ratio in the respective gear (ratio between transmission input speed and transmission output speed). For example 1 : 4.1567; 2 : 3.898; 3 : 2.887; 4 : 2.7783; 5 : 1.811; 6 : 1.6545; 7 : 0.4377; 8 : 0.6121; R : -2.2183."@en ;
+   samm:characteristic :StandardGearRatioSet .
+
+:spreading a samm:Property ;
+   samm:preferredName "Spreading"@en ;
+   samm:description "The transmission spreading coefficient. The ratio between the smallest (shortest gear) and the largest (longest gear) ratio."@en ;
+   samm:characteristic :Ratio ;
+   samm:exampleValue "6.79"^^xsd:float .
+
+:oil a samm:Property ;
+   samm:preferredName "Oil"@en ;
+   samm:description "The oil used for the transmission."@en ;
+   samm:characteristic :OilCharacteristic .
+
+:electricalPerformance a samm:Property ;
+   samm:preferredName "Electrical Performance"@en ;
+   samm:description "Attributes connected to the transmission-integrated electrical machine, if applicable."@en ;
+   samm:characteristic :PerformanceCharacteristic .
+
+:serviceHistory a samm:Property ;
+   samm:preferredName "Service History"@en ;
+   samm:description "Documentation of the service history of the transmission."@en ;
+   samm:characteristic ext-passport:DocumentList .
+
+:characteristics a samm:Property ;
+   samm:preferredName "Characteristics"@en ;
+   samm:description "Defines specific characteristics of the transmission."@en ;
+   samm:characteristic :ProductCharacteristics .
+
+:DriveTypeTrait a samm-c:Trait ;
+   samm:preferredName "Drive Type Trait"@en ;
+   samm:description "Trait of the drive type."@en ;
+   samm-c:baseCharacteristic :DriveList ;
+   samm-c:constraint :DriveTypeConstraint .
+
+:TorqueNewtonMetre a samm-c:Measurement ;
+   samm:preferredName "Torque Newton Metre"@en ;
+   samm:description "Characteristic to describe torque in newton meters."@en ;
+   samm:dataType xsd:nonNegativeInteger ;
+   samm-c:unit unit:newtonMetre .
+
+:KilowattMeasurement a samm-c:Measurement ;
+   samm:preferredName "Kilowatt Measurement"@en ;
+   samm:description "The performance power in kilowatt as non-negative integer."@en ;
+   samm:dataType xsd:nonNegativeInteger ;
+   samm-c:unit unit:kilowatt .
+
+:StringList a samm-c:List ;
+   samm:preferredName "String Characteristic"@en ;
+   samm:description "A list with the data types string."@en ;
+   samm:dataType xsd:string .
+
+:SpeedResistanceList a samm-c:List ;
+   samm:preferredName "Speed Resistance List"@en ;
+   samm:description "The speed resistance characteristic."@en ;
+   samm:dataType :SpeedResistanceEntity .
+
+:StandardGearRatioSet a samm-c:Set ;
+   samm:preferredName "Standard Gear Ratio Set"@en ;
+   samm:description "The set of ratio in the respective gear."@en ;
+   samm:dataType :GearRatioEntity .
+
+:Ratio a samm-c:Quantifiable ;
+   samm:preferredName "Ratio Characteristic"@en ;
+   samm:description "The ratio in the respective gear."@en ;
+   samm:dataType xsd:float .
+
+:OilCharacteristic a samm:Characteristic ;
+   samm:preferredName "Oil Characteristic"@en ;
+   samm:description "Characteristic for the oil."@en ;
+   samm:dataType :OilEntity .
+
+:PerformanceCharacteristic a samm:Characteristic ;
+   samm:preferredName "Performance Characteristic"@en ;
+   samm:description "Characteristic for performance related values."@en ;
+   samm:dataType :PerformanceEntity .
+
+:ProductCharacteristics a samm:Characteristic ;
+   samm:preferredName "Product Characteristics"@en ;
+   samm:description "Defines a set of specific characteristics of the transmission."@en ;
+   samm:dataType :CharacteristicsEntity .
+
+:DriveList a samm-c:List ;
+   samm:preferredName "Drive List"@en ;
+   samm:description "List of drive types, which is restricted to combustion, full hybrid, mild hybrid, plug-in hybrid, fuel-cell and battery."@en ;
+   samm:dataType xsd:string .
+
+:DriveTypeConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Drive Type Constraint"@en ;
+   samm:description "Constraint to only allow combustion, full hybrid, mild hybrid, plug-in hybrid, fuel-cell or battery.\n"@en ;
+   samm:value "(combustion|full hybrid|mild hybrid|plug-in hybrid|fuel-cell|battery)" .
+
+:SpeedResistanceEntity a samm:Entity ;
+   samm:preferredName "Speed Resistance Entity"@en ;
+   samm:description "The speed resistance entity. Includes the gear and the speed as separate properties."@en ;
+   samm:properties ( :gear :ratedSpeed ) .
+
+:GearRatioEntity a samm:Entity ;
+   samm:preferredName "Gear Ratio Entity"@en ;
+   samm:description "Entity for the ratio in the respective gear. Includes the gear and the ratio as separate properties."@en ;
+   samm:properties ( :gear :gearRatio ) .
+
+:OilEntity a samm:Entity ;
+   samm:preferredName "Oil Entity"@en ;
+   samm:description "Entity for the oil capacity and type."@en ;
+   samm:properties ( :oilCapacity :oilType ) .
+
+:PerformanceEntity a samm:Entity ;
+   samm:preferredName "Performance Entity"@en ;
+   samm:description "Entity for the performance."@en ;
+   samm:properties ( :applicable :electricalMachine ) .
+
+:CharacteristicsEntity a samm:Entity ;
+   samm:preferredName "Characteristics Entity"@en ;
+   samm:description "Entity which defines specific characteristics of the transmission such as different life spans and physical dimensions."@en ;
+   samm:properties ( :warranty :lifeTime ext-passport:physicalDimension ) .
+
+:gear a samm:Property ;
+   samm:preferredName "Gear"@en ;
+   samm:description "Respective gear for the measurement."@en ;
+   samm:characteristic :GearTrait ;
+   samm:exampleValue "1" .
+
+:ratedSpeed a samm:Property ;
+   samm:preferredName "Rated Speed"@en ;
+   samm:description "The permissible maximum input speed in the respective gear (depending on the transmission type) in 1/min."@en ;
+   samm:characteristic :RevolutionsPerMinute ;
+   samm:exampleValue "7800"^^xsd:nonNegativeInteger .
+
+:gearRatio a samm:Property ;
+   samm:preferredName "Gear Ratio"@en ;
+   samm:description "The ratio in the respective gear (ratio between transmission input speed and transmission output speed)."@en ;
+   samm:characteristic :Ratio ;
+   samm:exampleValue "4.1567"^^xsd:float .
+
+:oilCapacity a samm:Property ;
+   samm:preferredName "Oil Capacity"@en ;
+   samm:description "The defined oil volume in the transmission in cubic decimeters."@en ;
+   samm:characteristic :Capacity ;
+   samm:exampleValue "8.9"^^xsd:float .
+
+:oilType a samm:Property ;
+   samm:preferredName "Oil Type"@en ;
+   samm:description "The type of the oil for the transmission defined by the manufacturer of the transmission."@en ;
+   samm:characteristic :StringList ;
+   samm:exampleValue "Transmission Oil XY" .
+
+:applicable a samm:Property ;
+   samm:preferredName "Applicable"@en ;
+   samm:description "If there is a transmission-integrated electrical machine included, select true and state the values in the connected attributes. If there is none, select false and provide dummy data."@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue true .
+
+:electricalMachine a samm:Property ;
+   samm:preferredName "Electrical Machine"@en ;
+   samm:description "Attributes connected to the transmission-integrated electrical machine, if applicable. Otherwise dummy data (0 or null) can be provided."@en ;
+   samm:characteristic :ElectricalMachineCharacteristic .
+
+:warranty a samm:Property ;
+   samm:preferredName "Warranty"@en ;
+   samm:description "Commercial warranty period of the transmission (coupled to the Vehicle) in months."@en ;
+   samm:characteristic :MonthCharacteristics ;
+   samm:exampleValue "60"^^xsd:nonNegativeInteger .
+
+:lifeTime a samm:Property ;
+   samm:preferredName "Life Time"@en ;
+   samm:description "Expected transmission lifespan in kilometres."@en ;
+   samm:characteristic :KilometreCharacteristic ;
+   samm:exampleValue "500000"^^xsd:nonNegativeInteger .
+
+:GearTrait a samm-c:Trait ;
+   samm:preferredName "Gear Trait"@en ;
+   samm:description "Constraint to match a gear from 1 to 18 or R (reverse)."@en ;
+   samm-c:baseCharacteristic samm-c:Text ;
+   samm-c:constraint :GearConstraint .
+
+:RevolutionsPerMinute a samm-c:Measurement ;
+   samm:preferredName "Revolutions "@en ;
+   samm:description "The permissible maximum input speed in revolutions per minute in the respective gear."@en ;
+   samm:dataType xsd:nonNegativeInteger ;
+   samm-c:unit unit:revolutionsPerMinute .
+
+:Capacity a samm-c:Quantifiable ;
+   samm:preferredName "Capacity Characteristic"@en ;
+   samm:description "The oil capacity in dm³."@en ;
+   samm:dataType xsd:float ;
+   samm-c:unit unit:cubicDecimetre .
+
+:ElectricalMachineCharacteristic a samm:Characteristic ;
+   samm:preferredName "Electrical Machine Characteristic"@en ;
+   samm:description "Characteristic for the electrical machine."@en ;
+   samm:dataType :ElectricalMachineEntity .
+
+:MonthCharacteristics a samm-c:Measurement ;
+   samm:preferredName "Month Characteristics"@en ;
+   samm:description "Measurement in months as an integer."@en ;
+   samm:dataType xsd:nonNegativeInteger ;
+   samm-c:unit unit:month .
+
+:KilometreCharacteristic a samm-c:Measurement ;
+   samm:preferredName "Kilometre Characteristic"@en ;
+   samm:description "Measurement in kilometre as an integer."@en ;
+   samm:dataType xsd:nonNegativeInteger ;
+   samm-c:unit unit:kilometre .
+
+:GearConstraint a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "Gear Constraint"@en ;
+   samm:description "Constraint to match a gear from 1 to 18 or R (reverse)."@en ;
+   samm:value "^(1[0-8]|[1-9]|R)$" .
+
+:ElectricalMachineEntity a samm:Entity ;
+   samm:preferredName "Electrical Machine Entity"@en ;
+   samm:description "Entity for the electrical machine with power, torque and speed values."@en ;
+   samm:properties ( [ samm:property :machineTorque; samm:payloadName "torque" ] [ samm:property :machinePower; samm:payloadName "power" ] [ samm:property :machineVoltage; samm:payloadName "voltage" ] [ samm:property :machineSpeed; samm:payloadName "speed" ] ) .
+
+:machineTorque a samm:Property ;
+   samm:preferredName "Machine Torque"@en ;
+   samm:description "The torque of the electrical machine."@en ;
+   samm:characteristic :MachineTorqueCharacteristic .
+
+:machinePower a samm:Property ;
+   samm:preferredName "Machine Power"@en ;
+   samm:description "The power of the electrical machine."@en ;
+   samm:characteristic :MachinePowerCharacteristic .
+
+:machineVoltage a samm:Property ;
+   samm:preferredName "Machine Voltage"@en ;
+   samm:description "Nominal voltage of the electric system in volt."@en ;
+   samm:characteristic :VoltageMeasurement ;
+   samm:exampleValue "52"^^xsd:decimal .
+
+:machineSpeed a samm:Property ;
+   samm:preferredName "Machine Speed"@en ;
+   samm:description "Maximum allowable speed for the electric motor in revolutions per minute."@en ;
+   samm:characteristic :RevolutionsPerMinute ;
+   samm:exampleValue "16700"^^xsd:nonNegativeInteger .
+
+:MachineTorqueCharacteristic a samm:Characteristic ;
+   samm:preferredName "Machine Torque Characteristic"@en ;
+   samm:description "The electrical machine torque."@en ;
+   samm:dataType :MachineTorqueEntity .
+
+:MachinePowerCharacteristic a samm:Characteristic ;
+   samm:preferredName "Machine Power Characteristic"@en ;
+   samm:description "The electrical machine power."@en ;
+   samm:dataType :MachinePowerEntity .
+
+:VoltageMeasurement a samm-c:Measurement ;
+   samm:preferredName "Voltage Measurement"@en ;
+   samm:description "Measurement in voltage."@en ;
+   samm:dataType xsd:decimal ;
+   samm-c:unit unit:volt .
+
+:MachineTorqueEntity a samm:Entity ;
+   samm:preferredName "Machine Torque Entity"@en ;
+   samm:description "The entity for the electrical machine torque."@en ;
+   samm:properties ( [ samm:property :maximumTorque; samm:payloadName "max" ] :maximumAvailability [ samm:property :continuousTorque; samm:payloadName "continuous" ] ) .
+
+:MachinePowerEntity a samm:Entity ;
+   samm:preferredName "Machine Power Entity"@en ;
+   samm:description "The entity for the electrical machine power."@en ;
+   samm:properties ( [ samm:property :maximumPower; samm:payloadName "max" ] [ samm:property :continuousPower; samm:payloadName "continuous" ] :maximumAvailability ) .
+
+:maximumTorque a samm:Property ;
+   samm:preferredName "MaximumTorque"@en ;
+   samm:description "The maximum output torque in newton meters for a specified time period."@en ;
+   samm:characteristic :TorqueNewtonMetre ;
+   samm:exampleValue "180"^^xsd:nonNegativeInteger .
+
+:maximumAvailability a samm:Property ;
+   samm:preferredName "Maximum Availability"@en ;
+   samm:description "Specified time period for the peak measurement in seconds."@en ;
+   samm:characteristic :TimeMeasurement ;
+   samm:exampleValue "10"^^xsd:nonNegativeInteger .
+
+:continuousTorque a samm:Property ;
+   samm:preferredName "Continuous Torque"@en ;
+   samm:description "The torque that can be delivered without time limit in newton meters."@en ;
+   samm:characteristic :TorqueNewtonMetre ;
+   samm:exampleValue "178"^^xsd:nonNegativeInteger .
+
+:maximumPower a samm:Property ;
+   samm:preferredName "Maximum Power"@en ;
+   samm:description "The maximum output power in kilowatts for a specified time period."@en ;
+   samm:characteristic :KilowattMeasurement ;
+   samm:exampleValue "22"^^xsd:nonNegativeInteger .
+
+:continuousPower a samm:Property ;
+   samm:preferredName "Continuous Power"@en ;
+   samm:description "The power that can be delivered without time limit."@en ;
+   samm:characteristic :KilowattMeasurement ;
+   samm:exampleValue "16"^^xsd:nonNegativeInteger .
+
+:TimeMeasurement a samm-c:Measurement ;
+   samm:preferredName "Time Measurement"@en ;
+   samm:description "Time in seconds."@en ;
+   samm:dataType xsd:nonNegativeInteger ;
+   samm-c:unit unit:secondUnitOfTime .
+

--- a/io.catenax.transmission.transmission_pass/3.1.0/metadata.json
+++ b/io.catenax.transmission.transmission_pass/3.1.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.transmission.transmission_pass/RELEASE_NOTES.md
+++ b/io.catenax.transmission.transmission_pass/RELEASE_NOTES.md
@@ -1,33 +1,43 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
-## [Unreleased]
+## [3.1.0] - 2025-10-30
+
+### Changed
+
+- new attribute added: specVersion (Optional)
 
 ## [3.0.0] - 2024-05-21
+
 ### Changed
+
 - connection update to @prefix ext-passport: <urn:samm:io.catenax.generic.digital_product_passport:5.0.0#>
 - renamed and changed attribute and payload name from unspecific to generic on highest level
 - changed example value for oilType
 - changed names for torquePeak, torqueContinuous, powerPeak, powerContinuous, speed, maxPeriod
 - changed PerformancePower to KilowattMeasurement (characteristic)
 
-
 ## [2.0.0] - 2024-03-04
+
 ### Added
+
 - import of io.catenax.generic.digital_product_passport 4.0.0
 
 ### Changed
+
 - redefined electrical performance attributes
 - characteristics for the life time/warranty refined
 
 ## [1.0.0] - 2023-05-08
+
 ### Added
+
 model created
 
 ### Changed
+
 n/a
 
 ### Removed
+
 n/a
-
-


### PR DESCRIPTION
This PR adds the optional property `specVersion` to the TransmissionPass Aspect Model. This is fully compatible with v3.0.0.

In addition this PR deprecated outdated versions < 3.0.0

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
