### PR TITLE
feat: Add Digital Twin Notification model definition

### DIFF
--- a/io.catenax.digital_twin_notification/1.0.0/DigitalTwinNotification.ttl
+++ b/io.catenax.digital_twin_notification/1.0.0/DigitalTwinNotification.ttl
@@ -1,0 +1,171 @@
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:org.eclipse.esmf:1.0.0#> .
+@prefix ext-header: <urn:samm:io.catenax.shared.message_header:3.0.0#> .
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
+@prefix samm-u: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+
+:DigitalTwinNotification a samm:Aspect ;
+   samm:preferredName "Digital Twin Notification"@en ;
+   samm:description "Aspect model describing the notification payload for Digital Twin Registry (DTR) operations. It carries a message header with routing/context metadata and a content body referencing EDC endpoints and AAS shell descriptors."@en ;
+   samm:properties ( :content ext-header:header ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:content a samm:Property ;
+   samm:preferredName "Content"@en ;
+   samm:description "Payload content of the notification, including EDC connection details and shell descriptors."@en ;
+   samm:characteristic :ContentCharacteristic .
+
+:ContentCharacteristic a samm:Characteristic ;
+   samm:preferredName "Content"@en ;
+   samm:description "The notification body carrying EDC connection information and AAS shell descriptors."@en ;
+   samm:dataType :Content .
+
+:Content a samm:Entity ;
+   samm:preferredName "Content"@en ;
+   samm:description "The notification body carrying EDC connection information and AAS shell descriptors."@en ;
+   samm:properties ( :shells :edcAssetId :edcControlPlane ) .
+
+:shells a samm:Property ;
+   samm:preferredName "Shells"@en ;
+   samm:description "List of AAS shell descriptors included in the notification."@en ;
+   samm:characteristic :ShellsList .
+
+:edcAssetId a samm:Property ;
+   samm:preferredName "EDC Asset ID"@en ;
+   samm:description "The asset identifier in the EDC catalog.\""@en ;
+   samm:characteristic :String ;
+   samm:exampleValue "registry-asset" .
+
+:edcControlPlane a samm:Property ;
+   samm:preferredName "EDC Control Plane"@en ;
+   samm:description "The EDC control-plane endpoint of the DTR where the linked shells are hosted."@en ;
+   samm:characteristic :String ;
+   samm:exampleValue "https://edc.control.plane/api/v1/dsp" .
+
+:ShellsList a samm-c:List ;
+   samm:preferredName "Shells List"@en ;
+   samm:description "A list of shell entries."@en ;
+   samm:dataType :Shell .
+
+:String a samm:Characteristic ;
+   samm:preferredName "String"@en ;
+   samm:dataType xsd:string .
+
+:Shell a samm:Entity ;
+   samm:preferredName "Shell"@en ;
+   samm:description "An Asset Administration Shell descriptor."@en ;
+   samm:properties ( :submodelDescriptors :edcDataplane ext-uuid:uuidV4Property ) .
+
+:submodelDescriptors a samm:Property ;
+   samm:preferredName "Submodel Descriptors"@en ;
+   samm:description "List of submodel descriptors associated with the shell."@en ;
+   samm:characteristic :SubmodelDescriptorsList .
+
+:edcDataplane a samm:Property ;
+   samm:preferredName "EDC Data Plane"@en ;
+   samm:description "The EDC data-plane endpoint of the shell, composed of the DTR API base URL and the shell ID."@en ;
+   samm:characteristic :String ;
+   samm:exampleValue "https://edc.data.plane/api/public/urn:uuid:7effd7f4-6353-4401-9547-c54b420a22a0" .
+
+:SubmodelDescriptorsList a samm-c:List ;
+   samm:preferredName "Submodel Descriptors List"@en ;
+   samm:dataType :SubmodelDescriptor .
+
+:SubmodelDescriptor a samm:Entity ;
+   samm:preferredName "Submodel Descriptor"@en ;
+   samm:description "Descriptor for a single submodel, including its semantic identity and access endpoints."@en ;
+   samm:properties ( :semanticId ext-uuid:uuidV4Property :endpoints ) .
+
+:semanticId a samm:Property ;
+   samm:preferredName "Semantic ID"@en ;
+   samm:description "Reference to the semantic definition of the submodel."@en ;
+   samm:characteristic :SemanticIdCharacteristic .
+
+:endpoints a samm:Property ;
+   samm:preferredName "Endpoints"@en ;
+   samm:description "List of access endpoints for the submodel."@en ;
+   samm:characteristic :EndpointsList .
+
+:SemanticIdCharacteristic a samm:Characteristic ;
+   samm:preferredName "Semantic ID"@en ;
+   samm:dataType :SemanticId .
+
+:EndpointsList a samm-c:List ;
+   samm:preferredName "Endpoints List"@en ;
+   samm:dataType :Endpoint .
+
+:SemanticId a samm:Entity ;
+   samm:preferredName "Semantic ID"@en ;
+   samm:description "An external or global reference identifying the semantic meaning of a submodel."@en ;
+   samm:properties ( :type :keys ) .
+
+:Endpoint a samm:Entity ;
+   samm:preferredName "Endpoint"@en ;
+   samm:description "An access endpoint for a submodel."@en ;
+   samm:properties ( :interface :protocolInformation ) .
+
+:type a samm:Property ;
+   samm:preferredName "Reference Type"@en ;
+   samm:description "Type of reference, e.g. ExternalReference."@en ;
+   samm:characteristic :String ;
+   samm:exampleValue "ExternalReference" .
+
+:keys a samm:Property ;
+   samm:preferredName "Keys"@en ;
+   samm:description "List of reference keys."@en ;
+   samm:characteristic :KeysList .
+
+:interface a samm:Property ;
+   samm:preferredName "Interface"@en ;
+   samm:description "The interface identifier, e.g. SUBMODEL-VALUE-3.1."@en ;
+   samm:characteristic :String ;
+   samm:exampleValue "SUBMODEL-VALUE-3.1" .
+
+:protocolInformation a samm:Property ;
+   samm:preferredName "Protocol Information"@en ;
+   samm:description "Protocol-specific connection details for the endpoint."@en ;
+   samm:characteristic :ProtocolInformationCharacteristic .
+
+:KeysList a samm-c:List ;
+   samm:preferredName "Keys List"@en ;
+   samm:dataType :Key .
+
+:ProtocolInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "Protocol Information"@en ;
+   samm:dataType :ProtocolInformation .
+
+:Key a samm:Entity ;
+   samm:preferredName "Key"@en ;
+   samm:description "A single key entry within a reference."@en ;
+   samm:properties ( :type :value ) .
+
+:ProtocolInformation a samm:Entity ;
+   samm:preferredName "Protocol Information"@en ;
+   samm:description "Details for connecting to a submodel endpoint."@en ;
+   samm:properties ( :href :subprotocolBody ) .
+
+:value a samm:Property ;
+   samm:preferredName "Key Value"@en ;
+   samm:description "The value of the key, typically a URN to a semantic model."@en ;
+   samm:characteristic :String ;
+   samm:exampleValue "urn:samm:io.catenax.serial_part:4.0.0#SerialPart" .
+
+:href a samm:Property ;
+   samm:preferredName "Href"@en ;
+   samm:description "The URL of the submodel endpoint."@en ;
+   samm:characteristic :String ;
+   samm:exampleValue "https://edc.data.plane/api/public/urn%3Auuid%3A7effd7f4-6353-4401-9547-c54b420a22a0/submodel/$value" .
+
+:subprotocolBody a samm:Property ;
+   samm:preferredName "Subprotocol Body"@en ;
+   samm:description "Additional protocol details including the DSP endpoint and asset ID."@en ;
+   samm:characteristic :String ;
+   samm:exampleValue "dspEndpoint=https://edc.control.plane/api/v1/dsp;id=urn:uuid:1475f313-0a83-4e2b-b705-a100eebcb7d7" .
+

--- a/io.catenax.digital_twin_notification/1.0.0/DigitalTwinNotification.ttl
+++ b/io.catenax.digital_twin_notification/1.0.0/DigitalTwinNotification.ttl
@@ -1,3 +1,19 @@
+#######################################################################
+# Copyright (c) 2026 Robert Bosch GmbH
+# Copyright (c) 2026 Catena-X Automotive Network e.V.
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .


### PR DESCRIPTION
## Description
This pull request introduces a new aspect model definition for digital twin notifications in the `DigitalTwinNotification.ttl` file. The model describes the structure and semantics of notification payloads for Digital Twin Registry (DTR) operations, including message headers, EDC connection details, and Asset Administration Shell (AAS) descriptors.

Key additions and structure:

**Digital Twin Notification Model Definition:**

* Added a new `DigitalTwinNotification` aspect, providing a structured payload for DTR notifications, including both routing metadata and content referencing EDC endpoints and AAS shell descriptors.
* Defined the `content` property, which includes EDC asset and control plane information, as well as a list of shell descriptors.

**AAS Shell and Submodel Structure:**

* Introduced the `Shell` entity to represent AAS shell descriptors, including submodel descriptors and EDC dataplane endpoints.
* Added the `SubmodelDescriptor` entity, detailing semantic IDs and endpoint lists for each submodel.

**Endpoint and Protocol Details:**

* Defined `Endpoint` and `ProtocolInformation` entities to specify access endpoints and protocol-specific details for submodels, supporting flexible integration with EDC and DTR APIs.

**Supporting Types and Lists:**

* Introduced supporting list types 
Issue related: https://github.com/eclipse-tractusx/sldt-semantic-models/issues/966
Closes #

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] payload names and property identifiers must not contain two consecutive underscores ('__') at any position (e.g. `my__model` is not allowed)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] all external / imported models have the state "release"
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval