### PR TITLE
Harmonize Quality Core-1.0.0

### DIFF
--- a/io.catenax.shared.quality_core/1.0.0/QualityCore.ttl
+++ b/io.catenax.shared.quality_core/1.0.0/QualityCore.ttl
@@ -115,7 +115,7 @@
 :Part a samm:Entity ;
    samm:preferredName "Part"@en ;
    samm:description "A collection of part/component properties. A Catena-X data provider should provide the  properties that are useful for a Catena-X data consumer to clearly identify the part/component. For example, this can be done by using a serial number, data matrix code or delivery note"@en ;
-   samm:properties ( :partName [ samm:property :partDescription; samm:optional true ] [ samm:property :assemblyPartNumberVersion; samm:optional true ] [ samm:property :batchNumber; samm:optional true ] [ samm:property :calibrationInformation; samm:optional true ] [ samm:property :partId; samm:optional true ] [ samm:property :dataMatrixCode; samm:optional true ] [ samm:property :deliveryNote; samm:optional true ] [ samm:property :hwVersion; samm:optional true ] [ samm:property :orderNumber; samm:optional true ] [ samm:property :partNumber; samm:optional true ] [ samm:property :partVersion; samm:optional true ] [ samm:property :serialNumber; samm:optional true ] [ samm:property :swPartNumber; samm:optional true ] [ samm:property :swVersion; samm:optional true ] [ samm:property :variantInfomation; samm:optional true ] ) .
+   samm:properties ( :partName [ samm:property :partDescription; samm:optional true ] [ samm:property :assemblyPartNumberVersion; samm:optional true ] [ samm:property :batchNumber; samm:optional true ] [ samm:property :calibrationInformation; samm:optional true ] [ samm:property :partId; samm:optional true ] [ samm:property :dataMatrixCode; samm:optional true ] [ samm:property :deliveryNote; samm:optional true ] [ samm:property :hwVersion; samm:optional true ] [ samm:property :orderNumber; samm:optional true ] [ samm:property :partNumber; samm:optional true ] [ samm:property :partVersion; samm:optional true ] [ samm:property :partInstanceId; samm:optional true ] [ samm:property :swPartNumber; samm:optional true ] [ samm:property :swVersion; samm:optional true ] [ samm:property :variantInfomation; samm:optional true ] ) .
 
 :Plant a samm:Entity ;
    samm:preferredName "Plant properties"@en ;
@@ -269,9 +269,9 @@
    samm:characteristic samm-c:Text ;
    samm:exampleValue "0556A" .
 
-:serialNumber a samm:Property ;
-   samm:preferredName "OEM Serial number"@en ;
-   samm:description "Serial number of one specific part. A serial number is unique within one company. If you combine serial number with BPNL of that company than you get a unique identifier for this part in this data-space."@en ;
+:partInstanceId a samm:Property ;
+   samm:preferredName "OEM part instance id"@en ;
+   samm:description "Part instance id or serial number of one specific part. A serial number is unique within one company. If you combine serial number with BPNL of that company than you get a unique identifier for this part in this data-space."@en ;
    samm:characteristic :UniqueID ;
    samm:exampleValue "ECU20646005020221" .
 


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->
Part of Harmonization https://github.com/eclipse-tractusx/sldt-semantic-models/issues/875 .
Closes #

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] payload names and property identifiers must not contain two consecutive underscores ('__') at any position (e.g. `my__model` is not allowed)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] all external / imported models have the state "release"
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
