### PR TITLE
Update SAMM-CLI from 2.9.7 to 2.11.1 to move from SAMM 2.1 to SAMM 2.2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Closes #
 <!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
 ## MS2 Criteria
 (to be filled out by PR reviewer)
-- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.9.7)
+- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
 - [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
 - [ ] the identifiers for all model elements **start with a capital letter** except for properties
 - [ ] the identifier for **properties starts with a small letter**

--- a/.github/actions/model-validation/Readme.md
+++ b/.github/actions/model-validation/Readme.md
@@ -14,4 +14,4 @@
 #######################################################################
 -->
 # Note on updating ESMF SDK 
-The action uses the [ESMF SDK](https://github.com/eclipse-esmf/esmf-sdk). In case of an update you need to change the variable ``bamm_version`` to the required version of the ESMF SDK in the file [action.yml](action.yml).
+The action uses the [ESMF SDK](https://github.com/eclipse-esmf/esmf-sdk). In case of an update you need to change the variable ``samm_version`` to the required version of the ESMF SDK in the file [action.yml](action.yml).

--- a/.github/actions/model-validation/action.yml
+++ b/.github/actions/model-validation/action.yml
@@ -9,9 +9,9 @@ inputs:
     description: 'The modified files, detected by a previous action'
     default: "[]"
     required: false
-  bamm_version: 
+  samm_version: 
     description: The version of the used SAMM SDK
-    default: 2.9.7
+    default: 2.11.1
     required: true
   token:
     description: GitHub token

--- a/.github/actions/model-validation/index.js
+++ b/.github/actions/model-validation/index.js
@@ -8,8 +8,8 @@ const { TIMEOUT } = require('dns');
 
 
 var bulk = JSON.parse(core.getInput('bulk'))
-var bammVersion = core.getInput('bamm_version')
-var bammSdkPath = `${__dirname}/samm-cli-${bammVersion}.jar`;
+var sammVersion = core.getInput('samm_version')
+var sammSdkPath = `${__dirname}/samm-cli-${sammVersion}.jar`;
 
 var added = JSON.parse(core.getInput('added'))
 var modified = JSON.parse(core.getInput('modified'))
@@ -19,7 +19,7 @@ main()
 
 async function main() {
     try {
-        await asyncBammSdkDownload(`https://github.com/eclipse-esmf/esmf-sdk/releases/download/v${bammVersion}/samm-cli-${bammVersion}.jar`)
+        await asyncSammSdkDownload(`https://github.com/eclipse-esmf/esmf-sdk/releases/download/v${sammVersion}/samm-cli-${sammVersion}.jar`)
 
         if(bulk === false){
             validateChanges(added, modified, prNumber)
@@ -131,7 +131,7 @@ async function validateModel(file) {
     return new Promise((resolve, reject) => {
         console.log(`Validating TTL file ${file}`)
 
-        exec(`java -Dpolyglot.engine.WarnInterpreterOnly=false -jar ${bammSdkPath} aspect ${file} validate`, (error, stdout, stderr) => {
+        exec(`java -Dpolyglot.engine.WarnInterpreterOnly=false -jar ${sammSdkPath} aspect ${file} validate`, (error, stdout, stderr) => {
             if (stderr) {
                 reject(stderr)
             }
@@ -145,30 +145,30 @@ async function validateModel(file) {
 
 }
 
-async function asyncBammSdkDownload(url) {
+async function asyncSammSdkDownload(url) {
     return new Promise((resolve, reject) => {
-        downloadBammSdk(url, resolve, reject)
+        downloadSammSdk(url, resolve, reject)
     })
 }
 
-async function downloadBammSdk(url, resolve, reject) {
+async function downloadSammSdk(url, resolve, reject) {
     https.get(url, (response) => {
         if (response.statusCode >= 400) {
-            reject("Could not download SAMM SDK v${bammVersion}")
+            reject("Could not download SAMM SDK v${sammVersion}")
         }
 
         if (response.statusCode > 300 && response.statusCode < 400 && !!response.headers.location) {
-            downloadBammSdk(response.headers.location, resolve, reject)
+            downloadSammSdk(response.headers.location, resolve, reject)
         } else {
-            console.log(`Starting download of SAMM SDK v${bammVersion}`)
+            console.log(`Starting download of SAMM SDK v${sammVersion}`)
 
-            const filePath = fs.createWriteStream(bammSdkPath);
+            const filePath = fs.createWriteStream(sammSdkPath);
 
             response.pipe(filePath)
             filePath.on('finish', () => {
                 filePath.close()
-                console.log(`Downloaded SAMM SDK v${bammVersion}`)
-                resolve(`Downloaded SAMM SDK v${bammVersion}`)
+                console.log(`Downloaded SAMM SDK v${sammVersion}`)
+                resolve(`Downloaded SAMM SDK v${sammVersion}`)
             })
         }
     })

--- a/.github/actions/model-validation/index.js
+++ b/.github/actions/model-validation/index.js
@@ -1,3 +1,19 @@
+/*
+#######################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+*/
+
 const core = require('@actions/core');
 const github = require('@actions/github');
 const https = require('https');

--- a/.github/actions/validate-single/Readme.md
+++ b/.github/actions/validate-single/Readme.md
@@ -14,7 +14,7 @@
 #######################################################################
 -->
 # Note on updating ESMF SDK 
-The action uses the [ESMF SDK](https://github.com/eclipse-esmf/esmf-sdk). In case of an update you need to change the variable ``bamm_version`` to the required version of the ESMF SDK in the file [action.yml](action.yml).
+The action uses the [ESMF SDK](https://github.com/eclipse-esmf/esmf-sdk). In case of an update you need to change the variable ``samm_version`` to the required version of the ESMF SDK in the file [action.yml](action.yml).
 
 # Detect Changes Action
 This action validates whether and which changes in the repository need to be applied to an instance of the Semantic Hub being associated with the repository.

--- a/.github/actions/validate/Readme.md
+++ b/.github/actions/validate/Readme.md
@@ -14,7 +14,7 @@
 #######################################################################
 -->
 # Note on updating ESMF SDK 
-The action uses the [ESMF SDK](https://github.com/eclipse-esmf/esmf-sdk). In case of an update you need to change the variable ``bamm_version`` to the required version of the ESMF SDK in the file [action.yml](action.yml).
+The action uses the [ESMF SDK](https://github.com/eclipse-esmf/esmf-sdk). In case of an update you need to change the variable ``samm_version`` to the required version of the ESMF SDK in the file [action.yml](action.yml).
 
 # Detect Changes Action
 This action validates whether and which changes in the repository need to be applied to an instance of the Semantic Hub being associated with the repository.

--- a/.github/actions/validate/Readme.md
+++ b/.github/actions/validate/Readme.md
@@ -13,17 +13,20 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 -->
+
 # Note on updating ESMF SDK 
+
 The action uses the [ESMF SDK](https://github.com/eclipse-esmf/esmf-sdk). In case of an update you need to change the variable ``samm_version`` to the required version of the ESMF SDK in the file [action.yml](action.yml).
 
 # Detect Changes Action
+
 This action validates whether and which changes in the repository need to be applied to an instance of the Semantic Hub being associated with the repository.
 The action expects multiple arrays which either contain added, modified, renamed and deleted files from the last commit. 
 
 The actual deployment to an Semantic Hub instance is done through the Upload-action which expects a JSON-file with the changes to apply. Because of that, the result of the validation action is an archived JSON-file communicating these detected changes. 
 
-
 ## Test Cases
+
 For future developments, we propose the following test cases to be evaluated:
 
 ### main branch
@@ -41,6 +44,7 @@ delete model with status RELEASED | not relevant | model is still and Semantic H
 modify model | no addition or modification | log warning and no update of model in Semantic Hub
 
 ### other branch
+
 On any other branch besides the main-branch the metadata.json should be ignored. This results in the following test cases: 
 
 | Model | metadata.json | expected deployed model status |
@@ -49,6 +53,3 @@ add model | none | DRAFT
 add model | add metadata.json with status DEPRECATED | DRAFT
 existing model | add metadata.json with status RELEASED | DRAFT
 delete model | not relevant | delete model from Semantic Hub
-
-
-

--- a/.github/workflows/bulk-validation.yml
+++ b/.github/workflows/bulk-validation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: validate models
         uses: ./.github/actions/model-validation
         with:
-          bamm_version: 2.9.7
+          samm_version: 2.11.1
           bulk: true
       - name: Archive
         uses: actions/upload-artifact@v3

--- a/.github/workflows/bulk-validation.yml
+++ b/.github/workflows/bulk-validation.yml
@@ -1,12 +1,17 @@
-#
+#######################################################################
 # Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
-# See the AUTHORS file(s) distributed with this work for additional
-# information regarding authorship.
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
 #
-# See the LICENSE file(s) distributed with this work for
-# additional information regarding license terms.
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
 #
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
 
 name: Bulk Validation
 on:

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -85,7 +85,7 @@ jobs:
         uses: ./.github/actions/model-validation
         with:
           pr_number: ${{ github.event.number }}
-          bamm_version: 2.9.7
+          samm_version: 2.11.1
           added: ${{needs.synchronize-models.outputs.ADDED}}
           modified: ${{needs.synchronize-models.outputs.MODIFIED}}
       - name: Archive

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,5 +1,6 @@
 #######################################################################
 # Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 The repository contains the aspect models based on [SAMM (Semantic Aspect Meta Model)](https://eclipse-esmf.github.io/samm-specification/2.1.0/index.html) for the Tractus-X project for Catena-X.
 
-**Currently, we assume the usage of the version 2.9.7 of the [SAMM-CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.7/tooling-guide/samm-cli.html) and version 5.6.0 of the [Aspect Model Editor](https://eclipse-esmf.github.io/ame-guide/5.6.0/introduction.html)**.
+**Currently, we assume the usage of the version 2.11.1 of the [SAMM-CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.11.1/tooling-guide/samm-cli.html) and version 5.6.0 of the [Aspect Model Editor](https://eclipse-esmf.github.io/ame-guide/5.6.0/introduction.html)**.
 
 # Using the models
 
-The models can locally be processed with the [SAMM CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.7/tooling-guide/samm-cli.html), which is documented [here](https://eclipse-esmf.github.io/esmf-developer-guide/2.9.7/tooling-guide/samm-cli.html).
+The models can locally be processed with the [SAMM CLI](https://eclipse-esmf.github.io/esmf-developer-guide/2.11.1/tooling-guide/samm-cli.html), which is documented [here](https://eclipse-esmf.github.io/esmf-developer-guide/2.11.1/tooling-guide/samm-cli.html).
 It allows you to generate different artifacts (diagrams, example payload, java class files) out of it.
 
 For convenience you can also look into the `gen` folder of each model, which already contains often used  artifacts generated from the model.

--- a/generate.sh
+++ b/generate.sh
@@ -30,11 +30,11 @@
 
 
 # Adjust if SAMM CLI version changes
-JARNAME=samm-cli-2.9.7.jar
+JARNAME=samm-cli-2.11.1.jar
 SAMMFOLDER=.SAMMCLI/
 SAMMCLI=$SAMMFOLDER$JARNAME
 # Adjust if SAMM CLI version changes
-SAMMCLIURL=https://github.com/eclipse-esmf/esmf-sdk/releases/download/v2.9.7/samm-cli-2.9.7.jar
+SAMMCLIURL=https://github.com/eclipse-esmf/esmf-sdk/releases/download/v2.11.1/samm-cli-2.11.1.jar
 
 CATENAXCSS=$SAMMFOLDER/catena-template.css
 CATENAXCUSTOMCSSURL=https://raw.githubusercontent.com/eclipse-tractusx/sldt-semantic-hub/main/backend/src/main/resources/catena-template.css


### PR DESCRIPTION
This PR updates the SAMM-CLI which is used for validation and artefact generation from version 2.9.7 to the newer version 2.11.1 which resolves some issues.

This also introduces an update from SAMM v2.1 to SAMM v.2.2 which, however, is fully compatible with SAMM v2.1.

In addition, this removed some of the old `bamm`-references in the code base of the action script, which have been renamed to `samm`.

closed #883 