### PR TITLE
Added Steady links for serial part v4.0.0

### DIFF
--- a/io.catenax.shared.industry_core.common/1.0.0/Common.ttl
+++ b/io.catenax.shared.industry_core.common/1.0.0/Common.ttl
@@ -48,6 +48,7 @@
 :nameAtManufacturer a samm:Property ;
    samm:preferredName "name at manufacturer"@en ;
    samm:description "Name of the part as assigned by the manufacturer"@en ;
+   samm:see <https://rb-steady.bosch.tech/edg/tbl/prd_o_a02_core_ontology_v2.editor#prd-o-m-core-o:ProductAsRequired> ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Mirror left" .
 
@@ -72,6 +73,7 @@
 :customerPartId a samm:Property ;
    samm:preferredName "customer part identifier"@en ;
    samm:description "Part ID as assigned by the customer of the part. The customer Part ID identifies the part (as designed)in the customer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number or any other instance IDs. \nIf no specific part ID exists a part family ID may be substituted for it."@en ;
+   samm:see <https://rb-steady.bosch.tech/edg/tbl/prd_o_a02_core_ontology_v2.editor#prd-o-m-core-o:customerPartNumber> ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "PRT-12345" .
 
@@ -123,6 +125,7 @@
 :manufacturerPartId a samm:Property ;
    samm:preferredName "manufacturer part identifier"@en ;
    samm:description "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part (as designed) in the manufacturer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number or batch number."@en ;
+   samm:see <https://rb-steady.bosch.tech/edg/tbl/prd_o_a02_core_ontology_v2.editor#prd-core-o:partNumber> ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "123-0.740-3434-A" .
 
@@ -133,6 +136,7 @@
 
 :localIdentifiers a samm:Property ;
    samm:preferredName "local identifiers"@en ;
+   samm:see <https://rb-steady.bosch.tech/edg/tbl/prd_o_a02_core_ontology_v2.editor#prd-o-m-core-o:uniquePartID> ;
    samm:description "A local identifier enables identification of a part in a specific dataspace, but is not unique in the Catena-X dataspace. Multiple local identifiers may exist."@en ;
    samm:characteristic :LocalIdentifierCharacteristic .
 

--- a/io.catenax.shared.standard_codes/1.0.0/StandardCodes.ttl
+++ b/io.catenax.shared.standard_codes/1.0.0/StandardCodes.ttl
@@ -27,6 +27,7 @@
    samm:preferredName "country"@en ;
    samm:description "Alphabetic three-character (alpha-3) code representing a country name."@en ;
    samm:see <https://www.iso.org/iso-3166-country-codes.html> ;
+   samm:see <https://rb-steady.bosch.tech/edg/tbl/bosch_core_ontology_v1_2.editor#http://semantic.bosch.com/bosch-core-ontology-v1/CountryCode> ;
    samm:characteristic :CountryAlpha3Trait ;
    samm:exampleValue "DEU" .
 


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->
Added Steady links for some properties for Serial Part v4.0.0
 -->

Closes #

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] payload names and property identifiers must not contain two consecutive underscores ('__') at any position (e.g. `my__model` is not allowed)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] all external / imported models have the state "release"
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
