### PR TITLE
Harmonize Report Model

### DIFF
--- a/io.catenax.report_8d/1.0.0/Report8D.ttl
+++ b/io.catenax.report_8d/1.0.0/Report8D.ttl
@@ -390,7 +390,7 @@
 :PartEntity a samm:Entity ;
    samm:preferredName "Part Entity"@en ;
    samm:description "Entity of the Characteristic PartCharacteristic"@en ;
-   samm:properties ( [ samm:property :supplierPartNumber; samm:optional true ] :customerPartNumber :orderNumber [ samm:property ext-core:serialNumber; samm:optional true ] [ samm:property ext-core:batchNumber; samm:optional true ] [ samm:property ext-core:partName; samm:optional true ] [ samm:property ext-core:hwVersion; samm:optional true ] [ samm:property ext-core:partId; samm:optional true ] ) .
+   samm:properties ( [ samm:property :supplierPartId; samm:optional true ] :customerPartId :orderId [ samm:property ext-core:serialNumber; samm:optional true ] [ samm:property ext-core:batchNumber; samm:optional true ] [ samm:property ext-core:partName; samm:optional true ] [ samm:property ext-core:hwVersion; samm:optional true ] [ samm:property ext-core:partId; samm:optional true ] ) .
 
 :PersonEntity a samm:Entity ;
    samm:preferredName "Person Entity"@en ;
@@ -442,21 +442,21 @@
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Germany" .
 
-:supplierPartNumber a samm:Property ;
-   samm:preferredName "Supplier Part Number"@en ;
-   samm:description "The part number of the supplier is the identifier assigned to the part by the supplier."@en ;
+:supplierPartId a samm:Property ;
+   samm:preferredName "Supplier Part Id"@en ;
+   samm:description "The part id of the supplier is the identifier assigned to the part by the supplier."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "123456789" .
 
-:customerPartNumber a samm:Property ;
-   samm:preferredName "Customer Part Number"@en ;
-   samm:description "The part number of the customer is the identifier assigned to the part by the customer."@en ;
+:customerPartId a samm:Property ;
+   samm:preferredName "Customer Part Id"@en ;
+   samm:description "The part id of the customer is the identifier assigned to the part by the customer."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "987564321" .
 
-:orderNumber a samm:Property ;
-   samm:preferredName "Order number"@en ;
-   samm:description "The order number of the part is the number associated with the purchase order for the part."@en ;
+:orderId a samm:Property ;
+   samm:preferredName "Order Id"@en ;
+   samm:description "The order id of the part is the number associated with the purchase order for the part."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "192837645" .
 


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->
Part of Harmonization #875 . changes done in model.
Closes #

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] payload names and property identifiers must not contain two consecutive underscores ('__') at any position (e.g. `my__model` is not allowed)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] all external / imported models have the state "release"
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
