### PR TITLE
Bugfix (wrong version) for BPP 6.1.0

### DIFF
--- a/io.catenax.battery.battery_pass/6.1.0/BatteryPass.ttl
+++ b/io.catenax.battery.battery_pass/6.1.0/BatteryPass.ttl
@@ -28,7 +28,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.battery.battery_pass:6.0.0#> .
+@prefix : <urn:samm:io.catenax.battery.battery_pass:6.1.0#> .
 @prefix ext-passport: <urn:samm:io.catenax.generic.digital_product_passport:5.0.0#> .
 
 


### PR DESCRIPTION
This PR corrects the version of the BPP 6.1 within the .ttl-file.