### PR TITLE
chore(migrate-action-version): migrate checkout version

### DIFF
--- a/.github/workflows/model-state-check.yml
+++ b/.github/workflows/model-state-check.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # vollständige Historie holen
       - name: Fetch main branch

--- a/.github/workflows/upload-single-model.yml
+++ b/.github/workflows/upload-single-model.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           echo "WORKSPACE_UPPERCASE=INT" >> $GITHUB_ENV
       - name: Checkout files
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: validate changes from PR
         uses: ./.github/actions/validate-single
         with:

--- a/io.catenax.shared.quantity/3.0.0/metadata.json
+++ b/io.catenax.shared.quantity/3.0.0/metadata.json
@@ -1,1 +1,1 @@
-{"status": "test_for_MS2_check"}
+{"status": "release"}

--- a/io.catenax.shared.quantity/3.0.0/metadata.json
+++ b/io.catenax.shared.quantity/3.0.0/metadata.json
@@ -1,1 +1,1 @@
-{"status": "release"}
+{"status": "test_for_MS2_check"}


### PR DESCRIPTION
## Description

This PR "migrates" the used version (without any upgrade) for checkout action to SHA. NO upgrade is done.
The SHA values can be found [here](https://github.com/actions/checkout/releases)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files