### PR TITLE
Chores: Add missing metadata.json to io.catenax.business_partner_certificate

### DIFF
--- a/io.catenax.business_partner_certificate/3.1.0/metadata.json
+++ b/io.catenax.business_partner_certificate/3.1.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release" }


### PR DESCRIPTION
This PR adds a missing metadata.json to io.catenax.business_partner_certificate:3.1.0