### PR TITLE
added crypto material aspect model

### DIFF
--- a/io.catenax.crypto_material/1.0.0/CryptoMaterial.ttl
+++ b/io.catenax.crypto_material/1.0.0/CryptoMaterial.ttl
@@ -1,0 +1,245 @@
+#######################################################################
+# Copyright(c) 2026 Bayerische Motoren Werke Aktiengesellschaft(BMW AG)
+# Copyright(c) 2026 HELLA GmbH & Co. KGaA
+# Copyright(c) 2026 Magna International GmbH
+# Copyright(c) 2026 msg for automotive GmbH
+# Copyright(c) 2026 sovity GmbH
+# Copyright(c) 2026 T-Systems International GmbH
+# Copyright(c) 2026 Catena-X Automotive Network e.V.
+# Copyright(c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.crypto_material:1.0.0#> .
+@prefix ext-ic: <urn:samm:io.catenax.shared.industry_core.common:1.0.0#> .
+
+:CryptoMaterial a samm:Aspect ;
+   samm:preferredName "Crypto Material"@en ;
+   samm:description "The crypto material model contains information on the set of cryptographic materials associated with a unique instance of a serialized part or just-in-sequence part, such as e.g, an Electronic Control Unit (ECU)."@en ;
+   samm:properties ( ext-ic:globalAssetId :cryptoMaterials ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:cryptoMaterials a samm:Property ;
+   samm:preferredName "Crypto Materials"@en ;
+   samm:description "Set of one or more instances of cryptographic material associated with a unique instance of a serialized part or just-in-sequence part."@en ;
+   samm:characteristic :CryptoMaterialsSet .
+
+:rfc7468 a samm:Value ;
+   samm:preferredName "RFC 7468"@en ;
+   samm:description "Textual representation of BER or DER encoded ASN.1 structures, as specified in IETF RFC 7468."@en ;
+   samm:see <https://www.rfc-editor.org/rfc/rfc7468.html> ;
+   samm:value "rfc7468" .
+
+:base64 a samm:Value ;
+   samm:preferredName "Base64"@en ;
+   samm:description "Textual representation of arbitrary binary data as a string of Base64 characters, as specified in IETF RFC 4648."@en ;
+   samm:see <https://www.rfc-editor.org/rfc/rfc4648.html> ;
+   samm:value "base64" .
+
+:hex a samm:Value ;
+   samm:preferredName "HEX"@en ;
+   samm:description "Textual representation of arbitrary binary data as a string of Base16 (also referred to as hexadecimal) characters, as specified in IETF RFC 4648."@en ;
+   samm:see <https://www.rfc-editor.org/rfc/rfc4648.html> ;
+   samm:value "hex" .
+
+:CryptoMaterialEntity a samm:Entity ;
+   samm:preferredName "Crypto Material Entity"@en ;
+   samm:description "Entity containing information describing an instance of cryptographic material."@en ;
+   samm:properties (
+      :name
+      :type
+      :value
+      :format
+      :encoding
+   ) .
+
+:certificateSigningRequest a samm:Value ;
+   samm:preferredName "Certificate Signing Request"@en ;
+   samm:description "Certificate signing request (CSR) for requesting the issuing of a digital certificate to a subject from a certificate authority (CA)."@en ;
+   samm:value "certificateSigningRequest" .
+
+:ValueCharacteristic a samm:Characteristic ;
+   samm:preferredName "Value Characteristic"@en ;
+   samm:description "String containing the textual representation the value of cryptographic material in the format and encoding specified in the respective properties."@en ;
+   samm:dataType xsd:string .
+
+:pkcs1 a samm:Value ;
+   samm:preferredName "PKCS#1"@en ;
+   samm:description """PKCS#1 ASN.1 structure format for RSA private and public keys, as specified in IETF RFC 8017.
+
+Note: The PKCS#1 format is only used for asymmetric keys with the RSA algorithm and is superseeded by algorithm agnostic formats. All RSA keys can alternatively be formatted in PKCS#8 for private keys and the X.509 SubjectPublicKeyInfo for public keys, respectively."""@en ;
+   samm:see <https://www.rfc-editor.org/rfc/rfc8017.html> ;
+   samm:value "pkcs1" .
+
+:publicKey a samm:Value ;
+   samm:preferredName "Public Key"@en ;
+   samm:description "Public key of an asymmetric key pair that is used in an asymmetric cryptographic scheme."@en ;
+   samm:value "publicKey" .
+
+:value a samm:Property ;
+   samm:preferredName "Value"@en ;
+   samm:description "Value of cryptographic material in the format and encoding specified in the respective properties."@en ;
+   samm:characteristic :ValueCharacteristic ;
+   samm:exampleValue "-----BEGIN CERTIFICATE REQUEST-----\\nMIIBtzCCAT0CAQAwgZ8xDTALBgNVBCsMBDIwMjUxEzARBgNVBAgMClByb2R1Y3Rp...yVXgPMvdmc33ot8=\\n-----END CERTIFICATE REQUEST-----" .
+
+:pkcs8 a samm:Value ;
+   samm:preferredName "PKCS#8"@en ;
+   samm:description """PKCS#8 ASN.1 structure format for asymmetric private keys, as specified in IETF RFC 5958.
+
+Note: The PKCS#8v2 format allows to optionally bundle an asymmetric public key and/or a digital certificate with the private key. However, PKCS#8v2 cannot contain a public key or certificate on their own.
+
+Note: RFC 5958 obsoletes the PKCS#8v1 structure specified in IETF RFC 5208. However, the PKCS#8v2 ASN.1 structure is not supported in all systems and therefore PKCS#8v1 is still in use. In such case, the version information in the PKCS#8 ASN.1 structure must indicate the use of PKCS#8v1."""@en ;
+   samm:see <https://www.rfc-editor.org/rfc/rfc5958.html> ;
+   samm:value "pkcs8" .
+
+:FormatEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Format Enumeration"@en ;
+   samm:description "Enumeration defining the allowed formats for cryptographic material."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values (
+      :pkcs1
+      :pkcs8
+      :pkcs10
+      :raw
+      :subjectPublicKeyInfo
+      :x509v3
+   ) .
+
+:pkcs10 a samm:Value ;
+   samm:preferredName "PKCS#10"@en ;
+   samm:description "PKCS#10 ASN.1 structure format for certificate signing requests, as specified in IETF RFC 2986."@en ;
+   samm:see <https://www.rfc-editor.org/rfc/rfc2986.html> ;
+   samm:value "pkcs10" .
+
+:raw a samm:Value ;
+   samm:preferredName "Raw"@en ;
+   samm:description """Raw, unformatted binary data. For symmetric keys this is the binary representation of the key value.
+
+Note: This may be used for data that does not follow any specific cryptographic data format. The interpretation of the data is defined between participants."""@en ;
+   samm:value "raw" .
+
+:subjectPublicKeyInfo a samm:Value ;
+   samm:preferredName "Subject Public Key Info"@en ;
+   samm:description "SubjectPublicKeyInfo ASN.1 structure format for asymmetric public keys, as specified in IETF RFC 5280."@en ;
+   samm:see <https://www.rfc-editor.org/rfc/rfc5280.html> ;
+   samm:value "subjectPublicKeyInfo" .
+
+:x509v3 a samm:Value ;
+   samm:preferredName "X.509v3"@en ;
+   samm:description "X.509v3 ASN.1 structure format for digital certificates, as specified in IETF RFC 5280."@en ;
+   samm:see <https://www.rfc-editor.org/rfc/rfc5280.html> ;
+   samm:value "x509v3" .
+
+:EncodingEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Encoding Enumeration"@en ;
+   samm:description "Enumeration defining the allowed encodings for cryptographic material."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( :base64 :hex :rfc7468 ) .
+
+:type a samm:Property ;
+   samm:preferredName "Type"@en ;
+   samm:description """Type of cryptographic material.
+
+Provided cryptographic material must have one of the following types:
+- symmetric key
+- private key
+- public key
+- digital certificate
+- certificate signing request
+- secret material"""@en ;
+   samm:characteristic :TypeEnumeration ;
+   samm:exampleValue :certificateSigningRequest .
+
+:TypeEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Type Enumeration"@en ;
+   samm:description "Enumeration defining the allowed types of cryptographic material."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values (
+      :symmetricKey
+      :privateKey
+      :publicKey
+      :certificate
+      :certificateSigningRequest
+      :secretMaterial
+   ) .
+
+:secretMaterial a samm:Value ;
+   samm:preferredName "Secret Material"@en ;
+   samm:description "Any secret cryptographic material that is not considered a symmetric key or asymmetric private key. Secret cryptographic material includes e.g., passwords, seed values for random number generators, or blobs of secret data."@en ;
+   samm:value "secretMaterial" .
+
+:encoding a samm:Property ;
+   samm:preferredName "Encoding"@en ;
+   samm:description """Encoding of cryptographic material.
+
+Provided cryptographic material must have one of the following encodings:
+- Base64
+- HEX
+- RFC 7468"""@en ;
+   samm:characteristic :EncodingEnumeration ;
+   samm:exampleValue :rfc7468 .
+
+:name a samm:Property ;
+   samm:preferredName "Name"@en ;
+   samm:description """Name assigned to the cryptographic material.
+
+This property may be used to indicate the security service  provided by the cryptographic material and the usage or application it is associated with."""@en ;
+   samm:characteristic :NameCharacteristic ;
+   samm:exampleValue "ecuIdentityCsr" .
+
+:NameCharacteristic a samm:Characteristic ;
+   samm:preferredName "Name Characteristic"@en ;
+   samm:description "String containing the name assigned to cryptographic material."@en ;
+   samm:dataType xsd:string .
+
+:format a samm:Property ;
+   samm:preferredName "Format"@en ;
+   samm:description """Format of cryptographic material.
+
+Provided cryptographic material must have one of the following formats:
+- PKCS#1
+- PKCS#8
+- PKCS#10
+- raw
+- subjectPublicKeyInfo
+- X.509v3"""@en ;
+   samm:characteristic :FormatEnumeration ;
+   samm:exampleValue :pkcs10 .
+
+:privateKey a samm:Value ;
+   samm:preferredName "Private Key"@en ;
+   samm:description "Private key of an asymmetric key pair that is used in an asymmetric cryptographic scheme."@en ;
+   samm:value "privateKey" .
+
+:symmetricKey a samm:Value ;
+   samm:preferredName "Symmetric Key"@en ;
+   samm:description "Secret key shared between all participants in a symmetric cryptographic scheme."@en ;
+   samm:value "symmetricKey" .
+
+:certificate a samm:Value ;
+   samm:preferredName "Certificate"@en ;
+   samm:description "Digital certificate associating an asymmetric public key to the identity of the certificate's subject."@en ;
+   samm:value "certificate" .
+
+:CryptoMaterialsSet a samm-c:Set ;
+   samm:preferredName "Crypto Materials Set"@en ;
+   samm:description "Set containing instances of cryptographic material."@en ;
+   samm:dataType :CryptoMaterialEntity .
+

--- a/io.catenax.crypto_material/1.0.0/CryptoMaterial.ttl
+++ b/io.catenax.crypto_material/1.0.0/CryptoMaterial.ttl
@@ -21,8 +21,6 @@
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
-@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
-@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -30,14 +28,14 @@
 @prefix ext-ic: <urn:samm:io.catenax.shared.industry_core.common:1.0.0#> .
 
 :CryptoMaterial a samm:Aspect ;
-   samm:preferredName "Crypto Material"@en ;
+   samm:preferredName "crypto material"@en ;
    samm:description "The crypto material model contains information on the set of cryptographic materials associated with a unique instance of a serialized part or just-in-sequence part, such as e.g, an Electronic Control Unit (ECU)."@en ;
    samm:properties ( ext-ic:globalAssetId :cryptoMaterials ) ;
    samm:operations ( ) ;
    samm:events ( ) .
 
 :cryptoMaterials a samm:Property ;
-   samm:preferredName "Crypto Materials"@en ;
+   samm:preferredName "crypto materials"@en ;
    samm:description "Set of one or more instances of cryptographic material associated with a unique instance of a serialized part or just-in-sequence part."@en ;
    samm:characteristic :CryptoMaterialsSet .
 
@@ -60,7 +58,7 @@
    samm:value "hex" .
 
 :CryptoMaterialEntity a samm:Entity ;
-   samm:preferredName "Crypto Material Entity"@en ;
+   samm:preferredName "crypto material entity"@en ;
    samm:description "Entity containing information describing an instance of cryptographic material."@en ;
    samm:properties (
       :name
@@ -71,12 +69,12 @@
    ) .
 
 :certificateSigningRequest a samm:Value ;
-   samm:preferredName "Certificate Signing Request"@en ;
+   samm:preferredName "certificate signing request"@en ;
    samm:description "Certificate signing request (CSR) for requesting the issuing of a digital certificate to a subject from a certificate authority (CA)."@en ;
    samm:value "certificateSigningRequest" .
 
 :ValueCharacteristic a samm:Characteristic ;
-   samm:preferredName "Value Characteristic"@en ;
+   samm:preferredName "value characteristic"@en ;
    samm:description "String containing the textual representation the value of cryptographic material in the format and encoding specified in the respective properties."@en ;
    samm:dataType xsd:string .
 
@@ -89,12 +87,12 @@ Note: The PKCS#1 format is only used for asymmetric keys with the RSA algorithm 
    samm:value "pkcs1" .
 
 :publicKey a samm:Value ;
-   samm:preferredName "Public Key"@en ;
+   samm:preferredName "public key"@en ;
    samm:description "Public key of an asymmetric key pair that is used in an asymmetric cryptographic scheme."@en ;
    samm:value "publicKey" .
 
 :value a samm:Property ;
-   samm:preferredName "Value"@en ;
+   samm:preferredName "value"@en ;
    samm:description "Value of cryptographic material in the format and encoding specified in the respective properties."@en ;
    samm:characteristic :ValueCharacteristic ;
    samm:exampleValue "-----BEGIN CERTIFICATE REQUEST-----\\nMIIBtzCCAT0CAQAwgZ8xDTALBgNVBCsMBDIwMjUxEzARBgNVBAgMClByb2R1Y3Rp...yVXgPMvdmc33ot8=\\n-----END CERTIFICATE REQUEST-----" .
@@ -110,7 +108,7 @@ Note: RFC 5958 obsoletes the PKCS#8v1 structure specified in IETF RFC 5208. Howe
    samm:value "pkcs8" .
 
 :FormatEnumeration a samm-c:Enumeration ;
-   samm:preferredName "Format Enumeration"@en ;
+   samm:preferredName "format enumeration"@en ;
    samm:description "Enumeration defining the allowed formats for cryptographic material."@en ;
    samm:dataType xsd:string ;
    samm-c:values (
@@ -129,14 +127,14 @@ Note: RFC 5958 obsoletes the PKCS#8v1 structure specified in IETF RFC 5208. Howe
    samm:value "pkcs10" .
 
 :raw a samm:Value ;
-   samm:preferredName "Raw"@en ;
+   samm:preferredName "raw"@en ;
    samm:description """Raw, unformatted binary data. For symmetric keys this is the binary representation of the key value.
 
 Note: This may be used for data that does not follow any specific cryptographic data format. The interpretation of the data is defined between participants."""@en ;
    samm:value "raw" .
 
 :subjectPublicKeyInfo a samm:Value ;
-   samm:preferredName "Subject Public Key Info"@en ;
+   samm:preferredName "subject public key info"@en ;
    samm:description "SubjectPublicKeyInfo ASN.1 structure format for asymmetric public keys, as specified in IETF RFC 5280."@en ;
    samm:see <https://www.rfc-editor.org/rfc/rfc5280.html> ;
    samm:value "subjectPublicKeyInfo" .
@@ -148,13 +146,13 @@ Note: This may be used for data that does not follow any specific cryptographic 
    samm:value "x509v3" .
 
 :EncodingEnumeration a samm-c:Enumeration ;
-   samm:preferredName "Encoding Enumeration"@en ;
+   samm:preferredName "encoding enumeration"@en ;
    samm:description "Enumeration defining the allowed encodings for cryptographic material."@en ;
    samm:dataType xsd:string ;
    samm-c:values ( :base64 :hex :rfc7468 ) .
 
 :type a samm:Property ;
-   samm:preferredName "Type"@en ;
+   samm:preferredName "type"@en ;
    samm:description """Type of cryptographic material.
 
 Provided cryptographic material must have one of the following types:
@@ -168,7 +166,7 @@ Provided cryptographic material must have one of the following types:
    samm:exampleValue :certificateSigningRequest .
 
 :TypeEnumeration a samm-c:Enumeration ;
-   samm:preferredName "Type Enumeration"@en ;
+   samm:preferredName "type enumeration"@en ;
    samm:description "Enumeration defining the allowed types of cryptographic material."@en ;
    samm:dataType xsd:string ;
    samm-c:values (
@@ -181,12 +179,12 @@ Provided cryptographic material must have one of the following types:
    ) .
 
 :secretMaterial a samm:Value ;
-   samm:preferredName "Secret Material"@en ;
+   samm:preferredName "secret material"@en ;
    samm:description "Any secret cryptographic material that is not considered a symmetric key or asymmetric private key. Secret cryptographic material includes e.g., passwords, seed values for random number generators, or blobs of secret data."@en ;
    samm:value "secretMaterial" .
 
 :encoding a samm:Property ;
-   samm:preferredName "Encoding"@en ;
+   samm:preferredName "encoding"@en ;
    samm:description """Encoding of cryptographic material.
 
 Provided cryptographic material must have one of the following encodings:
@@ -197,7 +195,7 @@ Provided cryptographic material must have one of the following encodings:
    samm:exampleValue :rfc7468 .
 
 :name a samm:Property ;
-   samm:preferredName "Name"@en ;
+   samm:preferredName "name"@en ;
    samm:description """Name assigned to the cryptographic material.
 
 This property may be used to indicate the security service  provided by the cryptographic material and the usage or application it is associated with."""@en ;
@@ -205,12 +203,12 @@ This property may be used to indicate the security service  provided by the cryp
    samm:exampleValue "ecuIdentityCsr" .
 
 :NameCharacteristic a samm:Characteristic ;
-   samm:preferredName "Name Characteristic"@en ;
+   samm:preferredName "name characteristic"@en ;
    samm:description "String containing the name assigned to cryptographic material."@en ;
    samm:dataType xsd:string .
 
 :format a samm:Property ;
-   samm:preferredName "Format"@en ;
+   samm:preferredName "format"@en ;
    samm:description """Format of cryptographic material.
 
 Provided cryptographic material must have one of the following formats:
@@ -224,12 +222,12 @@ Provided cryptographic material must have one of the following formats:
    samm:exampleValue :pkcs10 .
 
 :privateKey a samm:Value ;
-   samm:preferredName "Private Key"@en ;
+   samm:preferredName "private key"@en ;
    samm:description "Private key of an asymmetric key pair that is used in an asymmetric cryptographic scheme."@en ;
    samm:value "privateKey" .
 
 :symmetricKey a samm:Value ;
-   samm:preferredName "Symmetric Key"@en ;
+   samm:preferredName "symmetric key"@en ;
    samm:description "Secret key shared between all participants in a symmetric cryptographic scheme."@en ;
    samm:value "symmetricKey" .
 

--- a/io.catenax.crypto_material/1.0.0/CryptoMaterial.ttl
+++ b/io.catenax.crypto_material/1.0.0/CryptoMaterial.ttl
@@ -39,20 +39,20 @@
    samm:description "Set of one or more instances of cryptographic material associated with a unique instance of a serialized part or just-in-sequence part."@en ;
    samm:characteristic :CryptoMaterialsSet .
 
-:rfc7468 a samm:Value ;
-   samm:preferredName "RFC 7468"@en ;
+:Rfc7468EnumValue a samm:Value ;
+   samm:preferredName "Internet Engineering Task Force Request For Comments 7468"@en ;
    samm:description "Textual representation of BER or DER encoded ASN.1 structures, as specified in IETF RFC 7468."@en ;
    samm:see <https://www.rfc-editor.org/rfc/rfc7468.html> ;
    samm:value "rfc7468" .
 
-:base64 a samm:Value ;
+:Base64EnumValue a samm:Value ;
    samm:preferredName "Base64"@en ;
    samm:description "Textual representation of arbitrary binary data as a string of Base64 characters, as specified in IETF RFC 4648."@en ;
    samm:see <https://www.rfc-editor.org/rfc/rfc4648.html> ;
    samm:value "base64" .
 
-:hex a samm:Value ;
-   samm:preferredName "HEX"@en ;
+:HexEnumValue a samm:Value ;
+   samm:preferredName "hexadecimal"@en ;
    samm:description "Textual representation of arbitrary binary data as a string of Base16 (also referred to as hexadecimal) characters, as specified in IETF RFC 4648."@en ;
    samm:see <https://www.rfc-editor.org/rfc/rfc4648.html> ;
    samm:value "hex" .
@@ -68,7 +68,7 @@
       :encoding
    ) .
 
-:certificateSigningRequest a samm:Value ;
+:CertificateSigningRequestEnumValue a samm:Value ;
    samm:preferredName "certificate signing request"@en ;
    samm:description "Certificate signing request (CSR) for requesting the issuing of a digital certificate to a subject from a certificate authority (CA)."@en ;
    samm:value "certificateSigningRequest" .
@@ -78,15 +78,15 @@
    samm:description "String containing the textual representation the value of cryptographic material in the format and encoding specified in the respective properties."@en ;
    samm:dataType xsd:string .
 
-:pkcs1 a samm:Value ;
-   samm:preferredName "PKCS#1"@en ;
+:Pkcs1EnumValue a samm:Value ;
+   samm:preferredName "Public Key Cryptographic Standard #1"@en ;
    samm:description """PKCS#1 ASN.1 structure format for RSA private and public keys, as specified in IETF RFC 8017.
 
 Note: The PKCS#1 format is only used for asymmetric keys with the RSA algorithm and is superseeded by algorithm agnostic formats. All RSA keys can alternatively be formatted in PKCS#8 for private keys and the X.509 SubjectPublicKeyInfo for public keys, respectively."""@en ;
    samm:see <https://www.rfc-editor.org/rfc/rfc8017.html> ;
    samm:value "pkcs1" .
 
-:publicKey a samm:Value ;
+:PublicKeyEnumValue a samm:Value ;
    samm:preferredName "public key"@en ;
    samm:description "Public key of an asymmetric key pair that is used in an asymmetric cryptographic scheme."@en ;
    samm:value "publicKey" .
@@ -97,8 +97,8 @@ Note: The PKCS#1 format is only used for asymmetric keys with the RSA algorithm 
    samm:characteristic :ValueCharacteristic ;
    samm:exampleValue "-----BEGIN CERTIFICATE REQUEST-----\\nMIIBtzCCAT0CAQAwgZ8xDTALBgNVBCsMBDIwMjUxEzARBgNVBAgMClByb2R1Y3Rp...yVXgPMvdmc33ot8=\\n-----END CERTIFICATE REQUEST-----" .
 
-:pkcs8 a samm:Value ;
-   samm:preferredName "PKCS#8"@en ;
+:Pkcs8EnumValue a samm:Value ;
+   samm:preferredName "Public Key Cryptographic Standard #8"@en ;
    samm:description """PKCS#8 ASN.1 structure format for asymmetric private keys, as specified in IETF RFC 5958.
 
 Note: The PKCS#8v2 format allows to optionally bundle an asymmetric public key and/or a digital certificate with the private key. However, PKCS#8v2 cannot contain a public key or certificate on their own.
@@ -112,34 +112,34 @@ Note: RFC 5958 obsoletes the PKCS#8v1 structure specified in IETF RFC 5208. Howe
    samm:description "Enumeration defining the allowed formats for cryptographic material."@en ;
    samm:dataType xsd:string ;
    samm-c:values (
-      :pkcs1
-      :pkcs8
-      :pkcs10
-      :raw
-      :subjectPublicKeyInfo
-      :x509v3
+      :Pkcs1EnumValue
+      :Pkcs8EnumValue
+      :Pkcs10EnumValue
+      :RawEnumValue
+      :SubjectPublicKeyInfoEnumValue
+      :X509v3EnumValue
    ) .
 
-:pkcs10 a samm:Value ;
-   samm:preferredName "PKCS#10"@en ;
+:Pkcs10EnumValue a samm:Value ;
+   samm:preferredName "Public Key Cryptographic Standard #10"@en ;
    samm:description "PKCS#10 ASN.1 structure format for certificate signing requests, as specified in IETF RFC 2986."@en ;
    samm:see <https://www.rfc-editor.org/rfc/rfc2986.html> ;
    samm:value "pkcs10" .
 
-:raw a samm:Value ;
+:RawEnumValue a samm:Value ;
    samm:preferredName "raw"@en ;
    samm:description """Raw, unformatted binary data. For symmetric keys this is the binary representation of the key value.
 
 Note: This may be used for data that does not follow any specific cryptographic data format. The interpretation of the data is defined between participants."""@en ;
    samm:value "raw" .
 
-:subjectPublicKeyInfo a samm:Value ;
+:SubjectPublicKeyInfoEnumValue a samm:Value ;
    samm:preferredName "subject public key info"@en ;
    samm:description "SubjectPublicKeyInfo ASN.1 structure format for asymmetric public keys, as specified in IETF RFC 5280."@en ;
    samm:see <https://www.rfc-editor.org/rfc/rfc5280.html> ;
    samm:value "subjectPublicKeyInfo" .
 
-:x509v3 a samm:Value ;
+:X509v3EnumValue a samm:Value ;
    samm:preferredName "X.509v3"@en ;
    samm:description "X.509v3 ASN.1 structure format for digital certificates, as specified in IETF RFC 5280."@en ;
    samm:see <https://www.rfc-editor.org/rfc/rfc5280.html> ;
@@ -149,7 +149,7 @@ Note: This may be used for data that does not follow any specific cryptographic 
    samm:preferredName "encoding enumeration"@en ;
    samm:description "Enumeration defining the allowed encodings for cryptographic material."@en ;
    samm:dataType xsd:string ;
-   samm-c:values ( :base64 :hex :rfc7468 ) .
+   samm-c:values ( :Base64EnumValue :HexEnumValue :Rfc7468EnumValue ) .
 
 :type a samm:Property ;
    samm:preferredName "type"@en ;
@@ -170,15 +170,15 @@ Provided cryptographic material must have one of the following types:
    samm:description "Enumeration defining the allowed types of cryptographic material."@en ;
    samm:dataType xsd:string ;
    samm-c:values (
-      :symmetricKey
-      :privateKey
-      :publicKey
-      :certificate
-      :certificateSigningRequest
-      :secretMaterial
+      :SymmetricKeyEnumValue
+      :PrivateKeyEnumValue
+      :PrivateKeyEnumValue
+      :CertificateEnumValue
+      :CertificateSigningRequestEnumValue
+      :SecretMaterialEnumValue
    ) .
 
-:secretMaterial a samm:Value ;
+:SecretMaterialEnumValue a samm:Value ;
    samm:preferredName "secret material"@en ;
    samm:description "Any secret cryptographic material that is not considered a symmetric key or asymmetric private key. Secret cryptographic material includes e.g., passwords, seed values for random number generators, or blobs of secret data."@en ;
    samm:value "secretMaterial" .
@@ -192,7 +192,7 @@ Provided cryptographic material must have one of the following encodings:
 - HEX
 - RFC 7468"""@en ;
    samm:characteristic :EncodingEnumeration ;
-   samm:exampleValue :rfc7468 .
+   samm:exampleValue :Rfc7468EnumValue .
 
 :name a samm:Property ;
    samm:preferredName "name"@en ;
@@ -219,19 +219,19 @@ Provided cryptographic material must have one of the following formats:
 - subjectPublicKeyInfo
 - X.509v3"""@en ;
    samm:characteristic :FormatEnumeration ;
-   samm:exampleValue :pkcs10 .
+   samm:exampleValue :Pkcs10EnumValue .
 
-:privateKey a samm:Value ;
+:PrivateKeyEnumValue a samm:Value ;
    samm:preferredName "private key"@en ;
    samm:description "Private key of an asymmetric key pair that is used in an asymmetric cryptographic scheme."@en ;
    samm:value "privateKey" .
 
-:symmetricKey a samm:Value ;
+:SymmetricKeyEnumValue a samm:Value ;
    samm:preferredName "symmetric key"@en ;
    samm:description "Secret key shared between all participants in a symmetric cryptographic scheme."@en ;
    samm:value "symmetricKey" .
 
-:certificate a samm:Value ;
+:CertificateEnumValue a samm:Value ;
    samm:preferredName "Certificate"@en ;
    samm:description "Digital certificate associating an asymmetric public key to the identity of the certificate's subject."@en ;
    samm:value "certificate" .

--- a/io.catenax.crypto_material/1.0.0/metadata.json
+++ b/io.catenax.crypto_material/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{"status" : "release"} 

--- a/io.catenax.crypto_material/RELEASE_NOTES.md
+++ b/io.catenax.crypto_material/RELEASE_NOTES.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this model will be documented in this file.
+
+## [1.0.0] 2026-04-02
+
+- initial version of the aspect model

--- a/io.catenax.crypto_material/RELEASE_NOTES.md
+++ b/io.catenax.crypto_material/RELEASE_NOTES.md
@@ -2,6 +2,6 @@
 
 All notable changes to this model will be documented in this file.
 
-## [1.0.0] 2026-04-02
+## [1.0.0] 26.06
 
 - initial version of the aspect model


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

Closes #

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] payload names and property identifiers must not contain two consecutive underscores ('__') at any position (e.g. `my__model` is not allowed)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [x] all external / imported models have the state "release"
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
