### PR TITLE
update of bpn model

### DIFF
--- a/io.catenax.shared.business_partner_number/1.0.0/metadata.json
+++ b/io.catenax.shared.business_partner_number/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{"status": "release"}
+{"status": "deprecated"}

--- a/io.catenax.shared.business_partner_number/2.0.0/BusinessPartnerNumber.ttl
+++ b/io.catenax.shared.business_partner_number/2.0.0/BusinessPartnerNumber.ttl
@@ -51,20 +51,24 @@
     samm:description "Property based on a BPNA."@en;
     samm:characteristic :BpnaTrait;
     samm:exampleValue "BPNA0123456789ZZ".
+
 :BpnaTrait a samm-c:Trait;
     samm:preferredName "BPNA Trait"@en;
     samm:description "Trait to ensure data format for BPNA."@en;
     samm-c:baseCharacteristic :BpnaCharacteristic;
     samm-c:constraint :BpnaRegularExpression.
+
 :BpnaCharacteristic a samm:Characteristic;
     samm:preferredName "Business Partner Number Site"@en;
     samm:description "BPNA (Business Partner Number Address) contains the legal name (incl. legal form, if registered) and additional organization information about site, e.g. Plant xxx, Branch office yyy of an organization with its corresponding, most commonly physical, address. A BPNA is always linked to a BPNL via relationship 'belongs to legal entity' and should be linked to a BPNS via relationship 'belongs to site'.The BPNA is on operational level (e.g. shipping or pick-up address)."@en;
     samm:dataType xsd:string;
     samm:see <https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_PDF_Maerz/5_BPDM/CX_-_0010_BUSINESS_PARTNER_NUMBER_PlatformCapabilityBPDM_v_1.0.1.pdf>.
+
 :BpnaRegularExpression a samm-c:RegularExpressionConstraint;
     samm:preferredName "BPNA Regular Expression"@en;
     samm:description "The provided regular expression ensures that the BPNA is composed of prefix 'BPNA', 10 digits and two alphanumeric letters."@en;
     samm:value "^BPNA[a-zA-Z0-9]{12}$".
+
 :bpnsProperty a samm:Property;
     samm:preferredName "Business Partner Number Site Property"@en;
     samm:description "Property based on a BPNS."@en;

--- a/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
+++ b/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
@@ -12,6 +12,7 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
+
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
@@ -86,8 +87,8 @@
    samm:preferredName "Bpns or Bpna Characteristic"@en ;
    samm:description "This characteristic allows BPNS or BPNA."@en ;
    samm:dataType xsd:string ;
-   samm-c:deconstructionRule "^(BPNS|BPNA)[A-Za-z0-9]{12}$" ;
-   samm-c:elements ( "^" :bpns "[A-Za-z0-9]{12}$" ) .
+   samm-c:deconstructionRule "\"(<BPNS>)|(<BPNA>)\" [A-Za-z0-9]{12}$" ;
+   samm-c:elements ( "\"" :bpns "|" :bpna "\" [A-Za-z0-9]{12}$" ) .
 
 :BpnlRegularExpression a samm-c:RegularExpressionConstraint ;
    samm:preferredName "BPNL Regular Expression"@en ;

--- a/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
+++ b/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
@@ -1,0 +1,96 @@
+#######################################################################
+# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.shared.business_partner_number:3.0.0#> .
+
+:bpna a samm:Property ;
+   samm:preferredName "Business Partner Number Address Property"@en ;
+   samm:description "Property based on a BPNA."@en ;
+   samm:characteristic :BpnaTrait ;
+   samm:exampleValue "BPNA0123456789ZZ" .
+
+:BpnaTrait a samm-c:Trait ;
+   samm:preferredName "BPNA Trait"@en ;
+   samm:description "Trait to ensure data format for BPNA."@en ;
+   samm-c:baseCharacteristic :BpnaCharacteristic ;
+   samm-c:constraint :BpnaRegularExpression .
+
+:BpnaCharacteristic a samm:Characteristic ;
+   samm:preferredName "Business Partner Number Site"@en ;
+   samm:description "BPNA (Business Partner Number Address) contains the legal name (incl. legal form, if registered) and additional organization information about site, e.g. Plant xxx, Branch office yyy of an organization with its corresponding, most commonly physical, address. A BPNA is always linked to a BPNL via relationship 'belongs to legal entity' and should be linked to a BPNS via relationship 'belongs to site'.The BPNA is on operational level (e.g. shipping or pick-up address)."@en ;
+   samm:dataType xsd:string .
+
+:BpnaRegularExpression a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "BPNA Regular Expression"@en ;
+   samm:description "The provided regular expression ensures that the BPNA is composed of prefix 'BPNA', 10 digits and two alphanumeric letters."@en ;
+   samm:value "^BPNA[a-zA-Z0-9]{12}$" .
+
+:bpns a samm:Property ;
+   samm:preferredName "Business Partner Number Site Property"@en ;
+   samm:description "Property based on a BPNS."@en ;
+   samm:characteristic :BpnsTrait ;
+   samm:exampleValue "BPNS0123456789ZZ" .
+
+:BpnsRegularExpression a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "BPNS Regular Expression"@en ;
+   samm:description "The provided regular expression ensures that the BPNS is composed of prefix 'BPNS', 10 digits and two alphanumeric letters."@en ;
+   samm:value "^BPNS[a-zA-Z0-9]{12}$" .
+
+:BpnsCharacteristic a samm:Characteristic ;
+   samm:preferredName "Business Partner Number Site"@en ;
+   samm:description "BPNS (Business Partner Number Site) represents a site which can be a production plant. A site can also be e.g. an office or a warehouse. An information related to a site is e.g. needed for reporting issues (How many sites does e.g. Beispiel AG have?), status of operation (out of operations due to environmental disaster), for certificates on site level (e.g. environment certificates) or for internal regulations on site level, (e.g. security topics, Corona rules,...). Several addresses (= BPNA with different streets and different gates) can belong to one site. A BPNS should be always linked to one BPNL via relationship 'belongs to legal entity'."@en ;
+   samm:dataType xsd:string .
+
+:BpnlTrait a samm-c:Trait ;
+   samm:preferredName "BPNL Trait"@en ;
+   samm:description "Trait to ensure data format for BPNL."@en ;
+   samm-c:baseCharacteristic :BpnlCharacteristic ;
+   samm-c:constraint :BpnlRegularExpression .
+
+:bpnl a samm:Property ;
+   samm:preferredName "Business Partner Number Legal Entity Property"@en ;
+   samm:description "Property based on a BPNL."@en ;
+   samm:characteristic :BpnlTrait ;
+   samm:exampleValue "BPNL0123456789ZZ" .
+
+:BpnsTrait a samm-c:Trait ;
+   samm:preferredName "BPNS Trait"@en ;
+   samm:description "Trait to ensure data format for BPNS."@en ;
+   samm-c:baseCharacteristic :BpnsCharacteristic ;
+   samm-c:constraint :BpnsRegularExpression .
+
+:BpnlCharacteristic a samm:Characteristic ;
+   samm:preferredName "Business Partner Number Legal Entity"@en ;
+   samm:description "BPNL (Business Partner Number Legal Entity) represents the legal entity of an organization (e.g. enterprise, university, association, …) and contains its legal name (incl. legal form, if registered), registered address and tax number. The registered address is the official, legal correspondence address which has to be supplied to governmental and tax authorities and is the address which is used in any legal or court documents. BPNL is on corporate level and is unique for this legal entity."@en ;
+   samm:dataType xsd:string .
+
+:BpnsOrBpnaCharacteristic a samm-c:StructuredValue ;
+   samm:preferredName "Bpns or Bpna Characteristic"@en ;
+   samm:description "This characteristic allows BPNS or BPNA."@en ;
+   samm:dataType xsd:string ;
+   samm-c:deconstructionRule "^(BPNS|BPNA)[A-Za-z0-9]{12}$" ;
+   samm-c:elements ( "^" :bpns "[A-Za-z0-9]{12}$" ) .
+
+:BpnlRegularExpression a samm-c:RegularExpressionConstraint ;
+   samm:preferredName "BPNL Regular Expression"@en ;
+   samm:description "The provided regular expression ensures that the BPNL is composed of prefix 'BPNL', 10 digits and two alphanumeric letters."@en ;
+   samm:value "^BPNL[a-zA-Z0-9]{12}$" .
+

--- a/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
+++ b/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
@@ -23,7 +23,7 @@
 @prefix : <urn:samm:io.catenax.shared.business_partner_number:3.0.0#> .
 
 :bpna a samm:Property ;
-   samm:preferredName "Business Partner Number Address Property"@en ;
+   samm:preferredName "Business Partner Number Address"@en ;
    samm:description "Property based on a BPNA."@en ;
    samm:characteristic :BpnaTrait ;
    samm:exampleValue "BPNA0123456789ZZ" .

--- a/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
+++ b/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
@@ -36,7 +36,7 @@
 
 :BpnaCharacteristic a samm:Characteristic ;
    samm:preferredName "Business Partner Number Site"@en ;
-   samm:description "BPNA (Business Partner Number Address) contains the legal name (incl. legal form, if registered) and additional organization information about site, e.g. Plant xxx, Branch office yyy of an organization with its corresponding, most commonly physical, address. A BPNA is always linked to a BPNL via relationship 'belongs to legal entity' and should be linked to a BPNS via relationship 'belongs to site'.The BPNA is on operational level (e.g. shipping or pick-up address)."@en ;
+   samm:description "BPNA (Business Partner Number Address) contains the legal name (incl. legal form, if registered) and additional organization information about site, e.g. Plant xxx, Branch office yyy of an organization with its corresponding, most commonly physical, address. A BPNA is always linked to a BPNL via relationship 'belongs to legal entity' and should be linked to a BPNS via relationship 'belongs to site'. The BPNA is on operational level (e.g. shipping or pick-up address)."@en ;
    samm:dataType xsd:string .
 
 :BpnaRegularExpression a samm-c:RegularExpressionConstraint ;
@@ -87,8 +87,8 @@
    samm:preferredName "Bpns or Bpna Characteristic"@en ;
    samm:description "This characteristic allows BPNS or BPNA."@en ;
    samm:dataType xsd:string ;
-   samm-c:deconstructionRule "\"(<BPNS>)|(<BPNA>)\" [A-Za-z0-9]{12}$" ;
-   samm-c:elements ( "\"" :bpns "|" :bpna "\" [A-Za-z0-9]{12}$" ) .
+   samm-c:deconstructionRule "^(BPNS[a-zA-Z0-9]{12})|(BPNA[a-zA-Z0-9]{12})$" ;
+   samm-c:elements ( :bpns :bpna ) .
 
 :BpnlRegularExpression a samm-c:RegularExpressionConstraint ;
    samm:preferredName "BPNL Regular Expression"@en ;

--- a/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
+++ b/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
@@ -44,6 +44,13 @@
    samm:description "The provided regular expression ensures that the BPNA is composed of prefix 'BPNA', 10 digits and two alphanumeric letters."@en ;
    samm:value "^BPNA[a-zA-Z0-9]{12}$" .
 
+:AnyBpnCharacteristic a samm-c:StructuredValue ;
+   samm:preferredName "any BPN charcteristic"@en ;
+   samm:description "allows the use of any BPN"@en ;
+   samm:dataType xsd:string ;
+   samm-c:deconstructionRule "^(BPNL[a-zA-Z0-9]{12})|(BPNS[a-zA-Z0-9]{12})|(BPNA[a-zA-Z0-9]{12})$" ;
+   samm-c:elements ( "^" :bpnl "|" :bpns "|" :bpna "$" ) .
+
 :bpns a samm:Property ;
    samm:preferredName "Business Partner Number Site Property"@en ;
    samm:description "Property based on a BPNS."@en ;

--- a/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
+++ b/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
@@ -1,5 +1,6 @@
 #######################################################################
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 Catena-X Automotive Network e.V.
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -12,99 +13,87 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
-@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
-@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
-@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
-@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <urn:samm:io.catenax.shared.business_partner_number:3.0.0#> .
 
-:BusinessPartnerNumber a samm:Aspect;
-    samm:preferredName "Shared Aspect for any business partner number"@en;
-    samm:description "This is a shared aspect for BPN with a regex."@en;
-    samm:properties (:bpnl :bpns :bpna);
-    samm:operations ();
-    samm:events ().
-
 :bpna a samm:Property ;
-   samm:preferredName "Business Partner Number Address"@en ;
+   samm:preferredName "Business Partner Number Address property"@en ;
    samm:description "Property based on a Business Partner Number Address (BPNA)."@en ;
-   samm:characteristic :BpnaTrait ;
+   samm:characteristic :BpnaCharacteristic ;
    samm:exampleValue "BPNA0123456789ZZ" .
 
-:BpnaTrait a samm-c:Trait ;
-   samm:preferredName "Business Partner Number Address Trait"@en ;
-   samm:description "Trait to ensure data format for Business Partner Number Address (BPNA)."@en ;
-   samm-c:baseCharacteristic :BpnaCharacteristic ;
-   samm-c:constraint :BpnaRegularExpression .
-
-:BpnaCharacteristic a samm:Characteristic ;
-   samm:preferredName "Business Partner Number Site"@en ;
-   samm:description "Business Partner Number Address (BPNA) contains the legal name (incl. legal form, if registered) and additional organization information about site, e.g. Plant xxx, Branch office yyy of an organization with its corresponding, most commonly physical, address. A BPNA is always linked to a BPNL via relationship 'belongs to legal entity' and should be linked to a BPNS via relationship 'belongs to site'. The BPNA is on operational level (e.g. shipping or pick-up address)."@en ;
-   samm:dataType xsd:string .
-
-:BpnaRegularExpression a samm-c:RegularExpressionConstraint ;
-   samm:preferredName "Business Partner Number Address Regular Expression"@en ;
-   samm:description "The provided regular expression ensures that the Business Partner Number Address (BPNA) is composed of prefix 'BPNA', 10 digits and two alphanumeric letters."@en ;
-   samm:value "^BPNA[a-zA-Z0-9]{12}$" .
-
-:AnyBpnCharacteristic a samm-c:StructuredValue ;
-   samm:preferredName "any Business Partner Number charcteristic"@en ;
-   samm:description "allows the use of any Business Partner Number (BPN)"@en ;
-   samm:dataType xsd:string ;
-   samm-c:deconstructionRule "^(BPNL[a-zA-Z0-9]{12})|(BPNS[a-zA-Z0-9]{12})|(BPNA[a-zA-Z0-9]{12})$" ;
-   samm-c:elements ( "^" :bpnl "|" :bpns "|" :bpna "$" ) .
-
 :bpns a samm:Property ;
-   samm:preferredName "Business Partner Number Site Property"@en ;
+   samm:preferredName "Business Partner Number Site property"@en ;
    samm:description "Property based on a Business Partner Number Site (BPNS)."@en ;
-   samm:characteristic :BpnsTrait ;
+   samm:characteristic :BpnsCharacteristic ;
    samm:exampleValue "BPNS0123456789ZZ" .
 
-:BpnsRegularExpression a samm-c:RegularExpressionConstraint ;
-   samm:preferredName "Business Partner Number Site regular expression"@en ;
-   samm:description "The provided regular expression ensures that the BPNS is composed of prefix 'BPNS', 10 digits and two alphanumeric letters."@en ;
-   samm:value "^BPNS[a-zA-Z0-9]{12}$" .
-
-:BpnsCharacteristic a samm:Characteristic ;
-   samm:preferredName "Business Partner Number Site"@en ;
-   samm:description "Business Partner Number Site (BPNS) represents a site which can be a production plant. A site can also be e.g. an office or a warehouse. An information related to a site is e.g. needed for reporting issues (How many sites does e.g. Beispiel AG have?), status of operation (out of operations due to environmental disaster), for certificates on site level (e.g. environment certificates) or for internal regulations on site level, (e.g. security topics, Corona rules,...). Several addresses (= BPNA with different streets and different gates) can belong to one site. A BPNS should be always linked to one BPNL via relationship 'belongs to legal entity'."@en ;
-   samm:dataType xsd:string .
-
-:BpnlTrait a samm-c:Trait ;
-   samm:preferredName "Business Partner Number Legal Trait"@en ;
-   samm:description "Trait to ensure data format for Business Partner Number Legal (BPNL)."@en ;
-   samm-c:baseCharacteristic :BpnlCharacteristic ;
-   samm-c:constraint :BpnlRegularExpression .
-
 :bpnl a samm:Property ;
-   samm:preferredName "Business Partner Number Legal Entity Property"@en ;
+   samm:preferredName "Business Partner Number Legal Entity property"@en ;
    samm:description "Property based on a Business Partner Number Legal (BPNL)."@en ;
-   samm:characteristic :BpnlTrait ;
+   samm:characteristic :BpnlCharacteristic ;
    samm:exampleValue "BPNL0123456789ZZ" .
 
-:BpnsTrait a samm-c:Trait ;
-   samm:preferredName "Business Partner Number Site Trait"@en ;
-   samm:description "Trait to ensure data format for Business Partner Number Site (BPNS)."@en ;
-   samm-c:baseCharacteristic :BpnsCharacteristic ;
-   samm-c:constraint :BpnsRegularExpression .
+:BpnaCharacteristic a samm-c:Trait ;
+   samm:preferredName "Business Partner Number Address characteristic"@en ;
+   samm:description "Business Partner Number Address (BPNA) contains the legal name (incl. legal form, if registered) and additional organization information about site, e.g. Plant xxx, Branch office yyy of an organization with its corresponding, most commonly physical, address. A BPNA is always linked to a BPNL via relationship 'belongs to legal entity' and should be linked to a BPNS via relationship 'belongs to site'. The BPNA is on operational level (e.g. shipping or pick-up address)."@en ;
+   samm-c:baseCharacteristic [
+      a samm:Characteristic;
+      samm:dataType xsd:string ;
+   ] ;
+   samm-c:constraint [
+      a samm-c:RegularExpressionConstraint ;
+      samm:value "^BPNA[a-zA-Z0-9]{12}$" ;
+   ] .
 
-:BpnlCharacteristic a samm:Characteristic ;
-   samm:preferredName "Business Partner Number Legal Entity"@en ;
-   samm:description "Business Partner Number Legal Entity (BPNL) represents the legal entity of an organization (e.g. enterprise, university, association, …) and contains its legal name (incl. legal form, if registered), registered address and tax number. The registered address is the official, legal correspondence address which has to be supplied to governmental and tax authorities and is the address which is used in any legal or court documents. BPNL is on corporate level and is unique for this legal entity."@en ;
-   samm:dataType xsd:string .
+:BpnlCharacteristic a samm-c:Trait ;
+   samm:preferredName "Business Partner Number Legal"@en ;
+   samm:description "The provided regular expression ensures that the Business Partner Number Legal Entity (BPNL) is composed of prefix 'BPNL', 10 digits and two alphanumeric letters."@en ;
+   samm-c:baseCharacteristic [
+      a samm:Characteristic;
+      samm:dataType xsd:string ;
+   ] ;
+   samm-c:constraint [
+      a samm-c:RegularExpressionConstraint ;
+      samm:value "^BPNL[a-zA-Z0-9]{12}$" ;
+   ] .
 
-:BpnsOrBpnaCharacteristic a samm-c:StructuredValue ;
+:BpnsCharacteristic a samm-c:Trait ;
+   samm:preferredName "Business Partner Number Site charcteristic"@en ;
+   samm:description "The provided regular expression ensures that the BPNS is composed of prefix 'BPNS', 10 digits and two alphanumeric letters."@en ;
+   samm-c:baseCharacteristic [
+      a samm:Characteristic;
+      samm:dataType xsd:string ;
+   ] ;
+   samm-c:constraint [
+      a samm-c:RegularExpressionConstraint ;
+      samm:value "^BPNS[a-zA-Z0-9]{12}$" ;
+   ] .
+
+:AnyBpnCharacteristic a samm-c:Trait ;
+   samm:preferredName "generic Business Partner Number characteristic"@en ;
+   samm:description "Business Partner Number Address (BPNA) contains the legal name (incl. legal form, if registered) and additional organization information about site, e.g. Plant xxx, Branch office yyy of an organization with its corresponding, most commonly physical, address. A BPNA is always linked to a BPNL via relationship 'belongs to legal entity' and should be linked to a BPNS via relationship 'belongs to site'. The BPNA is on operational level (e.g. shipping or pick-up address)."@en ;
+   samm-c:baseCharacteristic [
+      a samm:Characteristic;
+      samm:dataType xsd:string ;
+   ] ;
+   samm-c:constraint [
+      a samm-c:RegularExpressionConstraint ;
+      samm:value "^BPN[LSA]{1}[a-zA-Z0-9]{12}$" ;
+   ] .
+
+:BpnsOrBpnaCharacteristic a samm-c:Trait ;
    samm:preferredName "Business Partner Number Site or Address Characteristic"@en ;
    samm:description "This characteristic allows Business Partner Number Site (BPNS) or Address (BPNA)."@en ;
-   samm:dataType xsd:string ;
-   samm-c:deconstructionRule "^(BPNS[a-zA-Z0-9]{12})|(BPNA[a-zA-Z0-9]{12})$" ;
-   samm-c:elements ( :bpns :bpna ) .
-
-:BpnlRegularExpression a samm-c:RegularExpressionConstraint ;
-   samm:preferredName "Business Partner Number Legal Entity Regular Expression"@en ;
-   samm:description "The provided regular expression ensures that the Business Partner Number Legal Entity (BPNL) is composed of prefix 'BPNL', 10 digits and two alphanumeric letters."@en ;
-   samm:value "^BPNL[a-zA-Z0-9]{12}$" .
-
+   samm-c:baseCharacteristic [
+      a samm:Characteristic;
+      samm:dataType xsd:string ;
+   ] ;
+   samm-c:constraint [
+      a samm-c:RegularExpressionConstraint ;
+      samm:value "^BPN[SA]{1}[a-zA-Z0-9]{12}$" ;
+   ] .

--- a/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
+++ b/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
@@ -48,7 +48,8 @@
    samm-c:constraint [
       a samm-c:RegularExpressionConstraint ;
       samm:value "^BPNA[a-zA-Z0-9]{12}$" ;
-   ] .
+   ] ;
+   samm:see <https://catenax-ev.github.io/docs/standards/CX-0010-BusinessPartnerNumber> .
 
 :BpnlCharacteristic a samm-c:Trait ;
    samm:preferredName "Business Partner Number Legal"@en ;
@@ -60,7 +61,8 @@
    samm-c:constraint [
       a samm-c:RegularExpressionConstraint ;
       samm:value "^BPNL[a-zA-Z0-9]{12}$" ;
-   ] .
+   ] ;
+   samm:see <https://catenax-ev.github.io/docs/standards/CX-0010-BusinessPartnerNumber> .
 
 :BpnsCharacteristic a samm-c:Trait ;
    samm:preferredName "Business Partner Number Site charcteristic"@en ;
@@ -72,11 +74,12 @@
    samm-c:constraint [
       a samm-c:RegularExpressionConstraint ;
       samm:value "^BPNS[a-zA-Z0-9]{12}$" ;
-   ] .
+   ] ;
+   samm:see <https://catenax-ev.github.io/docs/standards/CX-0010-BusinessPartnerNumber> .
 
 :AnyBpnCharacteristic a samm-c:Trait ;
    samm:preferredName "generic Business Partner Number characteristic"@en ;
-   samm:description "Business Partner Number Address (BPNA) contains the legal name (incl. legal form, if registered) and additional organization information about site, e.g. Plant xxx, Branch office yyy of an organization with its corresponding, most commonly physical, address. A BPNA is always linked to a BPNL via relationship 'belongs to legal entity' and should be linked to a BPNS via relationship 'belongs to site'. The BPNA is on operational level (e.g. shipping or pick-up address)."@en ;
+   samm:description "Generic Business Partner Number (BPN) which allows the usage of BPNA, BPNL as well BPNS."@en ;
    samm-c:baseCharacteristic [
       a samm:Characteristic;
       samm:dataType xsd:string ;

--- a/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
+++ b/io.catenax.shared.business_partner_number/3.0.0/BusinessPartnerNumber.ttl
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -12,7 +12,6 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
-
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
@@ -22,83 +21,90 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <urn:samm:io.catenax.shared.business_partner_number:3.0.0#> .
 
+:BusinessPartnerNumber a samm:Aspect;
+    samm:preferredName "Shared Aspect for any business partner number"@en;
+    samm:description "This is a shared aspect for BPN with a regex."@en;
+    samm:properties (:bpnl :bpns :bpna);
+    samm:operations ();
+    samm:events ().
+
 :bpna a samm:Property ;
    samm:preferredName "Business Partner Number Address"@en ;
-   samm:description "Property based on a BPNA."@en ;
+   samm:description "Property based on a Business Partner Number Address (BPNA)."@en ;
    samm:characteristic :BpnaTrait ;
    samm:exampleValue "BPNA0123456789ZZ" .
 
 :BpnaTrait a samm-c:Trait ;
-   samm:preferredName "BPNA Trait"@en ;
-   samm:description "Trait to ensure data format for BPNA."@en ;
+   samm:preferredName "Business Partner Number Address Trait"@en ;
+   samm:description "Trait to ensure data format for Business Partner Number Address (BPNA)."@en ;
    samm-c:baseCharacteristic :BpnaCharacteristic ;
    samm-c:constraint :BpnaRegularExpression .
 
 :BpnaCharacteristic a samm:Characteristic ;
    samm:preferredName "Business Partner Number Site"@en ;
-   samm:description "BPNA (Business Partner Number Address) contains the legal name (incl. legal form, if registered) and additional organization information about site, e.g. Plant xxx, Branch office yyy of an organization with its corresponding, most commonly physical, address. A BPNA is always linked to a BPNL via relationship 'belongs to legal entity' and should be linked to a BPNS via relationship 'belongs to site'. The BPNA is on operational level (e.g. shipping or pick-up address)."@en ;
+   samm:description "Business Partner Number Address (BPNA) contains the legal name (incl. legal form, if registered) and additional organization information about site, e.g. Plant xxx, Branch office yyy of an organization with its corresponding, most commonly physical, address. A BPNA is always linked to a BPNL via relationship 'belongs to legal entity' and should be linked to a BPNS via relationship 'belongs to site'. The BPNA is on operational level (e.g. shipping or pick-up address)."@en ;
    samm:dataType xsd:string .
 
 :BpnaRegularExpression a samm-c:RegularExpressionConstraint ;
-   samm:preferredName "BPNA Regular Expression"@en ;
-   samm:description "The provided regular expression ensures that the BPNA is composed of prefix 'BPNA', 10 digits and two alphanumeric letters."@en ;
+   samm:preferredName "Business Partner Number Address Regular Expression"@en ;
+   samm:description "The provided regular expression ensures that the Business Partner Number Address (BPNA) is composed of prefix 'BPNA', 10 digits and two alphanumeric letters."@en ;
    samm:value "^BPNA[a-zA-Z0-9]{12}$" .
 
 :AnyBpnCharacteristic a samm-c:StructuredValue ;
-   samm:preferredName "any BPN charcteristic"@en ;
-   samm:description "allows the use of any BPN"@en ;
+   samm:preferredName "any Business Partner Number charcteristic"@en ;
+   samm:description "allows the use of any Business Partner Number (BPN)"@en ;
    samm:dataType xsd:string ;
    samm-c:deconstructionRule "^(BPNL[a-zA-Z0-9]{12})|(BPNS[a-zA-Z0-9]{12})|(BPNA[a-zA-Z0-9]{12})$" ;
    samm-c:elements ( "^" :bpnl "|" :bpns "|" :bpna "$" ) .
 
 :bpns a samm:Property ;
    samm:preferredName "Business Partner Number Site Property"@en ;
-   samm:description "Property based on a BPNS."@en ;
+   samm:description "Property based on a Business Partner Number Site (BPNS)."@en ;
    samm:characteristic :BpnsTrait ;
    samm:exampleValue "BPNS0123456789ZZ" .
 
 :BpnsRegularExpression a samm-c:RegularExpressionConstraint ;
-   samm:preferredName "BPNS Regular Expression"@en ;
+   samm:preferredName "Business Partner Number Site regular expression"@en ;
    samm:description "The provided regular expression ensures that the BPNS is composed of prefix 'BPNS', 10 digits and two alphanumeric letters."@en ;
    samm:value "^BPNS[a-zA-Z0-9]{12}$" .
 
 :BpnsCharacteristic a samm:Characteristic ;
    samm:preferredName "Business Partner Number Site"@en ;
-   samm:description "BPNS (Business Partner Number Site) represents a site which can be a production plant. A site can also be e.g. an office or a warehouse. An information related to a site is e.g. needed for reporting issues (How many sites does e.g. Beispiel AG have?), status of operation (out of operations due to environmental disaster), for certificates on site level (e.g. environment certificates) or for internal regulations on site level, (e.g. security topics, Corona rules,...). Several addresses (= BPNA with different streets and different gates) can belong to one site. A BPNS should be always linked to one BPNL via relationship 'belongs to legal entity'."@en ;
+   samm:description "Business Partner Number Site (BPNS) represents a site which can be a production plant. A site can also be e.g. an office or a warehouse. An information related to a site is e.g. needed for reporting issues (How many sites does e.g. Beispiel AG have?), status of operation (out of operations due to environmental disaster), for certificates on site level (e.g. environment certificates) or for internal regulations on site level, (e.g. security topics, Corona rules,...). Several addresses (= BPNA with different streets and different gates) can belong to one site. A BPNS should be always linked to one BPNL via relationship 'belongs to legal entity'."@en ;
    samm:dataType xsd:string .
 
 :BpnlTrait a samm-c:Trait ;
-   samm:preferredName "BPNL Trait"@en ;
-   samm:description "Trait to ensure data format for BPNL."@en ;
+   samm:preferredName "Business Partner Number Legal Trait"@en ;
+   samm:description "Trait to ensure data format for Business Partner Number Legal (BPNL)."@en ;
    samm-c:baseCharacteristic :BpnlCharacteristic ;
    samm-c:constraint :BpnlRegularExpression .
 
 :bpnl a samm:Property ;
    samm:preferredName "Business Partner Number Legal Entity Property"@en ;
-   samm:description "Property based on a BPNL."@en ;
+   samm:description "Property based on a Business Partner Number Legal (BPNL)."@en ;
    samm:characteristic :BpnlTrait ;
    samm:exampleValue "BPNL0123456789ZZ" .
 
 :BpnsTrait a samm-c:Trait ;
-   samm:preferredName "BPNS Trait"@en ;
-   samm:description "Trait to ensure data format for BPNS."@en ;
+   samm:preferredName "Business Partner Number Site Trait"@en ;
+   samm:description "Trait to ensure data format for Business Partner Number Site (BPNS)."@en ;
    samm-c:baseCharacteristic :BpnsCharacteristic ;
    samm-c:constraint :BpnsRegularExpression .
 
 :BpnlCharacteristic a samm:Characteristic ;
    samm:preferredName "Business Partner Number Legal Entity"@en ;
-   samm:description "BPNL (Business Partner Number Legal Entity) represents the legal entity of an organization (e.g. enterprise, university, association, …) and contains its legal name (incl. legal form, if registered), registered address and tax number. The registered address is the official, legal correspondence address which has to be supplied to governmental and tax authorities and is the address which is used in any legal or court documents. BPNL is on corporate level and is unique for this legal entity."@en ;
+   samm:description "Business Partner Number Legal Entity (BPNL) represents the legal entity of an organization (e.g. enterprise, university, association, …) and contains its legal name (incl. legal form, if registered), registered address and tax number. The registered address is the official, legal correspondence address which has to be supplied to governmental and tax authorities and is the address which is used in any legal or court documents. BPNL is on corporate level and is unique for this legal entity."@en ;
    samm:dataType xsd:string .
 
 :BpnsOrBpnaCharacteristic a samm-c:StructuredValue ;
-   samm:preferredName "Bpns or Bpna Characteristic"@en ;
-   samm:description "This characteristic allows BPNS or BPNA."@en ;
+   samm:preferredName "Business Partner Number Site or Address Characteristic"@en ;
+   samm:description "This characteristic allows Business Partner Number Site (BPNS) or Address (BPNA)."@en ;
    samm:dataType xsd:string ;
    samm-c:deconstructionRule "^(BPNS[a-zA-Z0-9]{12})|(BPNA[a-zA-Z0-9]{12})$" ;
    samm-c:elements ( :bpns :bpna ) .
 
 :BpnlRegularExpression a samm-c:RegularExpressionConstraint ;
-   samm:preferredName "BPNL Regular Expression"@en ;
-   samm:description "The provided regular expression ensures that the BPNL is composed of prefix 'BPNL', 10 digits and two alphanumeric letters."@en ;
+   samm:preferredName "Business Partner Number Legal Entity Regular Expression"@en ;
+   samm:description "The provided regular expression ensures that the Business Partner Number Legal Entity (BPNL) is composed of prefix 'BPNL', 10 digits and two alphanumeric letters."@en ;
    samm:value "^BPNL[a-zA-Z0-9]{12}$" .
 

--- a/io.catenax.shared.business_partner_number/3.0.0/metadata.json
+++ b/io.catenax.shared.business_partner_number/3.0.0/metadata.json
@@ -1,0 +1,1 @@
+{"status": "release"}

--- a/io.catenax.shared.business_partner_number/RELEASE_NOTES.md
+++ b/io.catenax.shared.business_partner_number/RELEASE_NOTES.md
@@ -1,43 +1,50 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
-## [3.0.0] - 2024-02-05
+## [3.0.0] 26.09
 
 ### Added
 
-- characteristics allowing BPNS or BPNA
-- characteristics allowing any BPN
+- added characteristics allowing BPNS or BPNA
+- added characteristics allowing any BPN
 
 ### Changed
 
-- renamed bpnlProperty to bpnl
-- renamed bpnsProperty to bpns
-- renamed bpnaProperty to bpna
+- renamed `bpnlProperty` to `bpnl`
+- renamed `bpnsProperty` to `bpns`
+- renamed `bpnaProperty` to `bpna`
 
 ### Removed
 
 - aspect node to make the model a shared model
 
 ## [2.0.0] - 2024-02-05
+
 ### Added
+
 n/a
 
 ### Changed
+
 - updated regexes
   - from `^BPNL[0-9]{8}[a-zA-Z0-9]{4}$` to `^BPNL[a-zA-Z0-9]{12}$`
   - semantic descriptions as checksum is not two UPPERCASE but two alphanumeric digits
 - fixed typo in prefferedName of BpnlTrait
 
-
 ### Removed
+
 n/a
 
 ## [1.0.0] - 2023-09-11
+
 ### Added
+
 - initial model
 
 ### Changed
+
 n/a
 
 ### Removed
+
 n/a

--- a/io.catenax.shared.business_partner_number/RELEASE_NOTES.md
+++ b/io.catenax.shared.business_partner_number/RELEASE_NOTES.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this model will be documented in this file.
 
 ## [3.0.0] 26.09
@@ -13,6 +14,7 @@ All notable changes to this model will be documented in this file.
 - renamed `bpnlProperty` to `bpnl`
 - renamed `bpnsProperty` to `bpns`
 - renamed `bpnaProperty` to `bpna`
+- overall clean up of elements
 
 ### Removed
 

--- a/io.catenax.shared.business_partner_number/RELEASE_NOTES.md
+++ b/io.catenax.shared.business_partner_number/RELEASE_NOTES.md
@@ -1,6 +1,23 @@
 # Changelog
 All notable changes to this model will be documented in this file.
 
+## [3.0.0] - 2024-02-05
+
+### Added
+
+- characteristics allowing BPNS or BPNA
+- characteristics allowing any BPN
+
+### Changed
+
+- renamed bpnlProperty to bpnl
+- renamed bpnsProperty to bpns
+- renamed bpnaProperty to bpna
+
+### Removed
+
+- aspect node to make the model a shared model
+
 ## [2.0.0] - 2024-02-05
 ### Added
 n/a


### PR DESCRIPTION
## Description
* adding a characteristic allowing BPNS or BPNS
* removing dead links
* removing aspect node to make it a shard model
* renaming
* * bpnlProperty --> bpnl
* *  bpnsProperty --> bpns
* *  bpnaProperty --> bpna
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

Closes #
#950 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] payload names and property identifiers must not contain two consecutive underscores ('__') at any position (e.g. `my__model` is not allowed)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [x] all external / imported models have the state "release"
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
