### PR TITLE
Chores: Remove 'Standardized' headline and status

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -24,8 +24,8 @@
 # Usage:
 # ./release.sh '10/01/2022' '12/15/2022'
 
-HEADLINES=("Added" "Deprecated" "Standardized")
-STATUS=("release" "deprecate" "standardize")
+HEADLINES=("Added" "Deprecated")
+STATUS=("release" "deprecated")
 
 for str in ${myArray[@]}; do
   echo $str

--- a/release.sh
+++ b/release.sh
@@ -27,10 +27,6 @@
 HEADLINES=("Added" "Deprecated")
 STATUS=("release" "deprecated")
 
-for str in ${myArray[@]}; do
-  echo $str
-done
-
 for i in ${!HEADLINES[@]}; do
   printf "\n## ${HEADLINES[$i]}\n"
   git checkout `git rev-list -n 1  --before="$2" main` >/dev/null 2>&1


### PR DESCRIPTION
I re-discovered the release.sh script (which is really useful).

This PR:

- removes the "standardized" state which is no longer supported
- removes a loop which is never triggered