### PR TITLE
[new model: eSDScom]

### DIFF
--- a/io.catenax.esdscom/1.0.0/eSDScom.ttl
+++ b/io.catenax.esdscom/1.0.0/eSDScom.ttl
@@ -1,4 +1,20 @@
-@prefix :       <urn:samm:eSDScom.eu:5.6.0#> .
+#######################################################################
+# Copyright(c) 2026 Qualisys GmbH
+# Copyright(c) 2026 Volkswagen AG
+# Copyright(c) 2026 BASF Intertrade AG
+# Copyright(c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International(CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+@prefix :       <urn:samm:io.catenax.esdscom:1.0.0#> .
 @prefix samm:   <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
@@ -11,9 +27,10 @@
 # Aspect
 # ──────────────────────────────────────────────────────────────────────────
 
-:DatasheetFeed a samm:Aspect ;
+:Esdscom a samm:Aspect ;
     samm:preferredName "Datasheet Feed"@en ;
     samm:description "The SDScom root element"@en ;
+    samm:see <https://esdscom.eu/esdscom_5_6> ;
     samm:properties (
         :informationFromExportingSystem
         :datasheet
@@ -27,10 +44,12 @@
 
 :abilityToBecomeAirborne a samm:Property ;
     samm:preferredName "Ability To Become Airborne"@en ;
+    samm:description "Potential for release into air, e.g. dustiness or volatility; qualitative information."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :abioticDegradation a samm:Property ;
     samm:preferredName "Abiotic Degradation"@en ;
+    samm:description "Abiotic degradation by non-biological processes, e.g. hydrolysis, photolysis or oxidation; where applicable half-life time"@en ;
     samm:characteristic :DegradationEliminationList .
 
 :abntNrb2015HazardClassification a samm:Property ;
@@ -50,11 +69,14 @@
 
 :acCode a samm:Property ;
     samm:preferredName "Ac Code"@en ;
+    samm:description "REACH article category code (AC)."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "AC1"^^xsd:string ;
     samm:characteristic :ArticleCategoryCodeEnumCharacteristic .
 
 :acFulltext a samm:Property ;
     samm:preferredName "Ac Fulltext"@en ;
+    samm:description "full text REACH article category (AC)."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
@@ -66,38 +88,46 @@
 
 :acidNo a samm:Property ;
     samm:preferredName "Acid No"@en ;
-    samm:characteristic :PhysChemUnitValueList .
+    samm:description "acid number; unit typically mg KOH/g."@en ;
+    samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :acute a samm:Property ;
     samm:preferredName "Acute"@en ;
+    samm:description "Acute M-factor or acute assessment value; dimensionless, if M-factor."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
 :acuteAlgaeToxicity a samm:Property ;
     samm:preferredName "Acute Algae Toxicity"@en ;
+    samm:description "Acute toxicity to algae or aquatic plants; endpoint e.g. EC50, unit mg/L."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :EcotoxicityAquaticList .
 
 :acuteEarthwormToxicity a samm:Property ;
     samm:preferredName "Acute Earthworm Toxicity"@en ;
+    samm:description "Acute toxicity to earthworms; endpoint e.g. LC50, unit mg/kg soil."@en ;
     samm:characteristic :EcotoxicityList .
 
 :acuteFishToxicity a samm:Property ;
     samm:preferredName "Acute Fish Toxicity"@en ;
+    samm:description "Acute toxicity to fish; endpoint e.g. LC50, unit mg/L."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :EcotoxicityAquaticList .
 
 :acuteInvertebrateToxicity a samm:Property ;
     samm:preferredName "Acute Invertebrate Toxicity"@en ;
+    samm:description "Acute toxicity to aquatic invertebrates; endpoint e.g. EC50, unit mg/L."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :EcotoxicityAquaticList .
 
 :acutePlantToxicity a samm:Property ;
     samm:preferredName "Acute Plant Toxicity"@en ;
+    samm:description "Acute toxicity to terrestrial plants; unit typically mg/kg soil."@en ;
     samm:characteristic :EcotoxicityList .
 
 :acuteSubchronicBirdToxicity a samm:Property ;
     samm:preferredName "Acute Subchronic Bird Toxicity"@en ;
+    samm:description "Acute/subchronic toxicity to birds; endpoint and unit depend on the test method."@en ;
     samm:characteristic :EcotoxicityList .
 
 :acuteSymptomsAndEffects a samm:Property ;
@@ -108,29 +138,35 @@
 
 :acuteToxicity a samm:Property ;
     samm:preferredName "Acute Toxicity"@en ;
+    samm:description "Acute toxicity by oral, dermal or inhalation route; unit e.g. mg/kg or mg/L/4h."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :AcuteToxicityCharacteristic .
 
 :acuteToxicityHumanExperience a samm:Property ;
     samm:preferredName "Acute Toxicity Human Experience"@en ;
+    samm:description "Human experience on acute toxicity; qualitative or case-based information."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :additionalEcotoxInformation a samm:Property ;
     samm:preferredName "Additional Ecotox Information"@en ;
+    samm:description "Additional ecotoxicological parameters or assessments, beyond standard information."@en ;
     samm:characteristic :AdditionalEcotoxInformationCharacteristic .
 
 :additionalEyeProtectionMeasures a samm:Property ;
     samm:preferredName "Additional Eye Protection Measures"@en ;
+    samm:description "Additional eye protection measures, e.g. eye shower, face shield or splash protection."@en ;
     samm:characteristic :PhraseList .
 
 :additionalHandProtectionMeasures a samm:Property ;
     samm:preferredName "Additional Hand Protection Measures"@en ;
+    samm:description "Additional hand protection measures, e.g. skin protection plan, change intervals or cleaning."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :additionalInfo a samm:Property ;
     samm:preferredName "Additional Info"@en ;
+    samm:description "Additional identification or product information."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
@@ -142,29 +178,35 @@
 
 :additionalLabellingInfo a samm:Property ;
     samm:preferredName "Additional Labelling Info"@en ;
+    samm:description "Additional labelling information, e.g. special advice or supplemental information."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :additionalRespiratoryProtectionMeasures a samm:Property ;
     samm:preferredName "Additional Respiratory Protection Measures"@en ;
+    samm:description "Additional respiratory protection measures, e.g. ventilation, wear-time limitation or emergency equipment."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :additionalSkinProtectionMeasures a samm:Property ;
     samm:preferredName "Additional Skin Protection Measures"@en ;
+    samm:description "Additional skin protection measures, e.g. protective clothing, cleaning or skin protection products."@en ;
     samm:characteristic :PhraseList .
 
 :address a samm:Property ;
     samm:preferredName "Address"@en ;
+    samm:description "Address of the supplier, importer or contact person."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :AddressCharacteristic .
 
 :adn a samm:Property ;
     samm:preferredName "Adn"@en ;
+    samm:description "Transport information under ADN for inland waterway transport."@en ;
     samm:characteristic :AdnCharacteristic .
 
 :adrRid a samm:Property ;
     samm:preferredName "Adr Rid"@en ;
+    samm:description "Transport information under ADR/RID for road and rail."@en ;
     samm:characteristic :AdrRidCharacteristic .
 
 :aerosolLabelling a samm:Property ;
@@ -174,6 +216,7 @@
 
 :agpaPictogram a samm:Property ;
     samm:preferredName "Agpa Pictogram"@en ;
+    samm:description "Pictogram for good practice or safe use; coded symbol."@en ;
     samm:characteristic samm-c:Text .
 
 :airExchangeRate a samm:Property ;
@@ -183,14 +226,17 @@
 
 :airReactive a samm:Property ;
     samm:preferredName "Air Reactive"@en ;
+    samm:description "Indicates whether the substance or mixture reacts with air; yes/no or assessment."@en ;
     samm:characteristic :PhraseList .
 
 :anilinePoint a samm:Property ;
     samm:preferredName "Aniline Point"@en ;
+    samm:description "Aniline point; unit typically °C."@en ;
     samm:characteristic :PhysChemUnitValueList .
 
 :aoxAdsorbableOrganohalogens a samm:Property ;
     samm:preferredName "Aox Adsorbable Organohalogens"@en ;
+    samm:description "AOX, adsorbable organically bound halogens; unit typically mg/L or mg/kg."@en ;
     samm:characteristic :PhysChemUnitValueList .
 
 :appearance a samm:Property ;
@@ -201,41 +247,51 @@
 
 :appraisalPeriod a samm:Property ;
     samm:preferredName "Appraisal Period"@en ;
+    samm:description "Assessment period for short-term exposure limits; unit typically min or h."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :appropriateEngineeringControls a samm:Property ;
     samm:preferredName "Appropriate Engineering Controls"@en ;
+    samm:description "Engineering controls, e.g. closed systems, local exhaust ventilation or process ventilation."@en ;
     samm:characteristic :PhraseList .
 
 :appropriateEnvionmentalExposureControl a samm:Property ;
     samm:preferredName "Appropriate Envionmental Exposure Control"@en ;
+    samm:description "Suitable measures to limit environmental exposure, e.g. containment, wastewater treatment or emission reduction."@en ;
     samm:characteristic :AppropriateEnvionmentalExposureControlCharacteristic .
 
 :aquatic a samm:Property ;
     samm:preferredName "Aquatic"@en ;
+    samm:description "Information on unknown aquatic toxicity; typically expressed as % with explanatory text."@en ;
+    samm:exampleValue "3.14"^^xsd:float ;
     samm:characteristic :PercentageCharacteristic .
 
 :aquaticToxicity a samm:Property ;
     samm:preferredName "Aquatic Toxicity"@en ;
+    samm:description "Information on acute or chronic aquatic toxicity; unit typically mg/L."@en ;
     samm:characteristic :AquaticToxicityCharacteristic .
 
 :article a samm:Property ;
     samm:preferredName "Article"@en ;
+    samm:description "Specific protective article or equipment item; text or product designation."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ProtectionArticleList .
 
 :articleCategoryNoIntendedRelease a samm:Property ;
     samm:preferredName "Article Category No Intended Release"@en ;
+    samm:description "Article category without intended release; REACH use descriptor AC."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ArticleCategoryList .
 
 :articleCategoryWithIntendedRelease a samm:Property ;
     samm:preferredName "Article Category With Intended Release"@en ;
+    samm:description "Article category with intended release; REACH use descriptor."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ArticleCategoryList .
 
 :aspirationHazard a samm:Property ;
     samm:preferredName "Aspiration Hazard"@en ;
+    samm:description "Assessment of aspiration hazard under CLP/GHS."@en ;
     samm:characteristic :AspirationHazardCharacteristic .
 
 :aspirationHazardHydrocarbonContent a samm:Property ;
@@ -250,35 +306,44 @@
 
 :assessedLegislation a samm:Property ;
     samm:preferredName "Assessed Legislation"@en ;
+    samm:description "Assessed legislation or regulatory requirement."@en ;
     samm:characteristic :AssessmentCharacteristic .
 
 :assessedRegulations a samm:Property ;
     samm:preferredName "Assessed Regulations"@en ;
+    samm:description "Norway: Assessed national or regional regulations."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :assessmentAcuteToxicityClassification a samm:Property ;
     samm:preferredName "Assessment Acute Toxicity Classification"@en ;
+    samm:description "Assessment of classification for acute toxicity under CLP/GHS."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :assessmentAspirationHazardClassification a samm:Property ;
     samm:preferredName "Assessment Aspiration Hazard Classification"@en ;
+    samm:description "Classification assessment for aspiration hazard under CLP/GHS."@en ;
     samm:characteristic :PhraseList .
 
 :assessmentAssessmentEnum a samm:Property ;
     samm:preferredName "Assessment"@en ;
+    samm:description "Assessment result for a legal provision; coded value."@en ;
+    samm:exampleValue "Yes"^^xsd:string ;
     samm:characteristic :AssessmentEnumCharacteristic .
 
 :assessmentCarcinogenicityClassification a samm:Property ;
     samm:preferredName "Assessment Carcinogenicity Classification"@en ;
+    samm:description "Classification assessment for carcinogenicity under CLP/GHS."@en ;
     samm:characteristic :PhraseList .
 
 :assessmentCorrosionIrritationClassification a samm:Property ;
     samm:preferredName "Assessment Corrosion Irritation Classification"@en ;
+    samm:description "Assessment of classification for skin corrosion/skin irritation under CLP/GHS."@en ;
     samm:characteristic :PhraseList .
 
 :assessmentEyeDamageOrIrritationClassification a samm:Property ;
     samm:preferredName "Assessment Eye Damage Or Irritation Classification"@en ;
+    samm:description "Assessment of classification for eye damage/eye irritation under CLP/GHS."@en ;
     samm:characteristic :PhraseList .
 
 :assessmentFactor a samm:Property ;
@@ -288,38 +353,47 @@
 
 :assessmentFulltext a samm:Property ;
     samm:preferredName "Assessment Fulltext"@en ;
+    samm:description "full text assessment for a legal provision."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :assessmentGermCellMutagenicityClassification a samm:Property ;
     samm:preferredName "Assessment Germ Cell Mutagenicity Classification"@en ;
+    samm:description "Assessment of classification on germ cell mutagenicity under CLP/GHS."@en ;
     samm:characteristic :PhraseList .
 
 :assessmentOrClassification a samm:Property ;
     samm:preferredName "Assessment Or Classification"@en ;
+    samm:description "Assessment or classification eines Effekts or endpoints."@en ;
     samm:characteristic :PhraseList .
 
 :assessmentPhrase a samm:Property ;
     samm:preferredName "Assessment"@en ;
+    samm:description "Assessment result in text form."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :assessmentReproductiveToxicityClassification a samm:Property ;
     samm:preferredName "Assessment Reproductive Toxicity Classification"@en ;
+    samm:description "Assessment of classification for reproductive toxicity under CLP/GHS."@en ;
     samm:characteristic :PhraseList .
 
 :assessmentRespiratorySensitisationClassification a samm:Property ;
     samm:preferredName "Assessment Respiratory Sensitisation Classification"@en ;
+    samm:description "Assessment of classification for respiratory sensitisation under CLP/GHS."@en ;
     samm:characteristic :PhraseList .
 
 :assessmentSkinSensitisationClassification a samm:Property ;
     samm:preferredName "Assessment Skin Sensitisation Classification"@en ;
+    samm:description "Assessment of classification for skin sensitisation under CLP/GHS."@en ;
     samm:characteristic :PhraseList .
 
 :assessmentSpecificTargetOrganReClassification a samm:Property ;
     samm:preferredName "Assessment Specific Target Organ Re Classification"@en ;
+    samm:description "Classification assessment for STOT RE (specific target organ toxicity repeated exposure) under CLP/GHS."@en ;
     samm:characteristic :PhraseList .
 
 :assessmentSpecificTargetOrganSeClassification a samm:Property ;
     samm:preferredName "Assessment Specific Target Organ Se Classification"@en ;
+    samm:description "Classification assessment for STOT SE (specific target organ toxicity following single exposure) under CLP/GHS."@en ;
     samm:characteristic :PhraseList .
 
 :ate a samm:Property ;
@@ -329,6 +403,7 @@
 
 :atmosphericLifetime a samm:Property ;
     samm:preferredName "Atmospheric Lifetime"@en ;
+    samm:description "Atmospheric lifetime of a substance; unit typically hours (h), days (d) or years (a)."@en ;
     samm:characteristic :PhysChemUnitValueList .
 
 :authorisationNo a samm:Property ;
@@ -339,12 +414,14 @@
 
 :authorizationNo a samm:Property ;
     samm:preferredName "Authorization No"@en ;
+    samm:description "Authorisation number, e.g. for biocidal product or other regulatory authorisation."@en ;
     samm:characteristic samm-c:Text .
 
 :autoignitionTemperature a samm:Property ;
     samm:preferredName "Autoignition Temperature"@en ;
+    samm:description "auto-ignition temperature; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
-    samm:characteristic :PhysChemUnitValueList .
+    samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :bimschNumber a samm:Property ;
     samm:preferredName "Bimsch Number"@en ;
@@ -353,11 +430,13 @@
 
 :bioaccumulation a samm:Property ;
     samm:preferredName "Bioaccumulation"@en ;
+    samm:description "Information on accumulation in organisms, e.g. BCF, log Kow or bioaccumulation assessment."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :BioaccumulationCharacteristic .
 
 :bioaccumulationEvaluation a samm:Property ;
     samm:preferredName "Bioaccumulation Evaluation"@en ;
+    samm:description "Assessment of bioaccumulation potential based on available data, e.g. BCF or log Kow."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
@@ -373,11 +452,13 @@
 
 :bioconcentrationFactor a samm:Property ;
     samm:preferredName "Bioconcentration Factor"@en ;
+    samm:description "Bioconcentration factor (BCF); dimensionless or L/kg, depending on method and data."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :BioconcentrationFactorList .
 
 :biologicalDegradability a samm:Property ;
     samm:preferredName "Biological Degradability"@en ;
+    samm:description "Biodegradability by microorganisms; unit e.g. % degradation after a defined period (d)."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :BiologicalDegradationList .
 
@@ -393,41 +474,50 @@
 
 :birdReproductionToxicity a samm:Property ;
     samm:preferredName "Bird Reproduction Toxicity"@en ;
+    samm:description "Bird reproduction toxicity; endpoint and unit depend on the test method."@en ;
     samm:characteristic :EcotoxicityList .
 
 :bod5CodRatio a samm:Property ;
     samm:preferredName "Bod5Cod Ratio"@en ;
+    samm:description "BOD5/COD ratio as an indicator of biodegradability; dimensionless."@en ;
     samm:characteristic :PhysChemValueList .
 
 :boilingPoint a samm:Property ;
     samm:preferredName "Boiling Point"@en ;
+    samm:description "Boiling point or boiling range; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueList .
 
 :boilingPointRelated a samm:Property ;
     samm:preferredName "Boiling Point Related"@en ;
+    samm:description "Information on boiling point, boiling range or sublimation."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :BoilingPointRelatedCharacteristic .
 
 :bulkDensity a samm:Property ;
     samm:preferredName "Bulk Density"@en ;
+    samm:description "bulk density; unit typically kg/m³ or g/cm³."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueWithTemperatureList .
 
 :california a samm:Property ;
     samm:preferredName "California"@en ;
+    samm:description "US state of California disposal-related information; heading or text field."@en ;
     samm:characteristic :CaliforniaCharacteristic .
 
 :carcinogenicity a samm:Property ;
     samm:preferredName "Carcinogenicity"@en ;
+    samm:description "Information on carcinogenicity, including classification, tests or human data."@en ;
     samm:characteristic :CarcinogenicityCharacteristic .
 
 :carcinogenicityHumanExperience a samm:Property ;
     samm:preferredName "Carcinogenicity Human Experience"@en ;
+    samm:description "Human experience on carcinogenicity; qualitative or epidemiological information."@en ;
     samm:characteristic :PhraseList .
 
 :carcinogenicityTestResults a samm:Property ;
     samm:preferredName "Carcinogenicity Test Results"@en ;
+    samm:description "Test results on carcinogenicity; study, species and endpoint."@en ;
     samm:characteristic :CmrDataList .
 
 :casInventoryName a samm:Property ;
@@ -443,6 +533,7 @@
 
 :certainFluorinatedGreenhouseGases a samm:Property ;
     samm:preferredName "Certain Fluorinated Greenhouse Gases"@en ;
+    samm:description "Information on certain fluorinated greenhouse gases according to relevant EU rules."@en ;
     samm:characteristic :CertainFluorinatedGreenhouseGasesCharacteristic .
 
 :certification a samm:Property ;
@@ -462,6 +553,7 @@
 
 :chemicalSafetyAssessment a samm:Property ;
     samm:preferredName "Chemical Safety Assessment"@en ;
+    samm:description "Indicates whether a chemical safety assessment was performed; yes/no."@en ;
     samm:characteristic :PhraseList .
 
 :chemicalSafetyAssessmentCarriedOut a samm:Property ;
@@ -471,10 +563,12 @@
 
 :chemicalSafetyAssessmentInfo a samm:Property ;
     samm:preferredName "Chemical Safety Assessment Info"@en ;
+    samm:description "Information on the chemical safety assessment under REACH."@en ;
     samm:characteristic :ChemicalSafetyAssessmentInfoCharacteristic .
 
 :chemicalSafetyReport a samm:Property ;
     samm:preferredName "Chemical Safety Report"@en ;
+    samm:description "Information on the chemical safety report (CSR), if required or available."@en ;
     samm:characteristic :ChemicalSafetyReportCharacteristic .
 
 :childResistantOpening a samm:Property ;
@@ -484,86 +578,109 @@
 
 :chronic a samm:Property ;
     samm:preferredName "Chronic"@en ;
+    samm:description "Chronic M-factor or chronic assessment value; dimensionless, if M-factor."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
 :chronicAlgaeToxicity a samm:Property ;
     samm:preferredName "Chronic Algae Toxicity"@en ;
+    samm:description "Chronic toxicity to algae or aquatic plants; endpoint e.g. NOEC/EC10, unit mg/L."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :EcotoxicityAquaticList .
 
 :chronicEarthwormToxicity a samm:Property ;
     samm:preferredName "Chronic Earthworm Toxicity"@en ;
+    samm:description "Chronic toxicity to earthworms; endpoint e.g. NOEC, unit mg/kg soil."@en ;
     samm:characteristic :EcotoxicityList .
 
 :chronicFishToxicity a samm:Property ;
     samm:preferredName "Chronic Fish Toxicity"@en ;
+    samm:description "Chronic toxicity to fish; endpoint e.g. NOEC/EC10, unit mg/L."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :EcotoxicityAquaticList .
 
 :chronicInvertebrateToxicity a samm:Property ;
     samm:preferredName "Chronic Invertebrate Toxicity"@en ;
+    samm:description "Chronic toxicity to aquatic invertebrates; endpoint e.g. NOEC/EC10, unit mg/L."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :EcotoxicityAquaticList .
 
 :chronicPlantToxicity a samm:Property ;
     samm:preferredName "Chronic Plant Toxicity"@en ;
+    samm:description "Chronic toxicity to terrestrial plants; endpoint e.g. NOEC/EC10, unit mg/kg soil."@en ;
     samm:characteristic :EcotoxicityList .
 
 :classCode a samm:Property ;
     samm:preferredName "Class Code"@en ;
-    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:description "Transport hazard class or classification code; coded value."@en ;
     samm:characteristic samm-c:Text .
 
 :classOrClasses a samm:Property ;
     samm:preferredName "Class Or Classes"@en ;
+    samm:description "Class or classes under national regulation, e.g. TA Luft."@en ;
     samm:characteristic :PhraseList .
 
 :classTransportClassEnum a samm:Property ;
     samm:preferredName "Class"@en ;
     samm:description "IMDG hazard class: The chemical’s most important transport hazard class."@en ;
+    samm:exampleValue "1"^^xsd:string ;
     samm:characteristic :TransportClassEnumCharacteristic .
 
 :classWaterHazardClassEnum a samm:Property ;
     samm:preferredName "Class"@en ;
     samm:description "Water hazard class (WGK):"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "1"^^xsd:string ;
     samm:characteristic :WaterHazardClassEnumCharacteristic .
 
 :classification a samm:Property ;
     samm:preferredName "Classification"@en ;
+    samm:description "Hazard classification according to the applicable classification system; coded value or phrase."@en ;
     samm:characteristic :ClassificationList .
 
 :classificationAssessment a samm:Property ;
     samm:preferredName "Classification Assessment"@en ;
+    samm:description "Classification assessment for the relevant toxicological endpoint."@en ;
     samm:characteristic :ClassificationAssessmentCharacteristic .
 
 :classificationClassificationAr a samm:Property ;
     samm:preferredName "Classification"@en ;
+    samm:description "Classification according to the rules specified for Argentina GHS/SDS rules."@en ;
     samm:characteristic :ClassificationArCharacteristic .
 
 :classificationClassificationBr a samm:Property ;
     samm:preferredName "Classification"@en ;
+    samm:description "Classification according to the rules specified for Brazil GHS/SDS rules."@en ;
     samm:characteristic :ClassificationBrCharacteristic .
 
 :classificationClassificationCa a samm:Property ;
     samm:preferredName "Classification"@en ;
+    samm:description "Classification in the Canadian WHMIS/GHS context."@en ;
     samm:characteristic :ClassificationCaCharacteristic .
+
+:classificationClassificationCn a samm:Property ;
+    samm:preferredName "Classification"@en ;
+    samm:description "Classification according to the rules specified for China GHS/SDS rules."@en ;
+    samm:characteristic :ClassificationCnCharacteristic .
 
 :classificationClassificationGb a samm:Property ;
     samm:preferredName "Classification"@en ;
+    samm:description "Classification according to UK CLP or the British CLP regulation."@en ;
     samm:characteristic :ClassificationGbCharacteristic .
 
 :classificationClassificationMx a samm:Property ;
     samm:preferredName "Classification"@en ;
+    samm:description "Classification according to the rules specified for Mexico GHS/SDS rules."@en ;
     samm:characteristic :ClassificationMxCharacteristic .
 
 :classificationClassificationTr a samm:Property ;
     samm:preferredName "Classification"@en ;
+    samm:description "Classification according to the GHS/SDS rules specified for Turkey."@en ;
     samm:characteristic :ClassificationTrCharacteristic .
 
 :classificationClassificationUs a samm:Property ;
     samm:preferredName "Classification"@en ;
+    samm:description "Classification according to US-HazCom/GHS-Kontext."@en ;
     samm:characteristic :ClassificationUsCharacteristic .
 
 :classificationNotes a samm:Property ;
@@ -574,6 +691,7 @@
 
 :classificationPhrase a samm:Property ;
     samm:preferredName "Classification"@en ;
+    samm:description "Classification in text form according to applicable classification system."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :classificationProcedure a samm:Property ;
@@ -588,16 +706,19 @@
 
 :cloudPoint a samm:Property ;
     samm:preferredName "Cloud Point"@en ;
+    samm:description "Cloud point; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueList .
 
 :code a samm:Property ;
     samm:preferredName "Code"@en ;
+    samm:description "code of a category, rule or classification; meaning from context."@en ;
     samm:characteristic samm-c:Text .
 
 :colour a samm:Property ;
     samm:preferredName "Colour"@en ;
     samm:description "Multiple entries (only) in case of \"multicolour\" and \"colouring agent\""@en ;
+    samm:exampleValue "colourless"^^xsd:string ;
     samm:characteristic :ColourEnumCharacteristic .
 
 :colourDescription a samm:Property ;
@@ -608,10 +729,13 @@
 
 :colourIntensity a samm:Property ;
     samm:preferredName "Colour Intensity"@en ;
+    samm:description "Colour intensity of the product; qualitative information."@en ;
+    samm:exampleValue "translucent"^^xsd:string ;
     samm:characteristic :ColourIntensityEnumCharacteristic .
 
 :colourIntensityDescription a samm:Property ;
     samm:preferredName "Colour Intensity Description"@en ;
+    samm:description "Description of colour intensity or colour characteristic."@en ;
     samm:characteristic :PhraseList .
 
 :companyContact a samm:Property ;
@@ -633,6 +757,7 @@
 
 :composition a samm:Property ;
     samm:preferredName "Composition"@en ;
+    samm:description "Composition or information on ingredients of a substance or mixture, including relevant hazardous constituents."@en ;
     samm:characteristic :CompositionCharacteristic .
 
 :compositionInformation a samm:Property ;
@@ -660,10 +785,12 @@
 
 :consumerExposureControl a samm:Property ;
     samm:preferredName "Consumer Exposure Control"@en ;
+    samm:description "Measures to limit consumer exposure during use or service life of articles."@en ;
     samm:characteristic :ConsumerExposureControlCharacteristic .
 
 :consumerUse a samm:Property ;
     samm:preferredName "Consumer Use"@en ;
+    samm:description "Indicates whether consumer use is intended; yes/no or description."@en ;
     samm:characteristic samm-c:Boolean .
 
 :containment a samm:Property ;
@@ -673,6 +800,7 @@
 
 :containmentAndCleaningUp a samm:Property ;
     samm:preferredName "Containment And Cleaning Up"@en ;
+    samm:description "Methods and materials for containment and cleaning up for leaks or releases; where applicable different measures depending on release quantity."@en ;
     samm:characteristic :ContainmentAndCleaningUpCharacteristic .
 
 :contentOfVoc a samm:Property ;
@@ -688,54 +816,65 @@
 
 :controlApproach a samm:Property ;
     samm:preferredName "Control Approach"@en ;
+    samm:description "Intended control approach, e.g. general ventilation, local exhaust or closed installation."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :controlParameters a samm:Property ;
     samm:preferredName "Control Parameters"@en ;
+    samm:description "Exposure limits and control parameters, e.g. occupational exposure limits, DNEL, DMEL or PNEC."@en ;
     samm:characteristic :ControlParametersCharacteristic .
 
 :correspondingExposureScenario a samm:Property ;
     samm:preferredName "Corresponding Exposure Scenario"@en ;
+    samm:description "Corresponding exposure scenario for the identified use."@en ;
     samm:characteristic :CorrespondingExposureScenarioList .
 
 :corrosiveToMetals a samm:Property ;
     samm:preferredName "Corrosive To Metals"@en ;
+    samm:description "Assessment of corrosivity to metals according to CLP/GHS; category or test result."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :CorrosiveToMetalsCharacteristic .
 
 :corrosivity a samm:Property ;
     samm:preferredName "Corrosivity"@en ;
+    samm:description "Information on corrosivity; category, assessment or Testergebnis."@en ;
     samm:characteristic :PhraseList .
 
 :country a samm:Property ;
     samm:preferredName "Country"@en ;
-    samm:description "This country informaion applies to all addresses and contacts and LegalRegistrationNumber within SupplierInformation."@en ;
+    samm:description "Country code or country of the language/text context; code or name."@en ;
+    samm:exampleValue "AD"^^xsd:string ;
     samm:characteristic :CountryCodeEnumCharacteristic .
 
-:cpid a samm:Property ;
-    samm:preferredName "Cpid"@en ;
+:cpId a samm:Property ;
+    samm:preferredName "Cp Id"@en ;
     samm:description "The product registration number for Swiss FOPH. Part of section 15 of SDS"@en ;
     samm:characteristic samm-c:Text .
 
 :criticalPressure a samm:Property ;
     samm:preferredName "Critical Pressure"@en ;
+    samm:description "Critical pressure; unit typically MPa, kPa or bar."@en ;
     samm:characteristic :PhysChemUnitValueWithTemperatureList .
 
 :crystallisationPoint a samm:Property ;
     samm:preferredName "Crystallisation Point"@en ;
+    samm:description "Crystallisation point; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueList .
 
 :csrLocation a samm:Property ;
     samm:preferredName "Csr Location"@en ;
+    samm:description "Location or storage place of the chemical safety report."@en ;
     samm:characteristic :PhraseList .
 
 :csrRequired a samm:Property ;
     samm:preferredName "Csr Required"@en ;
+    samm:description "Indicates whether a chemical safety report is required; yes/no."@en ;
     samm:characteristic samm-c:Boolean .
 
 :dangerReleasingSubstance a samm:Property ;
     samm:preferredName "Danger Releasing Substance"@en ;
+    samm:description "Hazard-releasing substance in the Transportkontext; name or identifier."@en ;
     samm:characteristic :PhraseList .
 
 :dangerReleasingSubstanceEnglish a samm:Property ;
@@ -758,12 +897,14 @@
     samm:preferredName "Date Generated Export"@en ;
     samm:description "Date of generation of this export file"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "2026-07-20"^^xsd:date ;
     samm:characteristic :DateCharacteristic .
 
 :decompositionTemperature a samm:Property ;
     samm:preferredName "Decomposition Temperature"@en ;
+    samm:description "Decomposition temperature or SADT; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
-    samm:characteristic :PhysChemUnitValueList .
+    samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :degradationRate a samm:Property ;
     samm:preferredName "Degradation Rate"@en ;
@@ -779,20 +920,24 @@
 
 :delimiter a samm:Property ;
     samm:preferredName "Delimiter"@en ;
+    samm:description "Delimiter for composite phrases."@en ;
     samm:characteristic samm-c:Text .
 
 :densities a samm:Property ;
     samm:preferredName "Densities"@en ;
+    samm:description "Density data, e.g. density, relative density or bulk density."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :DensitiesCharacteristic .
 
 :density a samm:Property ;
     samm:preferredName "Density"@en ;
+    samm:description "density; unit typically g/cm³ or kg/m³."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueWithTemperatureList .
 
 :derivedMinimalEffectLevel a samm:Property ;
     samm:preferredName "Derived Minimal Effect Level"@en ;
+    samm:description "DMEL data for exposure routes, where no safe threshold can be derived."@en ;
     samm:characteristic :DmelList .
 
 :derivedNoEffectLevel a samm:Property ;
@@ -802,6 +947,8 @@
 
 :dermal a samm:Property ;
     samm:preferredName "Dermal"@en ;
+    samm:description "Information on dermal exposure or toxicity; typically expressed as % with explanatory text where applicable."@en ;
+    samm:exampleValue "3.14"^^xsd:float ;
     samm:characteristic :PercentageCharacteristic .
 
 :description a samm:Property ;
@@ -811,11 +958,13 @@
 
 :descriptionOfFirstAidMeasures a samm:Property ;
     samm:preferredName "Description Of First Aid Measures"@en ;
+    samm:description "Description of first aid measures, understandable also for untrained first responders."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :DescriptionOfFirstAidMeasuresCharacteristic .
 
 :detergentInformation a samm:Property ;
     samm:preferredName "Detergent Information"@en ;
+    samm:description "Information under detergent legislation, e.g. ingredients or labelling."@en ;
     samm:characteristic :PhraseList .
 
 :detergentLabelling a samm:Property ;
@@ -842,6 +991,7 @@
 
 :dissociationConstant a samm:Property ;
     samm:preferredName "Dissociation Constant"@en ;
+    samm:description "Dissociation constant pKa or Ka; dimensionless or dependent on representation."@en ;
     samm:characteristic :DissociationConstantList .
 
 :dissolvedOrganicCarbon a samm:Property ;
@@ -851,34 +1001,41 @@
 
 :distribution a samm:Property ;
     samm:preferredName "Distribution"@en ;
+    samm:description "Distribution in environmental compartments or media; information e.g. soil, water, air, sediment."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :distributionStoppedDate a samm:Property ;
     samm:preferredName "Distribution Stopped Date"@en ;
     samm:description "Date when manufacturer stopped distribution. See also ProductDiscontinuedFromMarket."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "2026-07-20"^^xsd:date ;
     samm:characteristic :DateCharacteristic .
 
 :division a samm:Property ;
     samm:preferredName "Division"@en ;
+    samm:description "Subclass/division under dangerous goods law, e.g. 1.1 or 2.1."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
 :dmelValue a samm:Property ;
     samm:preferredName "Dmel Value"@en ;
+    samm:description "Derived Minimal Effect Level (DMEL); unit depends on exposure route and population."@en ;
     samm:characteristic :NumericValueWithUnitCharacteristic .
 
 :dnelValue a samm:Property ;
     samm:preferredName "Dnel Value"@en ;
+    samm:description "Derived No-Effect Level (DNEL); unit depends on exposure route and population."@en ;
     samm:characteristic :NumericValueWithUnitCharacteristic .
 
 :dose a samm:Property ;
     samm:preferredName "Dose"@en ;
+    samm:description "dose in the toxicological test; unit e.g. mg/kg KG or mg/L."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :DoseCharacteristic .
 
 :droppingPoint a samm:Property ;
     samm:preferredName "Dropping Point"@en ;
+    samm:description "Dropping point; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueList .
 
@@ -889,39 +1046,47 @@
 
 :ecNo a samm:Property ;
     samm:preferredName "Ec No"@en ;
+    samm:description "EC number of the substance according to EU inventories; coded value."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
 :ecologicalInformationEcologicalInformation a samm:Property ;
     samm:preferredName "Ecological Information"@en ;
+    samm:description "Ecological information zu ecotoxicity, persistence, degradability, bioaccumulation, mobility and other effects."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :EcologicalInformationCharacteristic .
 
 :ecotoxicologicalInformation a samm:Property ;
     samm:preferredName "Ecotoxicological Information"@en ;
+    samm:description "Information on environmental toxicity to aquatic, sediment or soil organisms."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :EcotoxicologicalInformationCharacteristic .
 
 :ecotoxicologyOverallEvaluation a samm:Property ;
     samm:preferredName "Ecotoxicology Overall Evaluation"@en ;
+    samm:description "Overall assessment of ecotoxicological properties and relevance for environmental hazards."@en ;
     samm:characteristic :PhraseList .
 
 :editingDate a samm:Property ;
     samm:preferredName "Editing Date"@en ;
     samm:description "If the exporting system is the SDS authoring system, the value of EditingDate should be omitted or be equal to RevisionDate. If the export is prepared by another system, e.g. from a service provider, the EditingDate is the status of data entry of the SDS and is equal to or larger than RevisionDate."@en ;
+    samm:exampleValue "2026-07-20"^^xsd:date ;
     samm:characteristic :DateCharacteristic .
 
 :effectDoseConcentration a samm:Property ;
     samm:preferredName "Effect Dose Concentration"@en ;
+    samm:description "Effect dose or effect concentration of a test; unit depends on the endpoint, e.g. mg/L or mg/kg."@en ;
     samm:characteristic :DoseCharacteristic .
 
 :effectTested a samm:Property ;
     samm:preferredName "Effect Tested"@en ;
+    samm:description "Tested toxicological effect or endpoint."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :DoseCharacteristic .
 
 :effectValue a samm:Property ;
     samm:preferredName "Effect Value"@en ;
+    samm:description "Effect value of a toxicological test; unit depends on the endpoint."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :effectsOfMisuse a samm:Property ;
@@ -932,7 +1097,8 @@
 
 :electricConductivity a samm:Property ;
     samm:preferredName "Electric Conductivity"@en ;
-    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+    samm:description "Electrical conductivity; unit typically S/m, mS/cm or µS/cm."@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureCharacteristic .
 
 :email a samm:Property ;
     samm:preferredName "Email"@en ;
@@ -942,6 +1108,7 @@
 
 :emailCompetentPerson a samm:Property ;
     samm:preferredName "Email Competent Person"@en ;
+    samm:description "Email address of the competent person responsible for the safety data sheet."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
@@ -959,23 +1126,28 @@
 
 :emergencyProcedures a samm:Property ;
     samm:preferredName "Emergency Procedures"@en ;
+    samm:description "Emergency procedures for release, e.g. evacuate the hazard area, remove ignition sources, consult experts."@en ;
     samm:characteristic :PhraseList .
 
 :emsCode a samm:Property ;
     samm:preferredName "Ems Code"@en ;
+    samm:description "EmS code under the IMDG code for emergency measures at sea; coded value."@en ;
     samm:characteristic samm-c:Text .
 
 :endocrineDisruptingPotential a samm:Property ;
     samm:preferredName "Endocrine Disrupting Potential"@en ;
+    samm:description "Assessment of potential endocrine-disrupting properties for humans or the environment."@en ;
     samm:characteristic :PhysChemUnitValueList .
 
 :endocrineDisruption a samm:Property ;
     samm:preferredName "Endocrine Disruption"@en ;
+    samm:description "Information on endocrine-disrupting properties for humans or the environment."@en ;
     samm:characteristic :PhraseList .
 
 :environmantalHazardThreshold a samm:Property ;
     samm:preferredName "Environmantal Hazard Threshold"@en ;
     samm:description "in kg"@en ;
+    samm:exampleValue "42"^^xsd:integer ;
     samm:characteristic :IntegerCharacteristic .
 
 :environmentalEffect a samm:Property ;
@@ -986,14 +1158,17 @@
 
 :environmentalExposureControls a samm:Property ;
     samm:preferredName "Environmental Exposure Controls"@en ;
+    samm:description "Environmental exposure controls and risk management measures for emissions to air, water or soil."@en ;
     samm:characteristic :PhraseList .
 
 :environmentalHazardsSevesoEntryDe a samm:Property ;
     samm:preferredName "Environmental Hazards"@en ;
+    samm:description "German major accident entry for environmental hazards; category or quantity thresholds."@en ;
     samm:characteristic :SevesoEntryDeCharacteristic .
 
 :environmentalHazardsSevesoEntryEu a samm:Property ;
     samm:preferredName "Environmental Hazards"@en ;
+    samm:description "EU Seveso entry for environmental hazards; category or thresholds."@en ;
     samm:characteristic :SevesoEntryEuCharacteristic .
 
 :environmentalPrecautions a samm:Property ;
@@ -1009,25 +1184,31 @@
 
 :eoxExtractableOrganohalogens a samm:Property ;
     samm:preferredName "Eox Extractable Organohalogens"@en ;
+    samm:description "EOX, extractable organically bound halogens; unit typically mg/kg."@en ;
     samm:characteristic :PhysChemUnitValueList .
 
 :equipment a samm:Property ;
     samm:preferredName "Equipment"@en ;
+    samm:description "Equipment or protective article for the described protection or application purpose."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :EquipmentList .
 
 :equipmentForSelfRescue a samm:Property ;
     samm:preferredName "Equipment For Self Rescue"@en ;
+    samm:description "self-rescue equipment for emergencies, e.g. escape filter or respiratory hood."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :ercCode a samm:Property ;
     samm:preferredName "Erc Code"@en ;
+    samm:description "REACH ERC code for environmental release category."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "ERC1"^^xsd:string ;
     samm:characteristic :EnvironmentalReleaseCategoryCodeEnumCharacteristic .
 
 :ercFulltext a samm:Property ;
     samm:preferredName "Erc Fulltext"@en ;
+    samm:description "full text environmental release category (ERC)."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
@@ -1038,6 +1219,7 @@
 
 :euAuthorisation a samm:Property ;
     samm:preferredName "Eu Authorisation"@en ;
+    samm:description "EU authorisation status or authorisation requirement, e.g. REACH Annex XIV."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
@@ -1049,10 +1231,12 @@
 
 :euRestrictionsOfOccupation a samm:Property ;
     samm:preferredName "Eu Restrictions Of Occupation"@en ;
+    samm:description "EU employment restrictions or occupational safety requirements."@en ;
     samm:characteristic :PhraseList .
 
 :euRestrictionsOnUse a samm:Property ;
     samm:preferredName "Eu Restrictions On Use"@en ;
+    samm:description "EU use restrictions, e.g. REACH Annex XVII."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
@@ -1064,11 +1248,14 @@
 
 :eupcsCode a samm:Property ;
     samm:preferredName "Eupcs Code"@en ;
+    samm:description "EuPCS code for product category under Annex VIII CLP; coded value."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "F"^^xsd:string ;
     samm:characteristic :EupcsCategoryCodeEnumCharacteristic .
 
 :eupcsFulltext a samm:Property ;
     samm:preferredName "Eupcs Fulltext"@en ;
+    samm:description "full text product category for the EuPCS code."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
@@ -1080,15 +1267,19 @@
 
 :evaluationGasGroupEnum a samm:Property ;
     samm:preferredName "Evaluation"@en ;
+    samm:description "Assessment or classification of the gas group; coded value."@en ;
+    samm:exampleValue "IIA"^^xsd:string ;
     samm:characteristic :GasGroupEnumCharacteristic .
 
 :evaluationPhrase a samm:Property ;
     samm:preferredName "Evaluation"@en ;
+    samm:description "Assessment or interpretation of a test result in textform."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :evaporationRate a samm:Property ;
     samm:preferredName "Evaporation Rate"@en ;
+    samm:description "Evaporation rate; dimensionless relativ zu Referenz or unit according to method."@en ;
     samm:characteristic :PhysChemValueWithTemperatureList .
 
 :ewlPacking a samm:Property ;
@@ -1105,37 +1296,47 @@
 
 :exactValue a samm:Property ;
     samm:preferredName "Exact Value"@en ;
+    samm:description "Exact numeric value of the package size or quantity; unit in the associated field."@en ;
+    samm:exampleValue "3.14"^^xsd:float ;
     samm:characteristic :FloatCharacteristic .
 
 :exactValueSymbol a samm:Property ;
     samm:preferredName "Exact Value Symbol"@en ;
+    samm:description "Comparison sign or symbol for the exact value, e.g. =, ca., < or >."@en ;
+    samm:exampleValue "eq"^^xsd:string ;
     samm:characteristic :ExactQualifierEnumCharacteristic .
 
 :exceptedQty a samm:Property ;
     samm:preferredName "Excepted Qty"@en ;
+    samm:description "Excepted quantity under dangerous goods regulations; coded or quantity value."@en ;
     samm:characteristic samm-c:Text .
 
 :expansionCoefficient a samm:Property ;
     samm:preferredName "Expansion Coefficient"@en ;
+    samm:description "Expansion coefficient; unit depending on the material, e.g. 1/K."@en ;
     samm:characteristic :PhysChemUnitValueWithTemperatureList .
 
 :explosionLimit a samm:Property ;
     samm:preferredName "Explosion Limit"@en ;
+    samm:description "Explosion/flammability limits; unit typically vol.-%."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ExplosionLimitCharacteristic .
 
 :explosiveProperties a samm:Property ;
     samm:preferredName "Explosive Properties"@en ;
+    samm:description "Explosive properties; qualitative assessment or test result."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :explosives a samm:Property ;
     samm:preferredName "Explosives"@en ;
+    samm:description "Assessment of explosive properties or classification as explosive substance/mixture."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ExplosivesCharacteristic .
 
 :exposureControlAppropriateMeasures a samm:Property ;
     samm:preferredName "Exposure Control Appropriate Measures"@en ;
+    samm:description "Suitable engineering, organisational and personal measures to reduce exposure."@en ;
     samm:characteristic :ExposureControlAppropriateMeasuresCharacteristic .
 
 :exposureControlPersonalProtectionExposureControlPersonalProtection a samm:Property ;
@@ -1146,18 +1347,22 @@
 
 :exposureControlsPersonalProtectionAdditionalInfo a samm:Property ;
     samm:preferredName "Exposure Controls Personal Protection Additional Info"@en ;
+    samm:description "Additional information on exposure controls and personal protective equipment."@en ;
     samm:characteristic :PhraseList .
 
 :exposureFrequency a samm:Property ;
     samm:preferredName "Exposure Frequency"@en ;
+    samm:description "Frequency of exposure; unit or category depends on the test."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :exposureGroup a samm:Property ;
     samm:preferredName "Exposure Group"@en ;
+    samm:description "Exposure group for DNEL/DMEL, e.g. workers, consumers or general population."@en ;
     samm:characteristic :ExposureGroupCharacteristic .
 
 :exposureRouteExposureRoute a samm:Property ;
     samm:preferredName "Exposure Route"@en ;
+    samm:description "Route of exposure in the toxicological test, e.g. oral, dermal or inhalation."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ExposureRouteCharacteristic .
 
@@ -1173,6 +1378,7 @@
 
 :exposureScenario a samm:Property ;
     samm:preferredName "Exposure Scenario"@en ;
+    samm:description "Exposure scenario or reference to it; describes uses, conditions and RMM."@en ;
     samm:characteristic :ExposureScenarioCharacteristic .
 
 :exposureScenarioIdentificationString a samm:Property ;
@@ -1182,10 +1388,12 @@
 
 :exposureScenarioName a samm:Property ;
     samm:preferredName "Exposure Scenario Name"@en ;
+    samm:description "name of the exposure scenario."@en ;
     samm:characteristic samm-c:Text .
 
 :exposureTime a samm:Property ;
     samm:preferredName "Exposure Time"@en ;
+    samm:description "Exposure duration in the test or scenario; unit typically min, h or d."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
@@ -1196,36 +1404,44 @@
 
 :extinguishingMedia a samm:Property ;
     samm:preferredName "Extinguishing Media"@en ;
+    samm:description "Suitable and unsuitable extinguishing media for fires involving or near the product."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ExtinguishingMediaCharacteristic .
 
 :eyeCorrosivity a samm:Property ;
     samm:preferredName "Eye Corrosivity"@en ;
+    samm:description "Information on corrosive effects on the eye or serious eye damage."@en ;
     samm:characteristic :PhraseList .
 
 :eyeDamageOrIrritation a samm:Property ;
     samm:preferredName "Eye Damage Or Irritation"@en ;
+    samm:description "Information on serious eye damage or eye irritation."@en ;
     samm:characteristic :EyeDamageOrIrritationCharacteristic .
 
 :eyeDamageOrIrritationHumanExperience a samm:Property ;
     samm:preferredName "Eye Damage Or Irritation Human Experience"@en ;
+    samm:description "Human experience on eye damage or irritation."@en ;
     samm:characteristic :PhraseList .
 
 :eyeDamageOrIrritationTestResults a samm:Property ;
     samm:preferredName "Eye Damage Or Irritation Test Results"@en ;
+    samm:description "test results on eye damage or eye irritation."@en ;
     samm:characteristic :CorrosionIrritationDataList .
 
 :eyeIrritation a samm:Property ;
     samm:preferredName "Eye Irritation"@en ;
+    samm:description "Information on eye irritation, e.g. category, test or result."@en ;
     samm:characteristic :PhraseList .
 
 :eyeProtection a samm:Property ;
     samm:preferredName "Eye Protection"@en ;
+    samm:description "eye/face protection measures to prevent contact with eyes or face."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :EyeProtectionCharacteristic .
 
 :eyeProtectionEquipment a samm:Property ;
     samm:preferredName "Eye Protection Equipment"@en ;
+    samm:description "Specific eye protection equipment, e.g. safety glasses, goggles or face shield."@en ;
     samm:characteristic :ProtectionArticleList .
 
 :fax a samm:Property ;
@@ -1236,6 +1452,7 @@
 
 :federal a samm:Property ;
     samm:preferredName "Federal"@en ;
+    samm:description "US federal disposal-related information; coded or textual value."@en ;
     samm:characteristic :FederalCharacteristic .
 
 :fileName a samm:Property ;
@@ -1245,6 +1462,7 @@
 
 :filterApparatusType a samm:Property ;
     samm:preferredName "Filter Apparatus Type"@en ;
+    samm:description "Filter device type for respiratory protection, e.g. half mask, full face mask or powered air-purifying respirator."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
@@ -1256,6 +1474,7 @@
 
 :fireFightingMeasures a samm:Property ;
     samm:preferredName "Fire Fighting Measures"@en ;
+    samm:description "Requirements and advice for firefighting for the substance or mixture."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :FireFightingMeasuresCharacteristic .
 
@@ -1289,6 +1508,7 @@
 
 :firstAidMeasures a samm:Property ;
     samm:preferredName "First Aid Measures"@en ;
+    samm:description "First aid measures according to Exposition; structured by route of exposure and urgency."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :FirstAidMeasuresCharacteristic .
 
@@ -1306,31 +1526,37 @@
 
 :flammableAerosols a samm:Property ;
     samm:preferredName "Flammable Aerosols"@en ;
+    samm:description "Classification or assessment of flammable aerosols under CLP/GHS."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :FlammableAerosolsCharacteristic .
 
 :flammableGases a samm:Property ;
     samm:preferredName "Flammable Gases"@en ;
+    samm:description "Classification or assessment of flammable gases under CLP/GHS."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :FlammableGasesCharacteristic .
 
 :flammableLiquids a samm:Property ;
     samm:preferredName "Flammable Liquids"@en ;
+    samm:description "Classification or assessment of flammable liquids; including flash point and boiling point."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :FlammableLiquidsCharacteristic .
 
 :flammableSolids a samm:Property ;
     samm:preferredName "Flammable Solids"@en ;
+    samm:description "Classification or assessment of flammable solids under CLP/GHS."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :FlammableSolidsCharacteristic .
 
 :flashPoint a samm:Property ;
     samm:preferredName "Flash Point"@en ;
+    samm:description "Flash point determined by the relevant method; typically expressed in °C."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
-    samm:characteristic :FlashPointList .
+    samm:characteristic :FlashPointCharacteristic .
 
 :fluorinatedGreenhouseGasesMethod a samm:Property ;
     samm:preferredName "Fluorinated Greenhouse Gases Method"@en ;
+    samm:description "Method for determining or assessing fluorinated greenhouse gases."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :forEmergencyResponders a samm:Property ;
@@ -1340,10 +1566,13 @@
 
 :forNonEmergencyPersonnel a samm:Property ;
     samm:preferredName "For Non Emergency Personnel"@en ;
+    samm:description "Advice for non-emergency personnel during accidental release, e.g. distance, ventilation, personal protection equipment (PPE) and evacuation."@en ;
     samm:characteristic :ForNonEmergencyPersonnelCharacteristic .
 
 :form a samm:Property ;
     samm:preferredName "Form"@en ;
+    samm:description "form or appearance of the product, e.g. powder, granulate, liquid or paste."@en ;
+    samm:exampleValue "aerosol dispenser: not specified"^^xsd:string ;
     samm:characteristic :FormEnumCharacteristic .
 
 :formDescription a samm:Property ;
@@ -1356,11 +1585,13 @@
     samm:preferredName "Freetext Language Code"@en ;
     samm:description "Enumeration with defined code set. Language independent. ISO 639-1 (2 letters)"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "aa"^^xsd:string ;
     samm:characteristic :LanguageCodeEnumCharacteristic .
 
 :freetextLanguageCountryCode a samm:Property ;
     samm:preferredName "Freetext Language Country Code"@en ;
     samm:description "If languages are used in more than one country, there might be national flavours that are significantly different (like pt-BR, en-US). In this case, indicate the country here. If empty, this field defaults to the originating country (pt-PT, en-GB)."@en ;
+    samm:exampleValue "AD"^^xsd:string ;
     samm:characteristic :CountryCodeEnumCharacteristic .
 
 :freetextLanguageName a samm:Property ;
@@ -1371,19 +1602,23 @@
 
 :freezingPoint a samm:Property ;
     samm:preferredName "Freezing Point"@en ;
+    samm:description "Freezing point; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueList .
 
 :fullText a samm:Property ;
     samm:preferredName "Full Text"@en ;
-    samm:characteristic samm-c:Text .
+    samm:description "If the Language and Country attributes are missing, Language and Country default to the FreetextLanguage and FreetextLanguageCountry named at the top of the XML file. \nIf there is only one instance of FullText, the Language and Country attributes should be omitted. If there is more than one instance, all but one should have those attributes."@en ;
+    samm:characteristic :FullTextList .
 
 :gasGroup a samm:Property ;
     samm:preferredName "Gas Group"@en ;
+    samm:description "gas group for explosion protection or transport context; coded value."@en ;
     samm:characteristic :GasGroupList .
 
 :gasesUnderPressure a samm:Property ;
     samm:preferredName "Gases Under Pressure"@en ;
+    samm:description "Classification of of gases under pressure; e.g. compressed, liquefied or refrigerated liquefied."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :GasesUnderPressureCharacteristic .
 
@@ -1399,12 +1634,19 @@
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :GbClpHazardLabelling2020Characteristic .
 
+:gbt2009HazardClassification a samm:Property ;
+    samm:preferredName "Gbt2009Hazard Classification"@en ;
+    samm:description "Hazard classification according to the Chinese GB 30000 standards"@en ;
+    samm:characteristic :Gbt2009HazardClassificationCharacteristic .
+
 :gender a samm:Property ;
     samm:preferredName "Gender"@en ;
+    samm:description "sex of the tested species; male, female or both."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :generalDescription a samm:Property ;
     samm:preferredName "General Description"@en ;
+    samm:description "General description of safe use of the mixture."@en ;
     samm:characteristic :GeneralDescriptionCharacteristic .
 
 :generalInformation a samm:Property ;
@@ -1426,10 +1668,12 @@
 
 :germCellMutagenicity a samm:Property ;
     samm:preferredName "Germ Cell Mutagenicity"@en ;
+    samm:description "Information on germ cell mutagenicity, including classification and test results."@en ;
     samm:characteristic :GermCellMutagenicityCharacteristic .
 
 :germCellMutagenicityHumanExperience a samm:Property ;
     samm:preferredName "Germ Cell Mutagenicity Human Experience"@en ;
+    samm:description "Human experience on germ cell mutagenicity; qualitative informationn."@en ;
     samm:characteristic :PhraseList .
 
 :gisCode a samm:Property ;
@@ -1445,6 +1689,7 @@
 
 :gloveBreakthroughTime a samm:Property ;
     samm:preferredName "Glove Breakthrough Time"@en ;
+    samm:description "Glove material breakthrough time; typically expressed in min."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
@@ -1455,10 +1700,13 @@
 
 :group a samm:Property ;
     samm:preferredName "Group"@en ;
+    samm:description "Short code of the exposure group; coded value."@en ;
+    samm:exampleValue "Worker"^^xsd:string ;
     samm:characteristic :EffectLevelGroupEnumCharacteristic .
 
 :groupFulltext a samm:Property ;
     samm:preferredName "Group Fulltext"@en ;
+    samm:description "Full designation der exposure group, e.g. industrial user or consumer."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :halfLifeTime a samm:Property ;
@@ -1468,10 +1716,12 @@
 
 :handProtection a samm:Property ;
     samm:preferredName "Hand Protection"@en ;
+    samm:description "hand protection measures including glove type, material, thickness and breakthrough time."@en ;
     samm:characteristic :HandProtectionCharacteristic .
 
 :handProtectionNecessaryProperties a samm:Property ;
     samm:preferredName "Hand Protection Necessary Properties"@en ;
+    samm:description "Required properties of hand protection, e.g. chemical resistance and breakthrough time."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
@@ -1488,10 +1738,12 @@
 
 :hazardBand a samm:Property ;
     samm:preferredName "Hazard Band"@en ;
+    samm:description "Hazard band in the control-banding system; coded or categorised information."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :hazardClassCategory a samm:Property ;
     samm:preferredName "Hazard Class Category"@en ;
+    samm:description "Hazard class and category according to GHS/CLP-System; coded value."@en ;
     samm:characteristic samm-c:Text .
 
 :hazardClassCategoryPrintable a samm:Property ;
@@ -1514,15 +1766,18 @@
 
 :hazardIdentification a samm:Property ;
     samm:preferredName "Hazard Identification"@en ;
+    samm:description "Hazards identification including classification, labelling and other hazards."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :HazardIdentificationCharacteristic .
 
 :hazardLabel a samm:Property ;
     samm:preferredName "Hazard Label"@en ;
+    samm:description "Danger label under dangerous goods law; number or code."@en ;
     samm:characteristic samm-c:Text .
 
 :hazardLabelAdr a samm:Property ;
     samm:preferredName "Hazard Label Adr"@en ;
+    samm:description "ADR label; number or code."@en ;
     samm:characteristic samm-c:Text .
 
 :hazardLabelEnglish a samm:Property ;
@@ -1532,6 +1787,7 @@
 
 :hazardLabelRid a samm:Property ;
     samm:preferredName "Hazard Label Rid"@en ;
+    samm:description "RID label; number or code."@en ;
     samm:characteristic samm-c:Text .
 
 :hazardLabelling a samm:Property ;
@@ -1542,6 +1798,7 @@
 
 :hazardNumber a samm:Property ;
     samm:preferredName "Hazard Number"@en ;
+    samm:description "Hazard identification number/Kemler code for dangerous goods transport; dimensionless."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
@@ -1549,6 +1806,7 @@
     samm:preferredName "Hazard Pictogram"@en ;
     samm:description "Pictogram: A graphical presentation that includes a symbol plus other graphic elements, such as a border, background pattern or colour that is intended to convey specific information on the hazard concerned."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "GHS01"^^xsd:string ;
     samm:characteristic :GhsPictogramCodeEnumCharacteristic .
 
 :hazardStatement a samm:Property ;
@@ -1577,14 +1835,17 @@
 
 :hazardousWasteCharacteristics a samm:Property ;
     samm:preferredName "Hazardous Waste Characteristics"@en ;
+    samm:description "Hazardous waste characteristics, e.g. flammability, toxicity or environmental hazard; coded or textual."@en ;
     samm:characteristic :PhraseList .
 
 :hazardousWasteCode a samm:Property ;
     samm:preferredName "Hazardous Waste Code"@en ;
+    samm:description "US state of California: Regional hazardous waste code; coded value."@en ;
     samm:characteristic samm-c:Text .
 
 :hazardousWasteStatus a samm:Property ;
     samm:preferredName "Hazardous Waste Status"@en ;
+    samm:description "US state of California: Status indicating whether waste is classified as hazardous; yes/no or classification."@en ;
     samm:characteristic :PhraseList .
 
 :hazcom2012HazardClassification a samm:Property ;
@@ -1607,34 +1868,42 @@
 :healthHazardThreshold a samm:Property ;
     samm:preferredName "Health Hazard Threshold"@en ;
     samm:description "in kg"@en ;
+    samm:exampleValue "42"^^xsd:integer ;
     samm:characteristic :IntegerCharacteristic .
 
 :healthHazardsSevesoEntryDe a samm:Property ;
     samm:preferredName "Health Hazards"@en ;
+    samm:description "German major accident entry for health hazards; category or quantity thresholds."@en ;
     samm:characteristic :SevesoEntryDeCharacteristic .
 
 :healthHazardsSevesoEntryEu a samm:Property ;
     samm:preferredName "Health Hazards"@en ;
+    samm:description "EU Seveso entry for health hazards; category or thresholds."@en ;
     samm:characteristic :SevesoEntryEuCharacteristic .
 
 :hintsOnStorageAssembly a samm:Property ;
     samm:preferredName "Hints On Storage Assembly"@en ;
+    samm:description "Advice on storage compatibility with other substances or mixtures."@en ;
     samm:characteristic :PhraseList .
 
 :humanExperience a samm:Property ;
     samm:preferredName "Human Experience"@en ;
+    samm:description "Human experience for the relevant toxicological endpoint."@en ;
     samm:characteristic :HumanExperienceCharacteristic .
 
 :humanToxicologicalData a samm:Property ;
     samm:preferredName "Human Toxicological Data"@en ;
+    samm:description "Human toxicological data or experience reports."@en ;
     samm:characteristic :PhraseList .
 
 :hydrolysisRate a samm:Property ;
     samm:preferredName "Hydrolysis Rate"@en ;
+    samm:description "Hydrolysis rate or half-life; unit e.g. 1/s, 1/d or Tage."@en ;
     samm:characteristic :HydrolysisRateList .
 
 :iataDgr a samm:Property ;
     samm:preferredName "Iata Dgr"@en ;
+    samm:description "Transport information according to IATA-DGR for air transport of dangerous goods."@en ;
     samm:characteristic :IataDgrCharacteristic .
 
 :idNoUsaDot a samm:Property ;
@@ -1644,6 +1913,7 @@
 
 :identificationSubstPrep a samm:Property ;
     samm:preferredName "Identification Subst Prep"@en ;
+    samm:description "Identification data for the substance/mixture, uses and supplier."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :IdentificationSubstPrepCharacteristic .
 
@@ -1655,26 +1925,33 @@
 
 :identifiedUseId a samm:Property ;
     samm:preferredName "Identified Use Id"@en ;
+    samm:description "Identifier of the identified use; technical or internal identifier."@en ;
+    samm:exampleValue "42"^^xsd:integer ;
     samm:characteristic :IntegerCharacteristic .
 
 :imdg a samm:Property ;
     samm:preferredName "Imdg"@en ;
+    samm:description "Transport information according to the IMDG code for sea transport of dangerous goods."@en ;
     samm:characteristic :ImdgCharacteristic .
 
 :inCaseOfEyeContact a samm:Property ;
     samm:preferredName "In Case Of Eye Contact"@en ;
+    samm:description "Symptoms or advice in case of eye contact."@en ;
     samm:characteristic :PhraseList .
 
 :inCaseOfIngestion a samm:Property ;
     samm:preferredName "In Case Of Ingestion"@en ;
+    samm:description "Symptoms or advice in case of ingestion."@en ;
     samm:characteristic :PhraseList .
 
 :inCaseOfInhalation a samm:Property ;
     samm:preferredName "In Case Of Inhalation"@en ;
+    samm:description "Symptoms or advice in case of inhalation."@en ;
     samm:characteristic :PhraseList .
 
 :inCaseOfSkinContact a samm:Property ;
     samm:preferredName "In Case Of Skin Contact"@en ;
+    samm:description "Symptoms or advice in case of skin contact."@en ;
     samm:characteristic :PhraseList .
 
 :inciName a samm:Property ;
@@ -1684,11 +1961,13 @@
 
 :indexNo a samm:Property ;
     samm:preferredName "Index No"@en ;
+    samm:description "Index number under Annex VI CLP; coded value."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
 :inductionTime a samm:Property ;
     samm:preferredName "Induction Time"@en ;
+    samm:description "Induction time until reaction or self-heating; unit typically min or h."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
@@ -1704,10 +1983,12 @@
 
 :industrialUse a samm:Property ;
     samm:preferredName "Industrial Use"@en ;
+    samm:description "Indicates whether industrial use is intended; yes/no or description."@en ;
     samm:characteristic samm-c:Boolean .
 
 :informationFromExportingSystem a samm:Property ;
     samm:preferredName "Information From Exporting System"@en ;
+    samm:description "Metadata and technical information from the exporting system."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :InformationFromExportingSystemCharacteristic .
 
@@ -1719,10 +2000,13 @@
 
 :inhalation a samm:Property ;
     samm:preferredName "Inhalation"@en ;
+    samm:description "Information on inhalation exposure or toxicity; typically expressed as % with explanatory text where applicable."@en ;
+    samm:exampleValue "3.14"^^xsd:float ;
     samm:characteristic :PercentageCharacteristic .
 
 :inoculum a samm:Property ;
     samm:preferredName "Inoculum"@en ;
+    samm:description "Inokulum or microbial test population in degradation tests; type/origin and where applicable concentration."@en ;
     samm:characteristic :PhraseList .
 
 :inorganicCarbon a samm:Property ;
@@ -1732,10 +2016,12 @@
 
 :insectToxicity a samm:Property ;
     samm:preferredName "Insect Toxicity"@en ;
+    samm:description "Toxicity to insects; endpoint and unit depend on the test method."@en ;
     samm:characteristic :EcotoxicityList .
 
 :instructionalMeasures a samm:Property ;
     samm:preferredName "Instructional Measures"@en ;
+    samm:description "Instructional or behavioural measures for safe use and exposure control."@en ;
     samm:characteristic :PhraseList .
 
 :instructionsForUse a samm:Property ;
@@ -1761,42 +2047,51 @@
 
 :intrusionDepth a samm:Property ;
     samm:preferredName "Intrusion Depth"@en ;
+    samm:description "Penetration or corrosion depth; unit typically mm or mm/Jahr."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :investigationMethod a samm:Property ;
     samm:preferredName "Investigation Method"@en ;
+    samm:description "Investigation or test method for the toxicological endpoint."@en ;
     samm:characteristic :InvestigationMethodCharacteristic .
 
 :investigationParameter a samm:Property ;
     samm:preferredName "Investigation Parameter"@en ;
+    samm:description "Investigation parameter in biological monitoring, e.g. metabolite or marker parameter."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :irritation a samm:Property ;
     samm:preferredName "Irritation"@en ;
+    samm:description "Information on irritation; category, assessment or Testergebnis."@en ;
     samm:characteristic :PhraseList .
 
 :irritationToRespiratoryTract a samm:Property ;
     samm:preferredName "Irritation To Respiratory Tract"@en ;
+    samm:description "Respiratory tract irritation in the STOT SE 3 (specific target organ toxicity following single exposure) context."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ToxInfoStotSe3Characteristic .
 
 :isBiocide a samm:Property ;
     samm:preferredName "Is Biocide"@en ;
+    samm:description "Indicates whether the product is a biocide; yes/no."@en ;
     samm:characteristic samm-c:Boolean .
 
 :isDetergent a samm:Property ;
     samm:preferredName "Is Detergent"@en ;
+    samm:description "Indicates whether the product is a detergent; yes/no."@en ;
     samm:characteristic samm-c:Boolean .
 
 :isTreatedArticle a samm:Property ;
     samm:preferredName "Is Treated Article"@en ;
+    samm:description "Indicates whether it is a treated article; yes/no."@en ;
     samm:characteristic samm-c:Boolean .
 
 :issueDate a samm:Property ;
     samm:preferredName "Issue Date"@en ;
     samm:description "Date of issue: The date when this SDS was prepared for the first time."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "2026-07-20"^^xsd:date ;
     samm:characteristic :DateCharacteristic .
 
 :iupacName a samm:Property ;
@@ -1807,6 +2102,7 @@
 
 :justificationForDataWaiving a samm:Property ;
     samm:preferredName "Justification For Data Waiving"@en ;
+    samm:description "Justification for data waiving or test waiving."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :labellingAccordingToOtherLegislation a samm:Property ;
@@ -1820,6 +2116,12 @@
     samm:description "The default language of the information, stated in a format according to ISO 639-1 (2 letters) followed by textual name"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :LanguageCharacteristic .
+
+:languange a samm:Property ;
+    samm:preferredName "Languange"@en ;
+    samm:description "Language identifier of the phrase; code or name."@en ;
+    samm:exampleValue "aa"^^xsd:string ;
+    samm:characteristic :LanguageCodeEnumCharacteristic .
 
 :legalDocument a samm:Property ;
     samm:preferredName "Legal Document"@en ;
@@ -1836,6 +2138,7 @@
 :legalDocumentPrintDate a samm:Property ;
     samm:preferredName "Legal Document Print Date"@en ;
     samm:description "Print date"@en ;
+    samm:exampleValue "2026-07-20"^^xsd:date ;
     samm:characteristic :DateCharacteristic .
 
 :legalDocumentSignature a samm:Property ;
@@ -1855,43 +2158,58 @@
 
 :limitValueTypeWithCountryOrOrganisation a samm:Property ;
     samm:preferredName "Limit Value Type With Country Or Organisation"@en ;
+    samm:description "type of limit value with country or organisation, e.g. AGW (DE), IOELV (EU) or MAK."@en ;
+    samm:exampleValue "AGW"^^xsd:string ;
     samm:characteristic :ExposureLimitValueTypeEnumCharacteristic .
 
 :limitedQty a samm:Property ;
     samm:preferredName "Limited Qty"@en ;
+    samm:description "Limited quantity under dangerous goods regulations; unit depends on the entry, e.g. L or kg."@en ;
     samm:characteristic samm-c:Text .
 
 :listItemNo a samm:Property ;
     samm:preferredName "List Item No"@en ;
+    samm:description "list item number in the phrase catalogue; technical identifier."@en ;
+    samm:exampleValue "42"^^xsd:integer ;
     samm:characteristic :IntegerCharacteristic .
 
 :lowMolecularWeightContentOfPolymers a samm:Property ;
     samm:preferredName "Low Molecular Weight Content Of Polymers"@en ;
+    samm:description "Fraction of low molecular weight polymer constituents; unit typically % w/w."@en ;
     samm:characteristic :PhysChemUnitValueList .
 
 :lowerExplosionLimit a samm:Property ;
     samm:preferredName "Lower Explosion Limit"@en ;
+    samm:description "Lower explosion limit; unit typically vol.-%."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
-    samm:characteristic :PhysChemUnitValueList .
+    samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :lowerTierQuantity a samm:Property ;
     samm:preferredName "Lower Tier Quantity"@en ;
+    samm:description "Lower-tier quantity threshold; typically expressed in t."@en ;
+    samm:exampleValue "42"^^xsd:integer ;
     samm:characteristic :LowerTierQuantityInlineCharacteristic .
 
 :lowerValue a samm:Property ;
     samm:preferredName "Lower Value"@en ;
+    samm:description "Lower limit of a quantity or size range; unit in context."@en ;
+    samm:exampleValue "3.14"^^xsd:float ;
     samm:characteristic :FloatCharacteristic .
 
 :lowerValueSymbol a samm:Property ;
     samm:preferredName "Lower Value Symbol"@en ;
+    samm:description "Comparison sign for the lower value, e.g. ≥ or >."@en ;
+    samm:exampleValue "gt"^^xsd:string ;
     samm:characteristic :LowerQualifierEnumCharacteristic .
 
 :mainGroup a samm:Property ;
     samm:preferredName "Main Group"@en ;
+    samm:description "main group according to biocidal or regulatory system; codierter or textual value."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :mainIntendedUse a samm:Property ;
     samm:preferredName "Main Intended Use"@en ;
+    samm:description "main intended use of the product or substance; short description of the intended use."@en ;
     samm:characteristic :EupcsCategoryCharacteristic .
 
 :majorAccidentsOrdinance a samm:Property ;
@@ -1901,6 +2219,7 @@
 
 :malCodeDeliveryState a samm:Property ;
     samm:preferredName "Mal Code Delivery State"@en ;
+    samm:description "MAL code in the delivery state under Danish requirements; code usually formatted as two numbers separated by a hyphen (example: 00-1)"@en ;
     samm:characteristic samm-c:Text .
 
 :malCodeReadyToUse a samm:Property ;
@@ -1910,6 +2229,7 @@
 
 :manufacturer a samm:Property ;
     samm:preferredName "Manufacturer"@en ;
+    samm:description "Manufacturer of the product, equipment or protective article."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
@@ -1920,11 +2240,13 @@
 
 :maskType a samm:Property ;
     samm:preferredName "Mask Type"@en ;
+    samm:description "Respiratory mask type, e.g. half mask, full face mask or particulate filtering mask."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :materialType a samm:Property ;
     samm:preferredName "Material Type"@en ;
+    samm:description "Material type of the test material or protection material."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
@@ -1942,10 +2264,12 @@
 :maxPercentage a samm:Property ;
     samm:preferredName "Max Percentage"@en ;
     samm:description "always interpreted as less than (not equal) to the value. If omitted, max percentage is 100."@en ;
+    samm:exampleValue "3.14"^^xsd:float ;
     samm:characteristic :FloatCharacteristic .
 
 :maxTemperatureReached a samm:Property ;
     samm:preferredName "Max Temperature Reached"@en ;
+    samm:description "Maximum temperature reached in the test; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
@@ -1957,40 +2281,49 @@
 
 :maxWearDurationOccasionalContact a samm:Property ;
     samm:preferredName "Max Wear Duration Occasional Contact"@en ;
+    samm:description "Maximum wear duration for occasional contact; typically expressed in min or h."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :maxWearDurationPermanentContact a samm:Property ;
     samm:preferredName "Max Wear Duration Permanent Contact"@en ;
+    samm:description "Maximum wear duration for permanent contact; typically expressed in min or h."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :maximumStoragePeriod a samm:Property ;
     samm:preferredName "Maximum Storage Period"@en ;
+    samm:description "Maximum storage period under specified conditions; unit e.g. Tage, Monate or Jahre."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :meanPhotoEffect a samm:Property ;
     samm:preferredName "Mean Photo Effect"@en ;
+    samm:description "Mean photo effect in phototoxicity test; dimensionless or method-dependent."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :measuresOnConsumerUseOfTheChemical a samm:Property ;
     samm:preferredName "Measures On Consumer Use Of The Chemical"@en ;
+    samm:description "risk management measures for consumers during use of the substance or mixture."@en ;
     samm:characteristic :PhraseList .
 
 :measuresOnServiceLifeInArticles a samm:Property ;
     samm:preferredName "Measures On Service Life In Articles"@en ;
+    samm:description "Measures to limit exposure during the service life of articles."@en ;
     samm:characteristic :PhraseList .
 
 :measuresToPreventAerosolAndDust a samm:Property ;
     samm:preferredName "Measures To Prevent Aerosol And Dust"@en ;
+    samm:description "Measures to prevent aerosol or dust formation."@en ;
     samm:characteristic :PhraseList .
 
 :measuresToPreventFire a samm:Property ;
     samm:preferredName "Measures To Prevent Fire"@en ;
+    samm:description "Measures to prevent fire and ignition hazards."@en ;
     samm:characteristic :PhraseList .
 
 :measuresToProtectEnvironment a samm:Property ;
     samm:preferredName "Measures To Protect Environment"@en ;
+    samm:description "Measures to prevent release to the environment, drains or surface water."@en ;
     samm:characteristic :PhraseList .
 
 :mediaNotBeUsed a samm:Property ;
@@ -2019,7 +2352,9 @@
 
 :medium a samm:Property ;
     samm:preferredName "Medium"@en ;
+    samm:description "Medium or solvent, in which a property was determined."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Water"^^xsd:string ;
     samm:characteristic :SolubilityMediumEnumCharacteristic .
 
 :mediumDescription a samm:Property ;
@@ -2036,44 +2371,56 @@
 
 :meltingPointRelated a samm:Property ;
     samm:preferredName "Melting Point Related"@en ;
+    samm:description "Information on melting, freezing, softening, dropping or solidification point."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :MeltingPointRelatedCharacteristic .
 
 :mergePhrase a samm:Property ;
     samm:preferredName "Merge Phrase"@en ;
+    samm:description "Composite text phrase from the phrase catalogue."@en ;
     samm:characteristic :MergePhraseList .
 
 :mergePhraseNo a samm:Property ;
     samm:preferredName "Merge Phrase No"@en ;
+    samm:description "Number of the composite phrase in the phrase catalogue; technical identifier."@en ;
+    samm:exampleValue "42"^^xsd:integer ;
     samm:characteristic :IntegerCharacteristic .
 
 :mergeText a samm:Property ;
     samm:preferredName "Merge Text"@en ;
+    samm:description "Merged text from phrase components."@en ;
     samm:characteristic samm-c:Text .
 
 :methodFulltext a samm:Property ;
     samm:preferredName "Method Fulltext"@en ;
+    samm:description "full text test method or investigation method."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :methodInvestigationMethodEnum a samm:Property ;
     samm:preferredName "Method"@en ;
+    samm:description "Coded test method or investigation method."@en ;
+    samm:exampleValue "in-vivo"^^xsd:string ;
     samm:characteristic :InvestigationMethodEnumCharacteristic .
 
 :methodPhrase a samm:Property ;
     samm:preferredName "Method"@en ;
+    samm:description "Method or procedure used to determine the stated property."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :microorganismToxicity a samm:Property ;
     samm:preferredName "Microorganism Toxicity"@en ;
+    samm:description "Toxicity to microorganisms, e.g. sewage treatment organisms; unit typically mg/L."@en ;
     samm:characteristic :EcotoxicityAquaticList .
 
 :minPercentage a samm:Property ;
     samm:preferredName "Min Percentage"@en ;
     samm:description "always interpreted as greater than or equal to the value"@en ;
+    samm:exampleValue "3.14"^^xsd:float ;
     samm:characteristic :FloatCharacteristic .
 
 :miscibility a samm:Property ;
     samm:preferredName "Miscibility"@en ;
+    samm:description "Miscibility with water or other media; qualitative information or Anteil in %."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
@@ -2084,14 +2431,17 @@
 
 :mobility a samm:Property ;
     samm:preferredName "Mobility"@en ;
+    samm:description "Information on mobility in environmental compartments, e.g. soil/water distribution or adsorption."@en ;
     samm:characteristic :MobilityList .
 
 :mobilityEvaluation a samm:Property ;
     samm:preferredName "Mobility Evaluation"@en ;
+    samm:description "Assessment of environmental mobility, e.g. based on sorption, solubility or partition coefficients."@en ;
     samm:characteristic :PhraseList .
 
 :molecularWeightDistribution a samm:Property ;
     samm:preferredName "Molecular Weight Distribution"@en ;
+    samm:description "Molecular weight distribution, e.g. Mn/Mw or dispersity; dimensionless or g/mol."@en ;
     samm:characteristic :PhysChemUnitValueList .
 
 :multiplyingFactor a samm:Property ;
@@ -2101,25 +2451,30 @@
 
 :name a samm:Property ;
     samm:preferredName "Name"@en ;
+    samm:description "name or designation of the product, GTIN entry or element."@en ;
     samm:characteristic samm-c:Text .
 
 :nameDetergentsRegulation a samm:Property ;
     samm:preferredName "Name Detergents Regulation"@en ;
+    samm:description "Designation of the applicable detergent regulation or information."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
 :narcoticEffects a samm:Property ;
     samm:preferredName "Narcotic Effects"@en ;
+    samm:description "Narcotic effects in the STOT SE 3 (specific target organ toxicity following single exposure) context."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ToxInfoStotSe3Characteristic .
 
 :nationalContact a samm:Property ;
     samm:preferredName "National Contact"@en ;
+    samm:description "National contact person or contact point for regional requirements."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislation a samm:Property ;
     samm:preferredName "National Legislation"@en ;
+    samm:description "National legislation or requirements for the product/substance."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :NationalLegislationCharacteristic .
 
@@ -2135,14 +2490,17 @@
 
 :nationalLegislationAustria a samm:Property ;
     samm:preferredName "National Legislation Austria"@en ;
+    samm:description "National legislation for Austria; structured value, code or phrase."@en ;
     samm:characteristic :RegulationsAtCharacteristic .
 
 :nationalLegislationBelarus a samm:Property ;
     samm:preferredName "National Legislation Belarus"@en ;
+    samm:description "National legislation for Belarus."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationBelgium a samm:Property ;
     samm:preferredName "National Legislation Belgium"@en ;
+    samm:description "National legislation for Belgium; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationBosniaAndHerzegovina a samm:Property ;
@@ -2152,30 +2510,37 @@
 
 :nationalLegislationBulgaria a samm:Property ;
     samm:preferredName "National Legislation Bulgaria"@en ;
+    samm:description "National legislation for Bulgaria; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationCroatia a samm:Property ;
     samm:preferredName "National Legislation Croatia"@en ;
+    samm:description "National legislation for Croatia; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationCyprus a samm:Property ;
     samm:preferredName "National Legislation Cyprus"@en ;
+    samm:description "National legislation for Cyprus; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationCzechRepublic a samm:Property ;
     samm:preferredName "National Legislation Czech Republic"@en ;
+    samm:description "National legislation for Czech Republic; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationDenmark a samm:Property ;
     samm:preferredName "National Legislation Denmark"@en ;
+    samm:description "National legislation for Denmark; structured value, code or phrase."@en ;
     samm:characteristic :RegulationsDkCharacteristic .
 
 :nationalLegislationEstonia a samm:Property ;
     samm:preferredName "National Legislation Estonia"@en ;
+    samm:description "National legislation for Estonia; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationFinland a samm:Property ;
     samm:preferredName "National Legislation Finland"@en ;
+    samm:description "National legislation for Finland; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationFrance a samm:Property ;
@@ -2185,15 +2550,18 @@
 
 :nationalLegislationGermany a samm:Property ;
     samm:preferredName "National Legislation Germany"@en ;
+    samm:description "National legislation for Germany."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :RegulationsDeCharacteristic .
 
 :nationalLegislationGreece a samm:Property ;
     samm:preferredName "National Legislation Greece"@en ;
+    samm:description "National legislation for Greece; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationHungary a samm:Property ;
     samm:preferredName "National Legislation Hungary"@en ;
+    samm:description "National legislation for Hungary; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationIceland a samm:Property ;
@@ -2203,18 +2571,22 @@
 
 :nationalLegislationIreland a samm:Property ;
     samm:preferredName "National Legislation Ireland"@en ;
+    samm:description "National legislation for Ireland; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationItaly a samm:Property ;
     samm:preferredName "National Legislation Italy"@en ;
+    samm:description "National legislation for Italy; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationKazakhstan a samm:Property ;
     samm:preferredName "National Legislation Kazakhstan"@en ;
+    samm:description "National legislation for Kazakhstan."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationLatvia a samm:Property ;
     samm:preferredName "National Legislation Latvia"@en ;
+    samm:description "National legislation for Latvia; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationLiechtenstein a samm:Property ;
@@ -2224,14 +2596,17 @@
 
 :nationalLegislationLithuania a samm:Property ;
     samm:preferredName "National Legislation Lithuania"@en ;
+    samm:description "National legislation for Lithuania; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationLuxembourg a samm:Property ;
     samm:preferredName "National Legislation Luxembourg"@en ;
+    samm:description "National legislation for Luxembourg; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationMalta a samm:Property ;
     samm:preferredName "National Legislation Malta"@en ;
+    samm:description "National legislation for Malta; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationMonaco a samm:Property ;
@@ -2246,6 +2621,7 @@
 
 :nationalLegislationNetherlands a samm:Property ;
     samm:preferredName "National Legislation Netherlands"@en ;
+    samm:description "National legislation for Netherlands; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationNorthMacedonia a samm:Property ;
@@ -2260,6 +2636,7 @@
 
 :nationalLegislationPoland a samm:Property ;
     samm:preferredName "National Legislation Poland"@en ;
+    samm:description "National legislation for Poland; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationPortugal a samm:Property ;
@@ -2269,10 +2646,12 @@
 
 :nationalLegislationRomania a samm:Property ;
     samm:preferredName "National Legislation Romania"@en ;
+    samm:description "National legislation for Romania; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationRussianFederation a samm:Property ;
     samm:preferredName "National Legislation Russian Federation"@en ;
+    samm:description "National legislation for Russian Federation."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationSanMarino a samm:Property ;
@@ -2287,10 +2666,12 @@
 
 :nationalLegislationSlovakia a samm:Property ;
     samm:preferredName "National Legislation Slovakia"@en ;
+    samm:description "National legislation for Slovakia; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationSlovenia a samm:Property ;
     samm:preferredName "National Legislation Slovenia"@en ;
+    samm:description "National legislation for Slovenia; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationSpain a samm:Property ;
@@ -2300,6 +2681,7 @@
 
 :nationalLegislationSweden a samm:Property ;
     samm:preferredName "National Legislation Sweden"@en ;
+    samm:description "National legislation for Sweden; structured value, code or phrase."@en ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationSwitzerland a samm:Property ;
@@ -2324,28 +2706,38 @@
 
 :nationalLegislationsDescription a samm:Property ;
     samm:preferredName "National Legislations Description"@en ;
+    samm:description "Norway: Description of national legal requirements."@en ;
     samm:characteristic :PhraseList .
 
 :nationalRegulations a samm:Property ;
     samm:preferredName "National Regulations"@en ;
+    samm:description "Norway: National provisions relevant for the product or disposal."@en ;
     samm:characteristic :PhraseList .
 
 :nationalWasteCode a samm:Property ;
     samm:preferredName "National Waste Code"@en ;
+    samm:description "Norway: National waste code or waste key; coded value."@en ;
     samm:characteristic :PhraseList .
 
 :nationalWasteLegislation a samm:Property ;
     samm:preferredName "National Waste Legislation"@en ;
+    samm:description "Norway: National waste legislation or waste-law context."@en ;
     samm:characteristic :NationalWasteLegislationNoList .
 
 :nationalWasteLegislationCh a samm:Property ;
     samm:preferredName "National Waste Legislation Ch"@en ;
+    samm:description "National Waste Legislation Ch: semantic data field in the area of EU-specific information; content as structured value, code or phrase."@en ;
     samm:characteristic :NationalWasteLegislationChCharacteristic .
 
 :nationalWasteLegislationDe a samm:Property ;
     samm:preferredName "National Waste Legislation De"@en ;
     samm:description "National legislation: National requirements related to waste that applies to the product or its packaging."@en ;
     samm:characteristic :NationalWasteLegislationDeList .
+
+:newLine a samm:Property ;
+    samm:preferredName "New Line"@en ;
+    samm:description "specify this empty tag to indicate a line break"@en ;
+    samm:characteristic samm-c:Text .
 
 :noInt20 a samm:Property ;
     samm:preferredName "No"@en ;
@@ -2354,6 +2746,7 @@
 
 :noPhrase a samm:Property ;
     samm:preferredName "No"@en ;
+    samm:description "Number or textual reference within a regulation."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :noString256 a samm:Property ;
@@ -2374,30 +2767,37 @@
 
 :nonHumanToxicologicalData a samm:Property ;
     samm:preferredName "Non Human Toxicological Data"@en ;
+    samm:description "Toxicological data from animal studies, in vitro or other non-human sources."@en ;
     samm:characteristic :NonHumanToxicologicalDataList .
 
 :norwegianPrFunctionCode a samm:Property ;
     samm:preferredName "Norwegian Pr Function Code"@en ;
+    samm:description "Norwegian PR function code; coded value."@en ;
     samm:characteristic :PhraseList .
 
 :notApplicableReason a samm:Property ;
     samm:preferredName "Not Applicable Reason"@en ;
+    samm:description "Norway: Reason why information is not applicable."@en ;
     samm:characteristic :PhraseList .
 
 :numberAverageMolecularWeight a samm:Property ;
     samm:preferredName "Number Average Molecular Weight"@en ;
+    samm:description "Number-average molecular weight Mn; unit typically g/mol."@en ;
     samm:characteristic :PhysChemUnitValueList .
 
 :oarGroup a samm:Property ;
     samm:preferredName "Oar Group"@en ;
+    samm:description "Norway: Group or category of occupational air requirement."@en ;
     samm:characteristic samm-c:Text .
 
 :oarValue a samm:Property ;
     samm:preferredName "Oar Value"@en ;
+    samm:description "Norway: numerical value for occupational air requirement."@en ;
     samm:characteristic samm-c:Text .
 
 :occupationalAirRequirement a samm:Property ;
     samm:preferredName "Occupational Air Requirement"@en ;
+    samm:description "Norway: Occupational air requirement or limit value under national law."@en ;
     samm:characteristic :OccupationalAirRequirementNoCharacteristic .
 
 :occupationalExposureLimit a samm:Property ;
@@ -2414,19 +2814,23 @@
     samm:preferredName "Odour"@en ;
     samm:description "Product odour: Description of the smell of the product."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
-    samm:characteristic :PhraseList .
+    samm:characteristic :PhraseCharacteristic .
 
 :odourThreshold a samm:Property ;
     samm:preferredName "Odour Threshold"@en ;
+    samm:description "Odour threshold; unit typically mg/m³, ppm or qualitative information."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
-    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+    samm:characteristic :PhysChemUnitValueWithTemperatureCharacteristic .
 
 :operationalConditions a samm:Property ;
     samm:preferredName "Operational Conditions"@en ;
+    samm:description "Operational conditions for safe use, e.g. duration, amount, temperature or ventilation."@en ;
     samm:characteristic :OperationalConditionsCharacteristic .
 
 :oral a samm:Property ;
     samm:preferredName "Oral"@en ;
+    samm:description "Information on oral exposure or toxicity; typically expressed as % with explanatory text where applicable."@en ;
+    samm:exampleValue "3.14"^^xsd:float ;
     samm:characteristic :PercentageCharacteristic .
 
 :organ a samm:Property ;
@@ -2436,27 +2840,33 @@
 
 :organAffected a samm:Property ;
     samm:preferredName "Organ Affected"@en ;
+    samm:description "Affected target organ or organ system."@en ;
     samm:characteristic :PhraseList .
 
 :organicPeroxides a samm:Property ;
     samm:preferredName "Organic Peroxides"@en ;
+    samm:description "Classification or assessment of organic peroxides under CLP/GHS."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :OrganicPeroxidesCharacteristic .
 
 :organisationalMeasures a samm:Property ;
     samm:preferredName "Organisational Measures"@en ;
+    samm:description "Organisational protection measures, e.g. work procedures, access restrictions or training."@en ;
     samm:characteristic :PhraseList .
 
 :organisationalSigns a samm:Property ;
     samm:preferredName "Organisational Signs"@en ;
+    samm:description "Organisational signs or notices, e.g. warning, prohibition or mandatory signs."@en ;
     samm:characteristic samm-c:Text .
 
 :other a samm:Property ;
     samm:preferredName "Other"@en ;
+    samm:description "Other information not assigned to a more specific field."@en ;
     samm:characteristic :PhraseList .
 
 :otherAdverseEffects a samm:Property ;
     samm:preferredName "Other Adverse Effects"@en ;
+    samm:description "Other adverse environmental effects, not already covered by standard endpoints."@en ;
     samm:characteristic :OtherAdverseEffectsCharacteristic .
 
 :otherEuLabellingRequirements a samm:Property ;
@@ -2472,6 +2882,7 @@
 :otherHazardThreshold a samm:Property ;
     samm:preferredName "Other Hazard Threshold"@en ;
     samm:description "in kg. Includes results from tables 4 and 5"@en ;
+    samm:exampleValue "42"^^xsd:integer ;
     samm:characteristic :IntegerCharacteristic .
 
 :otherHazardsInfo a samm:Property ;
@@ -2488,18 +2899,22 @@
 
 :otherHazardsSevesoEntryDe a samm:Property ;
     samm:preferredName "Other Hazards"@en ;
+    samm:description "German major accident entry for other hazards; category or quantity thresholds."@en ;
     samm:characteristic :SevesoEntryDeCharacteristic .
 
 :otherHazardsSevesoEntryEu a samm:Property ;
     samm:preferredName "Other Hazards"@en ;
+    samm:description "EU Seveso entry for other hazards; category or thresholds."@en ;
     samm:characteristic :SevesoEntryEuCharacteristic .
 
 :otherInformation a samm:Property ;
     samm:preferredName "Other Information"@en ;
+    samm:description "Additional transport- or safety-relevant information."@en ;
     samm:characteristic :OtherInformationCharacteristic .
 
 :otherLegislation a samm:Property ;
     samm:preferredName "Other Legislation"@en ;
+    samm:description "Other relevant legislation for the region or product."@en ;
     samm:characteristic :PhraseList .
 
 :otherName a samm:Property ;
@@ -2510,6 +2925,7 @@
 
 :otherPhysicalChemicalProperty a samm:Property ;
     samm:preferredName "Other Physical Chemical Property"@en ;
+    samm:description "Other physical and chemical property, relevant for safe use."@en ;
     samm:characteristic :PhraseList .
 
 :otherRestrictionsAndProhibitionRegulations a samm:Property ;
@@ -2519,30 +2935,36 @@
 
 :otherSafetyInformation a samm:Property ;
     samm:preferredName "Other Safety Information"@en ;
+    samm:description "Additional safety-relevant physical and chemical information."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :OtherSafetyInformationCharacteristic .
 
 :overallAssessmentOnCmrProperties a samm:Property ;
     samm:preferredName "Overall Assessment On Cmr Properties"@en ;
+    samm:description "Overall assessment of CMR properties: carcinogenicity, mutagenicity, reproductive toxicity."@en ;
     samm:characteristic :PhraseList .
 
 :oxidisingGases a samm:Property ;
     samm:preferredName "Oxidising Gases"@en ;
+    samm:description "Classification or assessment of oxidising gases under CLP/GHS."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :OxidisingGasesCharacteristic .
 
 :oxidisingLiquids a samm:Property ;
     samm:preferredName "Oxidising Liquids"@en ;
+    samm:description "Classification or assessment of oxidising liquids under CLP/GHS."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :OxidisingLiquidsCharacteristic .
 
 :oxidisingProperties a samm:Property ;
     samm:preferredName "Oxidising Properties"@en ;
+    samm:description "Oxidising properties; classification, assessment or test result."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :oxidisingSolids a samm:Property ;
     samm:preferredName "Oxidising Solids"@en ;
+    samm:description "Classification or assessment of oxidising solids under CLP/GHS."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :OxidisingSolidsCharacteristic .
 
@@ -2553,6 +2975,7 @@
 
 :pH a samm:Property ;
     samm:preferredName "PH"@en ;
+    samm:description "pH value; dimensionless (0-14)."@en ;
     samm:characteristic :NumericRangeWithQualifierCharacteristic .
 
 :packaging a samm:Property ;
@@ -2567,6 +2990,8 @@
 
 :packagingMaterial a samm:Property ;
     samm:preferredName "Packaging Material"@en ;
+    samm:description "Packaging material, e.g. Kunststoff, Metall, Glas or Papier."@en ;
+    samm:exampleValue "glass"^^xsd:string ;
     samm:characteristic :PackagingMaterialEnumCharacteristic .
 
 :packagingMaterialDescription a samm:Property ;
@@ -2576,10 +3001,13 @@
 
 :packagingSize a samm:Property ;
     samm:preferredName "Packaging Size"@en ;
+    samm:description "Package size or filling quantity; unit e.g. L, mL, kg or g."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :packagingType a samm:Property ;
     samm:preferredName "Packaging Type"@en ;
+    samm:description "Packaging type, e.g. bottle, canister, drum, IBC or box."@en ;
+    samm:exampleValue "aerosol can"^^xsd:string ;
     samm:characteristic :PackagingTypeEnumCharacteristic .
 
 :packagingTypeDescription a samm:Property ;
@@ -2589,46 +3017,60 @@
 
 :packagingWaste a samm:Property ;
     samm:preferredName "Packaging Waste"@en ;
+    samm:description "Information on disposal of packaging waste including contamination and suitable treatment."@en ;
     samm:characteristic :PhraseList .
 
 :packingGroup a samm:Property ;
     samm:preferredName "Packing Group"@en ;
+    samm:description "Packing group under dangerous goods regulations; value I, II or III."@en ;
+    samm:exampleValue "I"^^xsd:string ;
     samm:characteristic :PackingGroupEnumCharacteristic .
 
 :parameterTested a samm:Property ;
     samm:preferredName "Parameter Tested"@en ;
+    samm:description "Tested parameter or endpoint of a test."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
 :particleFraction a samm:Property ;
     samm:preferredName "Particle Fraction"@en ;
+    samm:description "Particle fraction for occupational exposure limits, e.g. inhalable or respirable."@en ;
+    samm:exampleValue "inhalable"^^xsd:string ;
     samm:characteristic :ExposureLimitFractionEnumCharacteristic .
 
 :particleFractionFulltext a samm:Property ;
     samm:preferredName "Particle Fraction Fulltext"@en ;
+    samm:description "full text designation of the particle fraction, e.g. inhalable dust fraction."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :particleSize a samm:Property ;
     samm:preferredName "Particle Size"@en ;
-    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+    samm:description "Particle size; typically expressed in nm or µm."@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureCharacteristic .
 
 :partitionCoefficient a samm:Property ;
     samm:preferredName "Partition Coefficient"@en ;
+    samm:description "n-octanol/water partition coefficient (log Kow) or comparable value; dimensionless."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PartitionCoefficientList .
 
 :pcCode a samm:Property ;
     samm:preferredName "Pc Code"@en ;
+    samm:description "REACH PC code for product category."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "PC1"^^xsd:string ;
     samm:characteristic :ProductCategoryCodeEnumCharacteristic .
 
 :pcFulltext a samm:Property ;
     samm:preferredName "Pc Fulltext"@en ;
+    samm:description "full text product category (PC)."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
 :pdscl a samm:Property ;
     samm:preferredName "Pdscl"@en ;
+    samm:description "Information according to Japanese Poisonous and Deleterious Substances Control Law (in Japanese), where applicable."@en ;
+    samm:exampleValue "deleterious"^^xsd:string ;
     samm:characteristic :PdsclCharacteristic .
 
 :peakLimitation a samm:Property ;
@@ -2638,19 +3080,23 @@
 
 :peakLimitationOverflowFactor a samm:Property ;
     samm:preferredName "Peak Limitation Overflow Factor"@en ;
+    samm:description "Peak limitation overflow factor for short-term exposure limits; dimensionless factor."@en ;
     samm:characteristic :NumericRangeWithQualifierCharacteristic .
 
 :penetrationNo a samm:Property ;
     samm:preferredName "Penetration No"@en ;
+    samm:description "Penetration number, e.g. for semi-solid substances; unit depends on method."@en ;
     samm:characteristic :PhysChemUnitValueWithTemperatureList .
 
 :persistenceDegradability a samm:Property ;
     samm:preferredName "Persistence Degradability"@en ;
+    samm:description "Information on persistence and degradability; includes biological and abiotic degradation processes."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PersistenceDegradabilityCharacteristic .
 
 :persistenceDegradabilityEvaluation a samm:Property ;
     samm:preferredName "Persistence Degradability Evaluation"@en ;
+    samm:description "Assessment of persistence and degradability based on available biological and abiotic data."@en ;
     samm:characteristic :PhraseList .
 
 :personalPrecautions a samm:Property ;
@@ -2660,6 +3106,7 @@
 
 :personalProtectionEquipment a samm:Property ;
     samm:preferredName "Personal Protection Equipment"@en ;
+    samm:description "Personal protective equipment, required or recommended for safe use."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PersonalProtectionEquipmentCharacteristic .
 
@@ -2671,15 +3118,19 @@
 
 :ph a samm:Property ;
     samm:preferredName "Ph"@en ;
+    samm:description "pH value; dimensionless."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :NumericRangeWithQualifierCharacteristic .
 
 :phNotRelevant a samm:Property ;
     samm:preferredName "Ph Not Relevant"@en ;
+    samm:description "Indicates that pH value is not relevant or not applicable; justification recommended."@en ;
+    samm:exampleValue "pH is below -3"^^xsd:string ;
     samm:characteristic :PhNotRelevantEnumCharacteristic .
 
 :phValue a samm:Property ;
     samm:preferredName "Ph Value"@en ;
+    samm:description "PH value of the product or an aqueous solution; dimensionless, at applicable concentration/temperature"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhValueList .
 
@@ -2691,11 +3142,13 @@
 
 :photoIrritationFactor a samm:Property ;
     samm:preferredName "Photo Irritation Factor"@en ;
+    samm:description "Photo irritation factor (PIF); dimensionless."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :photocatalyticProperties a samm:Property ;
     samm:preferredName "Photocatalytic Properties"@en ;
-    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+    samm:description "Photocatalytic properties or activity; qualitative or method-related information."@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureCharacteristic .
 
 :photochemicalOzoneCreationPotential a samm:Property ;
     samm:preferredName "Photochemical Ozone Creation Potential"@en ;
@@ -2704,10 +3157,12 @@
 
 :phototoxicity a samm:Property ;
     samm:preferredName "Phototoxicity"@en ;
+    samm:description "Information on phototoxicity or phototoxic reaction."@en ;
     samm:characteristic :PhototoxicityCharacteristic .
 
 :phototoxicityTestResults a samm:Property ;
     samm:preferredName "Phototoxicity Test Results"@en ;
+    samm:description "test results on phototoxicity."@en ;
     samm:characteristic :PhototoxicityTestResultsList .
 
 :phraseCatalogue a samm:Property ;
@@ -2720,10 +3175,13 @@
     samm:preferredName "Phrase Catalogue Date"@en ;
     samm:description "Date of release of the catalogue version: The version timestamp of the phrase catalogue the information is based on"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "2026-07-20"^^xsd:date ;
     samm:characteristic :DateCharacteristic .
 
 :phraseCatalogueId a samm:Property ;
     samm:preferredName "Phrase Catalogue Id"@en ;
+    samm:description "Identifier of the phrase catalogue used."@en ;
+    samm:exampleValue "42"^^xsd:integer ;
     samm:characteristic :EsdscomPhraseCatalogueIdCharacteristic .
 
 :phraseCatalogueIssuer a samm:Property ;
@@ -2746,10 +3204,14 @@
 
 :phraseCodeAtp12SpecialSupplementalLabelInfoEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
+    samm:description "code of special supplemental labelling according to CLP/ATP-Kontext."@en ;
+    samm:exampleValue "201"^^xsd:string ;
     samm:characteristic :Atp12SpecialSupplementalLabelInfoEnumCharacteristic .
 
 :phraseCodeAtp12SupplementalHazardInformationEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
+    samm:description "code of supplemental hazard information in the ATP/CLP context."@en ;
+    samm:exampleValue "006"^^xsd:string ;
     samm:characteristic :Atp12SupplementalHazardInformationEnumCharacteristic .
 
 :phraseCodeGhs03HazardEnum a samm:Property ;
@@ -2759,32 +3221,45 @@
 
 :phraseCodeGhs03PrecautionEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
+    samm:description "code of a precautionary statement according to GHS-Revision 3, e.g. P-Satz."@en ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeGhs05HazardEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
+    samm:description "code of a hazard statement according to GHS-Revision 5, e.g. H-Satz."@en ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeGhs05PrecautionEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
+    samm:description "code of a precautionary statement according to GHS-Revision 5, e.g. P-Satz."@en ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeGhs07HazardEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
+    samm:description "code of a hazard statement according to GHS-Revision 7, e.g. H-Satz."@en ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeGhs07PrecautionEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
+    samm:description "code of a precautionary statement according to GHS-Revision 7, e.g. P-Satz."@en ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeGhsSignalWordEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
+    samm:description "GHS signal word code, e.g. Danger or Warning."@en ;
+    samm:exampleValue "DGR"^^xsd:string ;
     samm:characteristic :GhsSignalWordEnumCharacteristic .
+
+:phraseCodeString64 a samm:Property ;
+    samm:preferredName "Phrase Code"@en ;
+    samm:description "Phrase code with a maximum of 64 characters; technical identifier."@en ;
+    samm:characteristic samm-c:Text .
 
 :phraseId a samm:Property ;
     samm:preferredName "Phrase Id"@en ;
-    samm:description "Phrase ID in the catalogue referenced by PhraseCatalogueId - which is not eSDScom, because eSDScom phrase IDs are represented as a field in the phrase types."@en ;
-    samm:characteristic samm-c:Text .
+    samm:description "eSDScom (= EuPhraC, ESCom) phrase ID. Optional because user phrases and other phrase catalogues are allowed."@en ;
+    samm:exampleValue "42"^^xsd:integer ;
+    samm:characteristic :EsdscomPhraseIdCharacteristic .
 
 :physicalChemicalPropertiesPhysicalChemicalProperties a samm:Property ;
     samm:preferredName "Physical Chemical Properties"@en ;
@@ -2795,19 +3270,23 @@
 :physicalHazardThreshold a samm:Property ;
     samm:preferredName "Physical Hazard Threshold"@en ;
     samm:description "in kg"@en ;
+    samm:exampleValue "42"^^xsd:integer ;
     samm:characteristic :IntegerCharacteristic .
 
 :physicalHazards a samm:Property ;
     samm:preferredName "Physical Hazards"@en ;
+    samm:description "Physical hazards according to CLP/GHS, e.g. flammability, oxidation or reactivity."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysicalHazardsCharacteristic .
 
 :physicalHazardsSevesoEntryDe a samm:Property ;
     samm:preferredName "Physical Hazards"@en ;
+    samm:description "German major accident entry for physical hazards; category or quantity thresholds."@en ;
     samm:characteristic :SevesoEntryDeCharacteristic .
 
 :physicalHazardsSevesoEntryEu a samm:Property ;
     samm:preferredName "Physical Hazards"@en ;
+    samm:description "EU Seveso entry for physical hazards; category or thresholds."@en ;
     samm:characteristic :SevesoEntryEuCharacteristic .
 
 :physicochemicalEffect a samm:Property ;
@@ -2816,16 +3295,25 @@
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
+:placard a samm:Property ;
+    samm:preferredName "Placard"@en ;
+    samm:description "Danger label/placard for transport labelling; code or description."@en ;
+    samm:exampleValue "1"^^xsd:string ;
+    samm:characteristic :TransportClassEnumCharacteristic .
+
 :plantToxicity a samm:Property ;
     samm:preferredName "Plant Toxicity"@en ;
+    samm:description "Toxicity to plants; endpoint and unit depend on the test, e.g. mg/kg soil or mg/L."@en ;
     samm:characteristic :EcotoxicityAquaticList .
 
 :pnecValue a samm:Property ;
     samm:preferredName "Pnec Value"@en ;
+    samm:description "Predicted No-Effect Concentration (PNEC); unit depends on environmental compartment, often mg/L."@en ;
     samm:characteristic :NumericValueWithUnitCharacteristic .
 
 :pollutionCategory a samm:Property ;
     samm:preferredName "Pollution Category"@en ;
+    samm:description "Pollution category for bulk transport; coded value."@en ;
     samm:characteristic :PhraseList .
 
 :postAddressLine1 a samm:Property ;
@@ -2836,11 +3324,13 @@
 
 :postAddressLine2 a samm:Property ;
     samm:preferredName "Post Address Line2"@en ;
+    samm:description "Second line of the postal address."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
 :postAddressLine3 a samm:Property ;
     samm:preferredName "Post Address Line3"@en ;
+    samm:description "Third line of the postal address."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
@@ -2858,27 +3348,33 @@
 
 :pourPoint a samm:Property ;
     samm:preferredName "Pour Point"@en ;
+    samm:description "pour point; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueList .
 
 :poxPurgeableOrganohalogens a samm:Property ;
     samm:preferredName "Pox Purgeable Organohalogens"@en ;
+    samm:description "POX, purgeable organically bound halogens; unit typically µg/L or mg/L."@en ;
     samm:characteristic :PhysChemUnitValueList .
 
 :prProductCode a samm:Property ;
     samm:preferredName "Pr Product Code"@en ;
+    samm:description "Norway: Product code in PR register or national notification system."@en ;
     samm:characteristic samm-c:Text .
 
 :prProductNo a samm:Property ;
     samm:preferredName "Pr Product No"@en ;
+    samm:description "Norway: Product number in PR register or national notification system."@en ;
     samm:characteristic samm-c:Text .
 
 :prProductRegistration a samm:Property ;
     samm:preferredName "Pr Product Registration"@en ;
+    samm:description "Norway: Product registration information in national register."@en ;
     samm:characteristic :PrProductRegistrationNoList .
 
 :precautionaryMeasures a samm:Property ;
     samm:preferredName "Precautionary Measures"@en ;
+    samm:description "Precautions for safe use, e.g. fire, dust or environmental protection."@en ;
     samm:characteristic :PrecautionaryMeasuresCharacteristic .
 
 :precautionaryStatement a samm:Property ;
@@ -2894,23 +3390,29 @@
 
 :pressure a samm:Property ;
     samm:preferredName "Pressure"@en ;
+    samm:description "Pressure value; typically expressed in Pa, kPa, hPa or bar."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :preventiveIndustrialMedicalExaminationRequired a samm:Property ;
     samm:preferredName "Preventive Industrial Medical Examination Required"@en ;
+    samm:description "Indicates whether occupational medical surveillance is required; yes/no or justification."@en ;
     samm:characteristic :PhraseList .
 
 :printAsAttachment a samm:Property ;
     samm:preferredName "Print As Attachment"@en ;
+    samm:description "Indicates whether the identified use is to be output as an annex; yes/no."@en ;
     samm:characteristic samm-c:Boolean .
 
 :procCode a samm:Property ;
     samm:preferredName "Proc Code"@en ;
+    samm:description "REACH PROC code for process category."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "PROC1"^^xsd:string ;
     samm:characteristic :ProcessCategoryCodeEnumCharacteristic .
 
 :procFulltext a samm:Property ;
     samm:preferredName "Proc Fulltext"@en ;
+    samm:description "full text process category (PROC)."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
@@ -2933,6 +3435,7 @@
 
 :productFunctionCode a samm:Property ;
     samm:preferredName "Product Function Code"@en ;
+    samm:description "Norway: Product function code in national register or notification system."@en ;
     samm:characteristic :PhraseList .
 
 :productFunctionDescription a samm:Property ;
@@ -2954,6 +3457,7 @@
 
 :productName a samm:Property ;
     samm:preferredName "Product Name"@en ;
+    samm:description "Product name in transport or bulk transport context."@en ;
     samm:characteristic samm-c:Text .
 
 :productNoUser a samm:Property ;
@@ -2964,6 +3468,7 @@
 
 :productRelatedMeasures a samm:Property ;
     samm:preferredName "Product Related Measures"@en ;
+    samm:description "Product-related risk reduction measures, e.g. formulation, packaging or dosing."@en ;
     samm:characteristic :PhraseList .
 
 :productSubcategory a samm:Property ;
@@ -2980,18 +3485,22 @@
 
 :productWaste a samm:Property ;
     samm:preferredName "Product Waste"@en ;
+    samm:description "Information on disposal of product residues including hazardous properties and treatment."@en ;
     samm:characteristic :PhraseList .
 
 :professionalUse a samm:Property ;
     samm:preferredName "Professional Use"@en ;
+    samm:description "Indicates whether professional use is intended; yes/no or description."@en ;
     samm:characteristic samm-c:Boolean .
 
 :propellantContent a samm:Property ;
     samm:preferredName "Propellant Content"@en ;
-    samm:characteristic :PhysChemUnitValueList .
+    samm:description "Propellant content; unit typically % w/w or % v/v."@en ;
+    samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :properShippingName a samm:Property ;
     samm:preferredName "Proper Shipping Name"@en ;
+    samm:description "Official transport designation; Proper Shipping Name."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :properShippingNameEnglish a samm:Property ;
@@ -3007,54 +3516,66 @@
 
 :properties a samm:Property ;
     samm:preferredName "Properties"@en ;
+    samm:description "Properties in the context of operational conditions or safe use."@en ;
     samm:characteristic :PropertiesCharacteristic .
 
 :protectiveClothingNecessaryProperties a samm:Property ;
     samm:preferredName "Protective Clothing Necessary Properties"@en ;
+    samm:description "Required properties of protective clothing, e.g. chemical resistance or flame protection."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :protectiveClothingRecommendedMaterial a samm:Property ;
     samm:preferredName "Protective Clothing Recommended Material"@en ;
+    samm:description "Recommended protective clothing material according to hazard and contact type."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :protectiveEquipment a samm:Property ;
     samm:preferredName "Protective Equipment"@en ;
+    samm:description "Required personal protective equipment to prevent skin, eye or clothing contact."@en ;
     samm:characteristic :PhraseList .
 
 :protectiveMeasures a samm:Property ;
     samm:preferredName "Protective Measures"@en ;
+    samm:description "Protective measures for safe handling and exposure prevention."@en ;
     samm:characteristic :PhraseList .
 
 :pyrophoricLiquids a samm:Property ;
     samm:preferredName "Pyrophoric Liquids"@en ;
+    samm:description "Classification or assessment of pyrophoric liquids under CLP/GHS."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PyrophoricLiquidsCharacteristic .
 
 :pyrophoricSolids a samm:Property ;
     samm:preferredName "Pyrophoric Solids"@en ;
+    samm:description "Classification or assessment of pyrophoric solids under CLP/GHS."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PyrophoricSolidsCharacteristic .
 
 :radicalFormationPotential a samm:Property ;
     samm:preferredName "Radical Formation Potential"@en ;
-    samm:characteristic :PhysChemValueWithTemperatureList .
+    samm:description "Radical formation potential; qualitative assessment or measured result."@en ;
+    samm:characteristic :PhysChemValueWithTemperatureCharacteristic .
 
 :rangeOfApplication a samm:Property ;
     samm:preferredName "Range Of Application"@en ;
+    samm:description "Scope or range of application of the information."@en ;
     samm:characteristic :PhraseList .
 
 :rcraBasisForListing a samm:Property ;
     samm:preferredName "Rcra Basis For Listing"@en ;
+    samm:description "US RCRA basis for listing as hazardous waste, e.g. F-, K-, P- or U-listing."@en ;
     samm:characteristic :PhraseList .
 
 :rcraWasteCode a samm:Property ;
     samm:preferredName "Rcra Waste Code"@en ;
+    samm:description "US RCRA hazardous waste code; coded value."@en ;
     samm:characteristic samm-c:Text .
 
 :reachRegNo a samm:Property ;
     samm:preferredName "Reach Reg No"@en ;
+    samm:description "REACH registration number of the substance; alphanumeric value."@en ;
     samm:characteristic samm-c:Text .
 
 :reactivityDescription a samm:Property ;
@@ -3065,36 +3586,45 @@
 
 :reasonForWaiving a samm:Property ;
     samm:preferredName "Reason For Waiving"@en ;
+    samm:description "Reason why testing or information is not required or not available."@en ;
+    samm:exampleValue "cannot be determined"^^xsd:string ;
     samm:characteristic :ReasonForWaivingCharacteristic .
 
 :recommendations a samm:Property ;
     samm:preferredName "Recommendations"@en ;
+    samm:description "Recommendations for specific end uses or safe application."@en ;
     samm:characteristic :PhraseList .
 
 :recommendedMonitoringProcedure a samm:Property ;
     samm:preferredName "Recommended Monitoring Procedure"@en ;
+    samm:description "Recommended measurement or monitoring procedure for relevant exposures."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :recommendedProtectiveClothingArticles a samm:Property ;
     samm:preferredName "Recommended Protective Clothing Articles"@en ;
+    samm:description "Recommended protective clothing articles, e.g. coverall, apron, boots or arm protection."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ProtectionArticleList .
 
 :recommendedRespiratoryProtectionArticles a samm:Property ;
     samm:preferredName "Recommended Respiratory Protection Articles"@en ;
+    samm:description "Recommended respiratory protective devices or filter types according to the exposure situation."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :RespiratoryProtectionArticleList .
 
 :redoxPotential a samm:Property ;
     samm:preferredName "Redox Potential"@en ;
-    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+    samm:description "Redox potential; unit typically mV."@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureCharacteristic .
 
 :reference a samm:Property ;
     samm:preferredName "Reference"@en ;
+    samm:description "Source or reference for limit values, tests or data; bibliographic or URL."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :referenceGas a samm:Property ;
     samm:preferredName "Reference Gas"@en ;
+    samm:description "Reference gas for relative gas or vapour density, e.g. Luft."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :referenceRelevantStandard a samm:Property ;
@@ -3110,54 +3640,77 @@
 
 :refractionIndex a samm:Property ;
     samm:preferredName "Refraction Index"@en ;
+    samm:description "Refractive index; dimensionless, usually at a defined temperature."@en ;
     samm:characteristic :PhysChemValueWithTemperatureList .
 
 :regionAr a samm:Property ;
     samm:preferredName "Region Ar"@en ;
+    samm:description "Region-specific information for Argentina."@en ;
     samm:characteristic :RegionArCharacteristic .
 
 :regionBr a samm:Property ;
     samm:preferredName "Region Br"@en ;
+    samm:description "Region-specific information for Brazil."@en ;
     samm:characteristic :RegionBrCharacteristic .
 
 :regionBrRegulationsBr a samm:Property ;
     samm:preferredName "Region Br"@en ;
+    samm:description "Regulatory information for Brazil."@en ;
     samm:characteristic :RegulationsBrCharacteristic .
 
 :regionBrTransportBr a samm:Property ;
     samm:preferredName "Region Br"@en ;
+    samm:description "Transport information for Brazil."@en ;
     samm:characteristic :TransportBrCharacteristic .
 
 :regionCa a samm:Property ;
     samm:preferredName "Region Ca"@en ;
+    samm:description "Region-specific information for Canada."@en ;
     samm:characteristic :RegionCaCharacteristic .
-
-:regionCaRegulationsCa a samm:Property ;
-    samm:preferredName "Region Ca"@en ;
-    samm:characteristic :RegulationsCaCharacteristic .
 
 :regionCaSdsSupplierInfo a samm:Property ;
     samm:preferredName "Region Ca"@en ;
+    samm:description "Region-specific information in the area of substance/mixture and supplier identification; jurisdiction follows from the field name."@en ;
     samm:characteristic :SdsSupplierInfoCharacteristic .
 
 :regionCaTransportCa a samm:Property ;
     samm:preferredName "Region Ca"@en ;
+    samm:description "Transport information for Canada."@en ;
     samm:characteristic :TransportCaCharacteristic .
+
+:regionCn a samm:Property ;
+    samm:preferredName "Region Cn"@en ;
+    samm:description "Region-specific information for China."@en ;
+    samm:characteristic :RegionCnCharacteristic .
+
+:regionCnSdsSupplierInfo a samm:Property ;
+    samm:preferredName "Region Cn"@en ;
+    samm:description "Region-specific information in the area of substance/mixture and supplier identification; jurisdiction follows from the field name."@en ;
+    samm:characteristic :SdsSupplierInfoCharacteristic .
+
+:regionCnTransportCn a samm:Property ;
+    samm:preferredName "Region Cn"@en ;
+    samm:description "Transport information for China."@en ;
+    samm:characteristic :TransportCnCharacteristic .
 
 :regionEu a samm:Property ;
     samm:preferredName "Region Eu"@en ;
+    samm:description "Region-specific information in the area of substance/mixture and supplier identification; jurisdiction follows from the field name."@en ;
     samm:characteristic :RegionEuCharacteristic .
 
 :regionEuAnnexesEu a samm:Property ;
     samm:preferredName "Region Eu"@en ;
+    samm:description "EU-specific annexes or additional information for safe use."@en ;
     samm:characteristic :AnnexesEuCharacteristic .
 
 :regionEuControlParametersEu a samm:Property ;
     samm:preferredName "Region Eu"@en ;
+    samm:description "Region-specific information in the area of exposure controls and personal protection; jurisdiction follows from the field name."@en ;
     samm:characteristic :ControlParametersEuCharacteristic .
 
 :regionEuDisposalConsiderationsEu a samm:Property ;
     samm:preferredName "Region Eu"@en ;
+    samm:description "Region-specific information in the area of disposal considerations; jurisdiction follows from the field name."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :DisposalConsiderationsEuCharacteristic .
 
@@ -3168,34 +3721,42 @@
 
 :regionEuSdsSupplierInfoEu a samm:Property ;
     samm:preferredName "Region Eu"@en ;
+    samm:description "Region-specific information in the area of substance/mixture and supplier identification; jurisdiction follows from the field name."@en ;
     samm:characteristic :SdsSupplierInfoEuCharacteristic .
 
 :regionEuSubstanceIdentityEu a samm:Property ;
     samm:preferredName "Region Eu"@en ;
+    samm:description "Region-specific information in the area of substance/mixture and supplier identification; jurisdiction follows from the field name."@en ;
     samm:characteristic :SubstanceIdentityEuCharacteristic .
 
 :regionEuTransportEu a samm:Property ;
     samm:preferredName "Region Eu"@en ;
+    samm:description "EU/ADR/RID/ADN-related transport information."@en ;
     samm:characteristic :TransportEuCharacteristic .
 
 :regionGb a samm:Property ;
     samm:preferredName "Region Gb"@en ;
+    samm:description "Region-specific information for Great Britain."@en ;
     samm:characteristic :RegionGbCharacteristic .
 
 :regionJp a samm:Property ;
     samm:preferredName "Region Jp"@en ;
+    samm:description "Region-specific regulatory information for Japan."@en ;
     samm:characteristic :RegulationsJpCharacteristic .
 
 :regionMx a samm:Property ;
     samm:preferredName "Region Mx"@en ;
+    samm:description "Region-specific information for Mexico."@en ;
     samm:characteristic :RegionMxCharacteristic .
 
 :regionMxRegulationsMx a samm:Property ;
     samm:preferredName "Region Mx"@en ;
+    samm:description "Regulatory information for Mexico."@en ;
     samm:characteristic :RegulationsMxCharacteristic .
 
 :regionMxTransportMx a samm:Property ;
     samm:preferredName "Region Mx"@en ;
+    samm:description "Transport information for Mexico."@en ;
     samm:characteristic :TransportMxCharacteristic .
 
 :regionRu a samm:Property ;
@@ -3205,31 +3766,38 @@
 
 :regionTr a samm:Property ;
     samm:preferredName "Region Tr"@en ;
+    samm:description "Region-specific information for Turkey."@en ;
     samm:characteristic :RegionTrCharacteristic .
 
 :regionUs a samm:Property ;
     samm:preferredName "Region Us"@en ;
+    samm:description "Region-specific information for USA."@en ;
     samm:characteristic :RegionUsCharacteristic .
 
 :regionUsDisposalConsiderationsUs a samm:Property ;
     samm:preferredName "Region Us"@en ;
+    samm:description "Region-specific information in the area of disposal considerations; jurisdiction follows from the field name."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :DisposalConsiderationsUsCharacteristic .
 
 :regionUsRegulationsUs a samm:Property ;
     samm:preferredName "Region Us"@en ;
+    samm:description "Regulatory information for USA."@en ;
     samm:characteristic :RegulationsUsCharacteristic .
 
 :regionUsSdsSupplierInfo a samm:Property ;
     samm:preferredName "Region Us"@en ;
+    samm:description "Region-specific information in the area of substance/mixture and supplier identification; jurisdiction follows from the field name."@en ;
     samm:characteristic :SdsSupplierInfoCharacteristic .
 
 :regionUsTransportUs a samm:Property ;
     samm:preferredName "Region Us"@en ;
+    samm:description "Transport information for USA."@en ;
     samm:characteristic :TransportUsCharacteristic .
 
 :registrationNoAccordingToBiozidMeldeverordnung a samm:Property ;
     samm:preferredName "Registration No According To Biozid Meldeverordnung"@en ;
+    samm:description "Registration number under the German Biocide Notification Ordinance; alphanumeric value."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :regulationsRelatedToCountryOrRegion a samm:Property ;
@@ -3242,6 +3810,7 @@
     samm:preferredName "Regulations Related To Country Or Region Code"@en ;
     samm:description "Enumeration with defined code set."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "AD"^^xsd:string ;
     samm:characteristic :CountryCodeEnumCharacteristic .
 
 :regulationsRelatedToCountryOrRegionName a samm:Property ;
@@ -3263,19 +3832,23 @@
 
 :relativeDensity a samm:Property ;
     samm:preferredName "Relative Density"@en ;
+    samm:description "Relative density relative to a reference substance; dimensionless."@en ;
     samm:characteristic :PhysChemValueWithTemperatureList .
 
 :relativeVapourDensity a samm:Property ;
     samm:preferredName "Relative Vapour Density"@en ;
+    samm:description "Relative vapour density relative to air; dimensionless."@en ;
     samm:characteristic :RelativeVapourDensityList .
 
 :relevantIdentifiedUse a samm:Property ;
     samm:preferredName "Relevant Identified Use"@en ;
+    samm:description "Relevant identified use according to REACH/exposure scenario."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :RelevantIdentifiedUseCharacteristic .
 
 :remark a samm:Property ;
     samm:preferredName "Remark"@en ;
+    samm:description "Suisse: data field in the area of EU-specific information; content as structured value, code or phrase."@en ;
     samm:characteristic :PhraseList .
 
 :reproductiveToxicity a samm:Property ;
@@ -3285,14 +3858,17 @@
 
 :reproductiveToxicityHumanExperience a samm:Property ;
     samm:preferredName "Reproductive Toxicity Human Experience"@en ;
+    samm:description "Human experience for reproductive toxicity."@en ;
     samm:characteristic :PhraseList .
 
 :reproductiveToxicityTestResults a samm:Property ;
     samm:preferredName "Reproductive Toxicity Test Results"@en ;
+    samm:description "Test results for reproductive toxicity."@en ;
     samm:characteristic :CmrDataList .
 
 :reproductiveToxicityType a samm:Property ;
     samm:preferredName "Reproductive Toxicity Type"@en ;
+    samm:description "type of reproductive toxicity, e.g. fertility, development or lactation."@en ;
     samm:characteristic :ReproductiveToxicityTypeCharacteristic .
 
 :requiredClinicalTesting a samm:Property ;
@@ -3309,6 +3885,7 @@
 
 :requiredProperties a samm:Property ;
     samm:preferredName "Required Properties"@en ;
+    samm:description "Required protective properties of the equipment, e.g. chemical resistance or standard compliance."@en ;
     samm:characteristic :PhraseList .
 
 :requirementsForStorageRoomsAndVessels a samm:Property ;
@@ -3318,29 +3895,35 @@
 
 :respiratoryOrSkinSensitisation a samm:Property ;
     samm:preferredName "Respiratory Or Skin Sensitisation"@en ;
+    samm:description "Information on respiratory or skin sensitisation."@en ;
     samm:characteristic :RespiratoryOrSkinSensitisationCharacteristic .
 
 :respiratoryOrSkinSensitisationTestResults a samm:Property ;
     samm:preferredName "Respiratory Or Skin Sensitisation Test Results"@en ;
+    samm:description "test results on respiratory or skin sensitisation."@en ;
     samm:characteristic :RespiratoryOrSkinSensitisationTestResultsList .
 
 :respiratoryProtection a samm:Property ;
     samm:preferredName "Respiratory Protection"@en ;
+    samm:description "Respiratory protection measures for exposure to gases, vapours, mists or dusts."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :RespiratoryProtectionCharacteristic .
 
 :respiratoryProtectionGeneral a samm:Property ;
     samm:preferredName "Respiratory Protection General"@en ;
+    samm:description "General information on respiratory protection and its conditions of use."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :respiratoryProtectionNecessaryAt a samm:Property ;
     samm:preferredName "Respiratory Protection Necessary At"@en ;
+    samm:description "Conditions, tasks or exposures, where respiratory protection is required."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :respiratorySensitisationHumanExperience a samm:Property ;
     samm:preferredName "Respiratory Sensitisation Human Experience"@en ;
+    samm:description "Human experience on respiratory sensitisation."@en ;
     samm:characteristic :PhraseList .
 
 :restriction a samm:Property ;
@@ -3356,48 +3939,59 @@
 
 :restrictionsOfOccupation a samm:Property ;
     samm:preferredName "Restrictions Of Occupation"@en ;
+    samm:description "Employment restrictions, e.g. for young people, pregnant workers or specific activities."@en ;
     samm:characteristic :PhraseList .
 
 :result a samm:Property ;
     samm:preferredName "Result"@en ;
+    samm:description "Result or assessment of a test; unit or category depends on context."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :resultEvaluation a samm:Property ;
     samm:preferredName "Result Evaluation"@en ;
+    samm:description "Assessment or interpretation of the test result."@en ;
     samm:characteristic :PhraseList .
 
 :resultEvaluationScore a samm:Property ;
     samm:preferredName "Result Evaluation Score"@en ;
+    samm:description "Assessment score of a test result; scale depends on method."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :results a samm:Property ;
     samm:preferredName "Results"@en ;
+    samm:description "Results of a test or assessment; unit depends on context."@en ;
     samm:characteristic :PhraseList .
 
 :revisionDate a samm:Property ;
     samm:preferredName "Revision Date"@en ;
     samm:description "Date of revision: The date of the last revision of the SDS document. See also EditingDate."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "2026-07-20"^^xsd:date ;
     samm:characteristic :DateCharacteristic .
 
 :riskManagementMeasures a samm:Property ;
     samm:preferredName "Risk Management Measures"@en ;
+    samm:description "risk management measures to limit exposure and emissions."@en ;
     samm:characteristic :RiskManagementMeasuresCharacteristic .
 
 :rmmControlBandingApproach a samm:Property ;
     samm:preferredName "Rmm Control Banding Approach"@en ;
+    samm:description "Control-banding approach to derive risk management measures; model or category."@en ;
     samm:characteristic :RmmControlBandingApproachList .
 
 :rmmEnvironment a samm:Property ;
     samm:preferredName "Rmm Environment"@en ;
+    samm:description "Environmental risk management measure."@en ;
     samm:characteristic :PhraseList .
 
 :rmmPictogram a samm:Property ;
     samm:preferredName "Rmm Pictogram"@en ;
+    samm:description "Pictogram for risk management measure; coded symbol"@en ;
     samm:characteristic samm-c:Text .
 
 :rmmWorker a samm:Property ;
     samm:preferredName "Rmm Worker"@en ;
+    samm:description "Worker-related risk management measure."@en ;
     samm:characteristic :PhraseList .
 
 :role a samm:Property ;
@@ -3410,6 +4004,7 @@
     samm:preferredName "Role Code"@en ;
     samm:description "Description of role: To describe an actor’s role. Accepted values: Responsible company, National responsible, Manufacturer, Importer, Only representative, Reimporter, Formulator, Distributor, Downstream user, Foreign manufacturer"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Responsible company"^^xsd:string ;
     samm:characteristic :RoleDescriptionEnumCharacteristic .
 
 :roleDescription a samm:Property ;
@@ -3419,14 +4014,18 @@
 
 :route a samm:Property ;
     samm:preferredName "Route"@en ;
+    samm:description "Short designation of the exposure route."@en ;
+    samm:exampleValue "Inhalation"^^xsd:string ;
     samm:characteristic :ExposureRouteEnumCharacteristic .
 
 :routeFulltext a samm:Property ;
     samm:preferredName "Route Fulltext"@en ;
+    samm:description "full text exposure route."@en ;
     samm:characteristic :PhraseList .
 
 :safeHandling a samm:Property ;
     samm:preferredName "Safe Handling"@en ;
+    samm:description "Advice on safe handling including protective, hygiene and environmental measures."@en ;
     samm:characteristic :SafeHandlingCharacteristic .
 
 :safeHandlingOfGasContainers a samm:Property ;
@@ -3441,21 +4040,25 @@
 
 :safetyCharacteristics a samm:Property ;
     samm:preferredName "Safety Characteristics"@en ;
+    samm:description "Safety characteristics, e.g. explosion limits, burning velocity or ignition temperature."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysicalHazardsSafetyCharacteristicsList .
 
 :safetyParameter a samm:Property ;
     samm:preferredName "Safety Parameter"@en ;
+    samm:description "Safety parameter tested or reported."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
 :safetyRelevantInformation a samm:Property ;
     samm:preferredName "Safety Relevant Information"@en ;
+    samm:description "Safety-relevant physical and chemical information according to SDS section 9."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :SafetyRelevantInformationCharacteristic .
 
 :safetyResult a samm:Property ;
     samm:preferredName "Safety Result"@en ;
+    samm:description "Result for the safety parameter; unit depends on the parameter."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueCharacteristic .
 
@@ -3466,20 +4069,24 @@
 
 :scaleOfUse a samm:Property ;
     samm:preferredName "Scale Of Use"@en ;
+    samm:description "Scale of use or amount used; qualitative information or Menge with unit."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :screeningProcedures a samm:Property ;
     samm:preferredName "Screening Procedures"@en ;
+    samm:description "Screening procedure for assessing a property or hazard."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysicalHazardsScreeningProceduresList .
 
 :screeningResult a samm:Property ;
     samm:preferredName "Screening Result"@en ;
+    samm:description "Result of a screening procedure; qualitative or quantitative information."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :screeningType a samm:Property ;
     samm:preferredName "Screening Type"@en ;
+    samm:description "type of screening procedure used."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
@@ -3499,12 +4106,14 @@
     samm:preferredName "Sdscom Subset"@en ;
     samm:description "Reference to the SDScomXML subsets SDScomBau and SDScomChem containing SDSComXML fields. More informaion to SDScomBau and SDScomChem are available at www.sdbtransfer.de"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "SdsComXml Light"^^xsd:string ;
     samm:characteristic :SdscomSubsetEnumCharacteristic .
 
 :sdscomVersionNo a samm:Property ;
     samm:preferredName "Sdscom Version No"@en ;
     samm:description "The version of the eSDScom standard which is applied in the transmission of information. This version number also denotes the minimum version number for eSDScom phrase IDs referenced in the XML file. For backward compatibility, the tag name is still SDScom, although the standard now includes ESCom exposure scenarios and is thus named eSDScom."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "5.6"^^xsd:string ;
     samm:characteristic :SdscomVersionEnumCharacteristic .
 
 :seaHazardClassification2021 a samm:Property ;
@@ -3521,6 +4130,7 @@
 
 :secondaryUses a samm:Property ;
     samm:preferredName "Secondary Uses"@en ;
+    samm:description "Secondary or additional uses of the product."@en ;
     samm:characteristic :EupcsCategoryList .
 
 :sectorOfUse a samm:Property ;
@@ -3536,29 +4146,35 @@
 
 :sedimentToxicity a samm:Property ;
     samm:preferredName "Sediment Toxicity"@en ;
+    samm:description "Toxicity to sediment organisms; unit typically mg/kg Sediment or mg/L."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :EcotoxicityList .
 
 :selfheatingSubstancesAndMixtures a samm:Property ;
     samm:preferredName "Selfheating Substances And Mixtures"@en ;
+    samm:description "Classification or assessment of self-heating substances and mixtures."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :SelfheatingSubstancesAndMixturesCharacteristic .
 
 :selfreactiveSubstancesAndMixtures a samm:Property ;
     samm:preferredName "Selfreactive Substances And Mixtures"@en ;
+    samm:description "Classification or assessment of self-reactive substances and mixtures."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :SelfreactiveSubstancesAndMixturesCharacteristic .
 
 :seveso a samm:Property ;
     samm:preferredName "Seveso"@en ;
+    samm:description "Seveso classification or relevance for major accident legislation."@en ;
     samm:characteristic :SevesoEuCharacteristic .
 
 :shipType a samm:Property ;
     samm:preferredName "Ship Type"@en ;
+    samm:description "ship type or tank type for bulk transport; coded value."@en ;
     samm:characteristic :PhraseList .
 
 :sicCode a samm:Property ;
     samm:preferredName "Sic Code"@en ;
+    samm:description "Norway: SIC code for industry sector or activity; coded value."@en ;
     samm:characteristic samm-c:Text .
 
 :signalWord a samm:Property ;
@@ -3569,15 +4185,18 @@
 
 :sinterTemperature a samm:Property ;
     samm:preferredName "Sinter Temperature"@en ;
+    samm:description "Sintering temperature; unit typically °C."@en ;
     samm:characteristic :PhysChemUnitValueList .
 
 :skinBodyOtherProtection a samm:Property ;
     samm:preferredName "Skin Body Other Protection"@en ;
+    samm:description "Other skin or body protection other than hand protection."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :skinCorrosionAcidicOrAlkalineReserve a samm:Property ;
     samm:preferredName "Skin Corrosion Acidic Or Alkaline Reserve"@en ;
+    samm:description "acid/alkaline reserve for assessing skin corrosion; method-dependent unit."@en ;
     samm:characteristic :SkinCorrosionAcidicOrAlkalineReserveCharacteristic .
 
 :skinCorrosionAcidicReserve a samm:Property ;
@@ -3592,54 +4211,66 @@
 
 :skinCorrosionIrritation a samm:Property ;
     samm:preferredName "Skin Corrosion Irritation"@en ;
+    samm:description "Information on skin corrosion or skin irritation."@en ;
     samm:characteristic :SkinCorrosionIrritationCharacteristic .
 
 :skinCorrosionIrritationHumanExperience a samm:Property ;
     samm:preferredName "Skin Corrosion Irritation Human Experience"@en ;
+    samm:description "Human experience on skin corrosion or skin irritation."@en ;
     samm:characteristic :PhraseList .
 
 :skinCorrosionIrritationTestResults a samm:Property ;
     samm:preferredName "Skin Corrosion Irritation Test Results"@en ;
+    samm:description "Test results on skin corrosion or skin irritation."@en ;
     samm:characteristic :CorrosionIrritationDataList .
 
 :skinHandProtectionLongTermContact a samm:Property ;
     samm:preferredName "Skin Hand Protection Long Term Contact"@en ;
+    samm:description "hand protection requirements for long-term or permanent contact."@en ;
     samm:characteristic :PhraseList .
 
 :skinHandProtectionShortTermContact a samm:Property ;
     samm:preferredName "Skin Hand Protection Short Term Contact"@en ;
+    samm:description "hand protection requirements for short-term or occasional contact."@en ;
     samm:characteristic :PhraseList .
 
 :skinProtection a samm:Property ;
     samm:preferredName "Skin Protection"@en ;
+    samm:description "body protection measures to prevent skin contact or contamination."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :SkinProtectionCharacteristic .
 
 :skinSensitisationHumanExperience a samm:Property ;
     samm:preferredName "Skin Sensitisation Human Experience"@en ;
+    samm:description "Human experience on skin sensitisation."@en ;
     samm:characteristic :PhraseList .
 
 :softeningPoint a samm:Property ;
     samm:preferredName "Softening Point"@en ;
+    samm:description "Softening point; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueList .
 
 :soilMicroorganismsToxicity a samm:Property ;
     samm:preferredName "Soil Microorganisms Toxicity"@en ;
+    samm:description "Toxicity to soil microorganisms; unit depends on the test, e.g. mg/kg soil."@en ;
     samm:characteristic :EcotoxicityList .
 
 :solidContent a samm:Property ;
     samm:preferredName "Solid Content"@en ;
+    samm:description "Solid content; unit typically % w/w."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
-    samm:characteristic :PhysChemUnitValueList .
+    samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :solidificationPoint a samm:Property ;
     samm:preferredName "Solidification Point"@en ;
+    samm:description "Solidification point; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueList .
 
 :solubilities a samm:Property ;
     samm:preferredName "Solubilities"@en ;
+    samm:description "Solubilities in water or other media; unit typically g/L, mg/L or qualitative information."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :SolubilitiesList .
 
@@ -3651,40 +4282,49 @@
 
 :solubilityDescription a samm:Property ;
     samm:preferredName "Solubility Description"@en ;
+    samm:description "Description of solubility or miscibility, e.g. soluble, partially soluble or insoluble."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :solutionExtractionBehaviourOfPolymersInWater a samm:Property ;
     samm:preferredName "Solution Extraction Behaviour Of Polymers In Water"@en ;
+    samm:description "Extraction behaviour of polymers in water; qualitative information or Masse/concentration."@en ;
     samm:characteristic :SolutionExtractionBehaviourOfPolymersInWaterList .
 
 :solventSeparationTest a samm:Property ;
     samm:preferredName "Solvent Separation Test"@en ;
-    samm:characteristic :PhysChemUnitValueList .
+    samm:description "Result of the solvent separation test; qualitative or quantitative information."@en ;
+    samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :source a samm:Property ;
     samm:preferredName "Source"@en ;
+    samm:description "Source of the information, test or assessment."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :sourcesOfSupply a samm:Property ;
     samm:preferredName "Sources Of Supply"@en ;
+    samm:description "Source of supply or supplier for equipment, product or protective article."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :specialPrecautionUser a samm:Property ;
     samm:preferredName "Special Precaution User"@en ;
+    samm:description "Special precautions for users during transport."@en ;
     samm:characteristic :PhraseList .
 
 :specialProtectiveEquipmentForFirefighters a samm:Property ;
     samm:preferredName "Special Protective Equipment For Firefighters"@en ;
+    samm:description "Special protective equipment for emergency responders, e.g. respiratory protection, protective clothing or cooling."@en ;
     samm:characteristic :PhraseList .
 
 :specialProvisions a samm:Property ;
     samm:preferredName "Special Provisions"@en ;
+    samm:description "Special provisions under dangerous goods law; coded or textual information."@en ;
     samm:characteristic samm-c:Text .
 
 :specialRulesOnPackaging a samm:Property ;
     samm:preferredName "Special Rules On Packaging"@en ;
+    samm:description "Special packaging rules under CLP/GHS, e.g. child-resistant fastening."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
@@ -3696,10 +4336,12 @@
 
 :speciesPhrase a samm:Property ;
     samm:preferredName "Species"@en ;
+    samm:description "Species tested in toxicity or ecotoxicity test; taxonomic or common name."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :speciesSpecies a samm:Property ;
     samm:preferredName "Species"@en ;
+    samm:description "test organism or species in the toxicological/ecotoxicological test."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :SpeciesCharacteristic .
 
@@ -3716,6 +4358,7 @@
 
 :specificEffect a samm:Property ;
     samm:preferredName "Specific Effect"@en ;
+    samm:description "Specific observed effect or toxicological effect."@en ;
     samm:characteristic :PhraseList .
 
 :specificEndUses a samm:Property ;
@@ -3725,6 +4368,7 @@
 
 :specificEnvironmentalReleaseCategory a samm:Property ;
     samm:preferredName "Specific Environmental Release Category"@en ;
+    samm:description "Specific environmental release category (SPERC) for the use."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :SpecificEnvironmentalReleaseCategoryList .
 
@@ -3736,25 +4380,30 @@
 
 :specificHygieneMeasures a samm:Property ;
     samm:preferredName "Specific Hygiene Measures"@en ;
+    samm:description "Specific hygiene measures, e.g. wash hands, remove contaminated clothing."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :specificTargetOrganRe a samm:Property ;
     samm:preferredName "Specific Target Organ Re"@en ;
+    samm:description "Specific target organ toxicity following repeated exposure (STOT RE)."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :SpecificTargetOrganReCharacteristic .
 
 :specificTargetOrganReHumanExperience a samm:Property ;
     samm:preferredName "Specific Target Organ Re Human Experience"@en ;
+    samm:description "Human experience for STOT RE (specific target organ toxicity repeated exposure)."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :specificTargetOrganReTestResults a samm:Property ;
     samm:preferredName "Specific Target Organ Re Test Results"@en ;
+    samm:description "Test results on STOT RE (specific target organ toxicity repeated exposure)."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :StotDataList .
 
 :specificTargetOrganSe a samm:Property ;
     samm:preferredName "Specific Target Organ Se"@en ;
+    samm:description "Specific target organ toxicity following single exposure (STOT SE)."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :SpecificTargetOrganSeCharacteristic .
 
@@ -3766,10 +4415,12 @@
 
 :specificTargetOrganSeHumanExperience a samm:Property ;
     samm:preferredName "Specific Target Organ Se Human Experience"@en ;
+    samm:description "Human experience for STOT SE (specific target organ toxicity following single exposure)."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :specificTargetOrganSeTestResults a samm:Property ;
     samm:preferredName "Specific Target Organ Se Test Results"@en ;
+    samm:description "Test results on STOT SE (specific target organ toxicity following single exposure)."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :StotDataList .
 
@@ -3781,11 +4432,13 @@
 
 :spercCode a samm:Property ;
     samm:preferredName "Sperc Code"@en ;
+    samm:description "SPERC code for specific environmental release category."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
 :spercFulltext a samm:Property ;
     samm:preferredName "Sperc Fulltext"@en ;
+    samm:description "full text SPERC designation."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
@@ -3815,33 +4468,40 @@
     samm:preferredName "State"@en ;
     samm:description "Physical state (only solid/liquid/gaseous) under standard conditions (20°C, 1013 hpa)"@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "solid"^^xsd:string ;
     samm:characteristic :StateUnderStandardConditionsEnumCharacteristic .
 
 :stateFulltext a samm:Property ;
     samm:preferredName "State Fulltext"@en ;
+    samm:description "Physical state under standard conditions."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :stateUnderStandardConditions a samm:Property ;
     samm:preferredName "State Under Standard Conditions"@en ;
-    samm:characteristic :StateUnderStandardConditionsCharacteristic .
+    samm:description "Physical state under standard conditions; gas, liquid or solid."@en ;
+    samm:characteristic :StateUnderStandardConditionsList .
 
 :stoerfallverordnung a samm:Property ;
     samm:preferredName "Stoerfallverordnung"@en ;
+    samm:description "Information on the German Major Accident Ordinance and relevant hazard categories."@en ;
     samm:characteristic :SevesoDeCharacteristic .
 
 :storageAirHumidity a samm:Property ;
     samm:preferredName "Storage Air Humidity"@en ;
+    samm:description "Permitted or recommended storage humidity; typically expressed in % relative humidity."@en ;
     samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :storageClassCh a samm:Property ;
     samm:preferredName "Storage Class Ch"@en ;
     samm:description "Classification of the chemical in accordance with Swiss guidance on storage. See https://www.kvu.ch/de/arbeitsgruppen?id=151"@en ;
+    samm:exampleValue "1"^^xsd:string ;
     samm:characteristic :StorageClassEnumChCharacteristic .
 
 :storageClassDe a samm:Property ;
     samm:preferredName "Storage Class De"@en ;
     samm:description "German storage class: Classification of the chemical in accordance with German regulation."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "1"^^xsd:string ;
     samm:characteristic :StorageClassEnumDeCharacteristic .
 
 :storagePrecautions a samm:Property ;
@@ -3851,6 +4511,7 @@
 
 :storagePressure a samm:Property ;
     samm:preferredName "Storage Pressure"@en ;
+    samm:description "Permitted or recommended storage pressure; unit typically Pa, kPa, hPa or bar."@en ;
     samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :storageStability a samm:Property ;
@@ -3861,30 +4522,39 @@
 
 :storageTemperature a samm:Property ;
     samm:preferredName "Storage Temperature"@en ;
+    samm:description "Permitted or recommended storage temperature; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :suCode a samm:Property ;
     samm:preferredName "Su Code"@en ;
+    samm:description "REACH SU code for sector of use."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "SU1"^^xsd:string ;
     samm:characteristic :SectorOfUseCodeEnumCharacteristic .
 
 :suFulltext a samm:Property ;
     samm:preferredName "Su Fulltext"@en ;
+    samm:description "full text sector of use (SU)."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
 :sublimationPoint a samm:Property ;
     samm:preferredName "Sublimation Point"@en ;
+    samm:description "Sublimation point; unit typically °C."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueList .
 
 :subrisk a samm:Property ;
     samm:preferredName "Subrisk"@en ;
+    samm:description "Subsidiary risk in the transport context; Gefahrklasse or code."@en ;
+    samm:exampleValue "1"^^xsd:string ;
     samm:characteristic :TransportClassEnumCharacteristic .
 
 :subsidiaryRisk a samm:Property ;
     samm:preferredName "Subsidiary Risk"@en ;
+    samm:description "Subsidiary risk(s) in dangerous goods transport; danger label/class information."@en ;
+    samm:exampleValue "1"^^xsd:string ;
     samm:characteristic :TransportClassEnumCharacteristic .
 
 :substanceIdentifiers a samm:Property ;
@@ -3894,51 +4564,63 @@
 
 :substancesWhichInContactWithWaterEmitFlammableGases a samm:Property ;
     samm:preferredName "Substances Which In Contact With Water Emit Flammable Gases"@en ;
+    samm:description "Assessment of substances/mixtures, which emit flammable gases in contact with water."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :SubstancesWhichInContactWithWaterEmitFlammableGasesCharacteristic .
 
 :suitableEyeProtection a samm:Property ;
     samm:preferredName "Suitable Eye Protection"@en ;
+    samm:description "Suitable eye protection equipment according to hazard and exposure potential."@en ;
     samm:characteristic :PhraseList .
 
 :suitableGlovesType a samm:Property ;
     samm:preferredName "Suitable Gloves Type"@en ;
+    samm:description "Suitable glove type according to contact type and exposure duration."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
 :suitableMaterial a samm:Property ;
     samm:preferredName "Suitable Material"@en ;
+    samm:description "Suitable material, e.g. nitrile, butyl rubber or Viton, depending on resistance."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
 :suitableProtectiveClothing a samm:Property ;
     samm:preferredName "Suitable Protective Clothing"@en ;
+    samm:description "Suitable protective clothing according to substance properties and exposure."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :suitableRespiratoryProtectionEquipment a samm:Property ;
     samm:preferredName "Suitable Respiratory Protection Equipment"@en ;
+    samm:description "Suitable respiratory protective equipment including filter class or device type."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :sumiReference a samm:Property ;
     samm:preferredName "Sumi Reference"@en ;
+    samm:description "Reference to SUMI/Safe Use of Mixtures Information; identifier or source."@en ;
     samm:characteristic :SumiReferenceCharacteristic .
 
 :summaryRmMeasures a samm:Property ;
     samm:preferredName "Summary Rm Measures"@en ;
+    samm:description "Summary of risk management measures for safe use."@en ;
     samm:characteristic :SummaryRmMeasuresCharacteristic .
 
 :summaryRmMeasuresEnvironm a samm:Property ;
     samm:preferredName "Summary Rm Measures Environm"@en ;
+    samm:description "Summary of environmental risk management measures."@en ;
     samm:characteristic :PhraseList .
 
 :summaryRmMeasuresMan a samm:Property ;
     samm:preferredName "Summary Rm Measures Man"@en ;
+    samm:description "Summary of worker-related risk management measures."@en ;
     samm:characteristic :PhraseList .
 
 :supplementalHazard a samm:Property ;
     samm:preferredName "Supplemental Hazard"@en ;
+    samm:description "Supplemental hazard information or EUH/additional statement."@en ;
+    samm:exampleValue "006"^^xsd:string ;
     samm:characteristic :Atp12SupplementalHazardInformationEnumCharacteristic .
 
 :supplementalHazardInformation a samm:Property ;
@@ -3954,6 +4636,7 @@
 
 :surfaceTension a samm:Property ;
     samm:preferredName "Surface Tension"@en ;
+    samm:description "Surface tension; typically expressed in mN/m."@en ;
     samm:characteristic :SurfaceTensionList .
 
 :swedReference a samm:Property ;
@@ -3963,11 +4646,13 @@
 
 :symptomsAndEffectsGeneral a samm:Property ;
     samm:preferredName "Symptoms And Effects General"@en ;
+    samm:description "most important acute and delayed symptoms and effects after exposure."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :symptomsOfExposure a samm:Property ;
     samm:preferredName "Symptoms Of Exposure"@en ;
+    samm:description "Symptoms after exposure, structured by route of exposure or effect."@en ;
     samm:characteristic :SymptomsOfExposureCharacteristic .
 
 :systemUsedInPreparation a samm:Property ;
@@ -3978,6 +4663,7 @@
 
 :taLuft a samm:Property ;
     samm:preferredName "Ta Luft"@en ;
+    samm:description "Information on TA Luft, e.g. substance class, number or mass fraction."@en ;
     samm:characteristic :TaLuftList .
 
 :tactileWarning a samm:Property ;
@@ -3992,15 +4678,18 @@
 
 :task a samm:Property ;
     samm:preferredName "Task"@en ;
+    samm:description "Description of the task or use activity in the risk management context."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :tasksNeedingRespiratoryProtection a samm:Property ;
     samm:preferredName "Tasks Needing Respiratory Protection"@en ;
+    samm:description "Tasks where respiratory protection is required or recommended."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :technicalMeasures a samm:Property ;
     samm:preferredName "Technical Measures"@en ;
+    samm:description "Technical risk reduction measures, e.g. enclosure, ventilation or containment."@en ;
     samm:characteristic :PhraseList .
 
 :technicalMeasuresAndStorageConditions a samm:Property ;
@@ -4010,48 +4699,60 @@
 
 :technicalSigns a samm:Property ;
     samm:preferredName "Technical Signs"@en ;
+    samm:description "Technical labels or signs on installations or work equipment."@en ;
     samm:characteristic samm-c:Text .
 
 :terrestrialToxicity a samm:Property ;
     samm:preferredName "Terrestrial Toxicity"@en ;
+    samm:description "Toxicity to terrestrial organisms; unit typically mg/kg soil."@en ;
     samm:characteristic :TerrestrialToxicityCharacteristic .
 
 :testDate a samm:Property ;
     samm:preferredName "Test Date"@en ;
+    samm:description "date of test or analysis."@en ;
+    samm:exampleValue "2026-07-20"^^xsd:date ;
     samm:characteristic :DateCharacteristic .
 
 :testDuration a samm:Property ;
     samm:preferredName "Test Duration"@en ;
+    samm:description "Duration of a test or exposure; unit typically min, h or d."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :testMaterial a samm:Property ;
     samm:preferredName "Test Material"@en ;
+    samm:description "Tested matrix or sample, e.g. blood, urine, air, water, soil or test material."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :testMethod a samm:Property ;
     samm:preferredName "Test Method"@en ;
+    samm:description "test method or test guideline, e.g. OECD or internal method."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :testPerformed a samm:Property ;
     samm:preferredName "Test Performed"@en ;
+    samm:description "Indicates whether a test was performed; yes/no or test description."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :TestPerformedList .
 
 :testReference a samm:Property ;
     samm:preferredName "Test Reference"@en ;
+    samm:description "Reference to test report, method, standard or literature source."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :testResult a samm:Property ;
     samm:preferredName "Test Result"@en ;
+    samm:description "Result of a test; unit depends on the endpoint."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :testResults a samm:Property ;
     samm:preferredName "Test Results"@en ;
+    samm:description "test results or result summary; unit depends on the test."@en ;
     samm:characteristic :PhraseList .
 
 :text a samm:Property ;
     samm:preferredName "Text"@en ;
+    samm:description "Suisse: data field in the area of EU-specific information; content as structured value, code or phrase."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :theoreticalCarbonDioxideAmount a samm:Property ;
@@ -4066,16 +4767,19 @@
 
 :thermalHazardsProtection a samm:Property ;
     samm:preferredName "Thermal Hazards Protection"@en ;
+    samm:description "Protective measures against thermal hazards, e.g. heat, cold or burns."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :thicknessOfGloveMaterial a samm:Property ;
     samm:preferredName "Thickness Of Glove Material"@en ;
+    samm:description "Glove material thickness; typically expressed in mm."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :title a samm:Property ;
     samm:preferredName "Title"@en ;
+    samm:description "Title or designation of the section, scenario or information block."@en ;
     samm:characteristic :PhraseList .
 
 :totalOrganicCarbon a samm:Property ;
@@ -4085,10 +4789,12 @@
 
 :toxicokineticInfo a samm:Property ;
     samm:preferredName "Toxicokinetic Info"@en ;
+    samm:description "Information on absorption, distribution, metabolism and excretion."@en ;
     samm:characteristic :ToxicokineticInfoCharacteristic .
 
 :toxicologicalInformationToxicologicalInformation a samm:Property ;
     samm:preferredName "Toxicological Information"@en ;
+    samm:description "Toxicological information on health hazards, exposure experience and test results."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ToxicologicalInformationCharacteristic .
 
@@ -4105,6 +4811,7 @@
 
 :transportInBulk a samm:Property ;
     samm:preferredName "Transport In Bulk"@en ;
+    samm:description "Information on bulk transport, e.g. MARPOL/IBC or ADN/ADR context."@en ;
     samm:characteristic :TransportInBulkCharacteristic .
 
 :transportInformation a samm:Property ;
@@ -4115,10 +4822,12 @@
 
 :transportType a samm:Property ;
     samm:preferredName "Transport Type"@en ;
+    samm:description "type of environmental transport or pathway, e.g. water, soil, air or sediment."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :type a samm:Property ;
     samm:preferredName "Type"@en ;
+    samm:description "type or category of the named element; coded or described by phrase."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :TypeList .
 
@@ -4130,31 +4839,43 @@
 
 :typeDoseEnum a samm:Property ;
     samm:preferredName "Type"@en ;
+    samm:description "type of dose information, e.g. LD50, NOAEL or LOAEL."@en ;
+    samm:exampleValue "NOEC"^^xsd:string ;
     samm:characteristic :DoseEnumCharacteristic .
 
 :typeEffectLevelTypeEnum a samm:Property ;
     samm:preferredName "Type"@en ;
+    samm:description "type of effect level, e.g. acute/long-term, local/systemic; coded value."@en ;
+    samm:exampleValue "Acute oral (systemic)"^^xsd:string ;
     samm:characteristic :EffectLevelTypeEnumCharacteristic .
 
 :typeFulltext a samm:Property ;
     samm:preferredName "Type Fulltext"@en ;
+    samm:description "full text description of the effect level type."@en ;
     samm:characteristic :PhraseList .
 
 :typePnecTypeEnum a samm:Property ;
     samm:preferredName "Type"@en ;
+    samm:description "PNEC compartment or type, e.g. freshwater, marine water, soil, sediment or sewage treatment plant."@en ;
+    samm:exampleValue "Soil"^^xsd:string ;
     samm:characteristic :PnecTypeEnumCharacteristic .
 
 :typeReproductiveToxicityTypeEnum a samm:Property ;
     samm:preferredName "Type"@en ;
+    samm:description "Coded type of reproductive toxicity."@en ;
+    samm:exampleValue "sexual function"^^xsd:string ;
     samm:characteristic :ReproductiveToxicityTypeEnumCharacteristic .
 
 :typeViscosityTypeEnum a samm:Property ;
     samm:preferredName "Type"@en ;
+    samm:description "Type of viscosity, e.g. kinematic or dynamic; coded value."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Dynamic"^^xsd:string ;
     samm:characteristic :ViscosityTypeEnumCharacteristic .
 
 :ucnCode a samm:Property ;
     samm:preferredName "Ucn Code"@en ;
+    samm:description "Norway: UCN code in national product register; coded value."@en ;
     samm:characteristic samm-c:Text .
 
 :ufi a samm:Property ;
@@ -4169,49 +4890,64 @@
 
 :unit a samm:Property ;
     samm:preferredName "Unit"@en ;
+    samm:description "Unit of measure for the stated value; coded or written out."@en ;
+    samm:exampleValue "°C"^^xsd:string ;
     samm:characteristic :UnitEnumCharacteristic .
 
 :unitFulltext a samm:Property ;
     samm:preferredName "Unit Fulltext"@en ;
+    samm:description "Written-out unit of measure for the stated value."@en ;
     samm:characteristic :PhraseList .
 
 :unitValue a samm:Property ;
     samm:preferredName "Unit Value"@en ;
+    samm:description "Value with unit, e.g. numeric measured value and unit of measure."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :unknownToxicity a samm:Property ;
     samm:preferredName "Unknown Toxicity"@en ;
+    samm:description "Fraction or indication of unknown toxicity; typically expressed as % with explanatory text."@en ;
     samm:characteristic :UnknownToxicityCharacteristic .
 
 :unsuitableEyeProtection a samm:Property ;
     samm:preferredName "Unsuitable Eye Protection"@en ;
+    samm:description "Unsuitable eye protection equipment or materials for the specified application."@en ;
     samm:characteristic :PhraseList .
 
 :unsuitableMaterials a samm:Property ;
     samm:preferredName "Unsuitable Materials"@en ;
+    samm:description "Unsuitable materials, that do not provide sufficient protection or resistance."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :unsuitableProtectiveClothing a samm:Property ;
     samm:preferredName "Unsuitable Protective Clothing"@en ;
+    samm:description "Unsuitable protective clothing or materials for the described exposure."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :upperExplosionLimit a samm:Property ;
     samm:preferredName "Upper Explosion Limit"@en ;
+    samm:description "Upper explosion limit; unit typically vol.-%."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
-    samm:characteristic :PhysChemUnitValueList .
+    samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :upperTierQuantity a samm:Property ;
     samm:preferredName "Upper Tier Quantity"@en ;
+    samm:description "Upper-tier quantity threshold; typically expressed in t."@en ;
+    samm:exampleValue "42"^^xsd:integer ;
     samm:characteristic :UpperTierQuantityInlineCharacteristic .
 
 :upperValue a samm:Property ;
     samm:preferredName "Upper Value"@en ;
+    samm:description "Upper limit of a quantity or size range; unit in context."@en ;
+    samm:exampleValue "3.14"^^xsd:float ;
     samm:characteristic :FloatCharacteristic .
 
 :upperValueSymbol a samm:Property ;
     samm:preferredName "Upper Value Symbol"@en ;
+    samm:description "Comparison sign for the upper value, e.g. ≤ or <."@en ;
+    samm:exampleValue "lt"^^xsd:string ;
     samm:characteristic :UpperQualifierEnumCharacteristic .
 
 :url a samm:Property ;
@@ -4222,16 +4958,19 @@
 
 :use a samm:Property ;
     samm:preferredName "Use"@en ;
+    samm:description "General use or purpose of the product."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :useAdvisedAgainst a samm:Property ;
     samm:preferredName "Use Advised Against"@en ;
+    samm:description "Uses advised against, including justification where applicable."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseList .
 
 :useDescriptors a samm:Property ;
     samm:preferredName "Use Descriptors"@en ;
+    samm:description "REACH use descriptors, e.g. SU, PROC, PC, ERC, AC or SPERC."@en ;
     samm:characteristic :UseDescriptorsCharacteristic .
 
 :userId a samm:Property ;
@@ -4242,41 +4981,53 @@
 
 :valueFloat a samm:Property ;
     samm:preferredName "Value"@en ;
+    samm:description "Numeric value as floating-point number; unit follows from context or associated unit field."@en ;
+    samm:exampleValue "3.14"^^xsd:float ;
     samm:characteristic :FloatCharacteristic .
 
 :valueNumericRangeWithQualifier a samm:Property ;
     samm:preferredName "Value"@en ;
+    samm:description "Numeric value or range with qualifier, e.g. <, >, approx. or interval."@en ;
     samm:characteristic :NumericRangeWithQualifierCharacteristic .
 
 :valueNumericRangeWithUnitAndQualifier a samm:Property ;
     samm:preferredName "Value"@en ;
+    samm:description "Numeric value or range with unit and qualifier, e.g. >, <, approx. or interval."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :valuePhrase a samm:Property ;
     samm:preferredName "Value"@en ;
+    samm:description "Textual value or characteristic of a property."@en ;
     samm:characteristic :PhraseCharacteristic .
 
 :valuePhysChemUnitValue a samm:Property ;
     samm:preferredName "Value"@en ;
+    samm:description "Physical and chemical value with unit, e.g. temperature, pressure or concentration."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueCharacteristic .
 
 :valuePhysChemUnitValueWithTemperature a samm:Property ;
     samm:preferredName "Value"@en ;
-    samm:characteristic :PhysChemUnitValueWithTemperatureCharacteristic .
+    samm:description "If the product has a low solubility or is insoluble in the specified medium, and if there is no numerical translation of this circumstance, put the respective phrase in AdditionalInfo. (see issue #71)"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
 
 :valuePhysChemValueWithTemperature a samm:Property ;
     samm:preferredName "Value"@en ;
+    samm:description "Physical and chemical value with associated temperature; unit depends on the parameter."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemValueWithTemperatureCharacteristic .
 
 :vapourPressure a samm:Property ;
     samm:preferredName "Vapour Pressure"@en ;
+    samm:description "Vapour pressure; unit typically hPa, kPa or Pa."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhysChemUnitValueWithTemperatureList .
 
 :vbfClass a samm:Property ;
     samm:preferredName "Vbf Class"@en ;
+    samm:description "Vbf Class: Flammable liquid class Austia, content as structured value or code."@en ;
+    samm:exampleValue "A I"^^xsd:string ;
     samm:characteristic :VbfClassCharacteristic .
 
 :versionNo a samm:Property ;
@@ -4292,23 +5043,28 @@
 
 :viscosity a samm:Property ;
     samm:preferredName "Viscosity"@en ;
+    samm:description "Viscosity; unit typically mm²/s or mPa·s."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :ViscosityList .
 
 :visitingAddressCity a samm:Property ;
     samm:preferredName "Visiting Address City"@en ;
+    samm:description "city of the visiting address."@en ;
     samm:characteristic samm-c:Text .
 
 :visitingAddressLine1 a samm:Property ;
     samm:preferredName "Visiting Address Line1"@en ;
+    samm:description "First line of the visiting address."@en ;
     samm:characteristic samm-c:Text .
 
 :visitingAddressLine2 a samm:Property ;
     samm:preferredName "Visiting Address Line2"@en ;
+    samm:description "Second line of the visiting address."@en ;
     samm:characteristic samm-c:Text .
 
 :visitingAddressLine3 a samm:Property ;
     samm:preferredName "Visiting Address Line3"@en ;
+    samm:description "Third line of the visiting address."@en ;
     samm:characteristic samm-c:Text .
 
 :visitingAddressPostCode a samm:Property ;
@@ -4324,6 +5080,7 @@
 
 :vocInPercentByWeight a samm:Property ;
     samm:preferredName "Voc In Percent By Weight"@en ;
+    samm:description "VOC content as mass fraction; unit % w/w."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PercentageRangeCharacteristic .
 
@@ -4352,11 +5109,13 @@
 
 :wasteCodeWasteCode a samm:Property ;
     samm:preferredName "Waste Code"@en ;
+    samm:description "Waste code according to the applicable waste catalogue, e.g. EWC/AVV-code; coded value."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic samm-c:Text .
 
 :wasteDescription a samm:Property ;
     samm:preferredName "Waste Description"@en ;
+    samm:description "Description of the disposal or disposal type, aligned with the waste code and disposal route."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
     samm:characteristic :PhraseCharacteristic .
 
@@ -4372,22 +5131,27 @@
 
 :waterHazardClass a samm:Property ;
     samm:preferredName "Water Hazard Class"@en ;
+    samm:description "Water hazard class (WGK) under German law; coded value."@en ;
     samm:characteristic :WaterHazardClassCharacteristic .
 
 :waterReactive a samm:Property ;
     samm:preferredName "Water Reactive"@en ;
+    samm:description "Indicates whether the substance or mixture reacts with water; yes/no or assessment."@en ;
     samm:characteristic :PhraseList .
 
 :weightAverageMolecularWeight a samm:Property ;
     samm:preferredName "Weight Average Molecular Weight"@en ;
+    samm:description "Weight-average molecular weight Mw; unit typically g/mol."@en ;
     samm:characteristic :PhysChemUnitValueList .
 
 :weightFraction a samm:Property ;
     samm:preferredName "Weight Fraction"@en ;
+    samm:description "Mass fraction; typically expressed in %."@en ;
     samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
 
 :whmis2015HazardClassification a samm:Property ;
     samm:preferredName "Whmis2015Hazard Classification"@en ;
+    samm:description "Hazard classification according to WHMIS 2015; classes, categories and H-statements."@en ;
     samm:characteristic :Whmis2015HazardClassificationCharacteristic .
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -4396,1526 +5160,1799 @@
 
 :AbntNrb2015HazardClassificationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Abnt Nrb2015Hazard Classification Characteristic"@en ;
+    samm:description "Single Abnt Nrb2015Hazard Classification value."@en ;
     samm:dataType :AbntNrb2015HazardClassification .
 
 :AbntNrb2017HazardLabellingCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Abnt Nrb2017Hazard Labelling Characteristic"@en ;
+    samm:description "Single Abnt Nrb2017Hazard Labelling value."@en ;
     samm:dataType :AbntNrb2017HazardLabelling .
 
 :AbntNrb2019HazardClassificationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Abnt Nrb2019Hazard Classification Characteristic"@en ;
+    samm:description "Single Abnt Nrb2019Hazard Classification value."@en ;
     samm:dataType :AbntNrb2019HazardClassification .
 
 :AccidentalReleaseMeasuresCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Accidental Release Measures Characteristic"@en ;
+    samm:description "Single Accidental Release Measures value."@en ;
     samm:dataType :AccidentalReleaseMeasures .
 
 :AcuteToxicityCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Acute Toxicity Characteristic"@en ;
+    samm:description "Single Acute Toxicity value."@en ;
     samm:dataType :AcuteToxicity .
 
 :AdditionalEcotoxInformationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Additional Ecotox Information Characteristic"@en ;
+    samm:description "Single Additional Ecotox Information value."@en ;
     samm:dataType :AdditionalEcotoxInformation .
 
 :AddressCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Address Characteristic"@en ;
+    samm:description "Single Address value."@en ;
     samm:dataType :Address .
 
 :AdnCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Adn Characteristic"@en ;
+    samm:description "Single Adn value."@en ;
     samm:dataType :Adn .
 
 :AdrRidCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Adr Rid Characteristic"@en ;
+    samm:description "Single Adr Rid value."@en ;
     samm:dataType :AdrRid .
 
 :AnnexesEuCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Annexes Eu Characteristic"@en ;
+    samm:description "Single Annexes Eu value."@en ;
     samm:dataType :AnnexesEu .
 
 :AppearanceCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Appearance Characteristic"@en ;
+    samm:description "Single Appearance value."@en ;
     samm:dataType :Appearance .
 
 :AppropriateEnvionmentalExposureControlCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Appropriate Envionmental Exposure Control Characteristic"@en ;
+    samm:description "Single Appropriate Envionmental Exposure Control value."@en ;
     samm:dataType :AppropriateEnvionmentalExposureControl .
 
 :AquaticToxicityCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Aquatic Toxicity Characteristic"@en ;
+    samm:description "Single Aquatic Toxicity value."@en ;
     samm:dataType :AquaticToxicity .
 
 :ArticleCategoryCodeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Article Category Code Enum Characteristic"@en ;
+    samm:description "Allowed values for Article Category Code Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "AC1" "AC2" "AC3" "AC4" "AC5" "AC6" "AC7" "AC8" "AC10" "AC11" "AC13" "AC30" "AC31" "AC32" "AC33" "AC34" "AC35" "AC36" "AC38" "AC0" ) .
 
 :ArticleCategoryList a samm-c:List ;
     samm:preferredName "Article Category List"@en ;
+    samm:description "List of Article Category values."@en ;
     samm:dataType :ArticleCategory .
 
 :AspirationHazardCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Aspiration Hazard Characteristic"@en ;
+    samm:description "Single Aspiration Hazard value."@en ;
     samm:dataType :AspirationHazard .
 
 :AssessmentCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Assessment Characteristic"@en ;
+    samm:description "Single Assessment value."@en ;
     samm:dataType :Assessment .
 
 :AssessmentEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Assessment Enum Characteristic"@en ;
+    samm:description "Allowed values for Assessment Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "Yes" "No" "Not assessed" ) .
 
 :AteCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Ate Characteristic"@en ;
+    samm:description "Single Ate value."@en ;
     samm:dataType :Ate .
-
-:AteValueCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Ate Value Characteristic"@en ;
-    samm:dataType :AteValue .
 
 :Atp12SpecialSupplementalLabelInfoEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Atp12Special Supplemental Label Info Enum Characteristic"@en ;
+    samm:description "Allowed values for Atp12Special Supplemental Label Info Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "201" "201A" "202" "203" "204" "205" "206" "207" "208" "209" "209A" "210" "401" ) .
 
 :Atp12SpecialSupplementalLabelInfoList a samm-c:List ;
     samm:preferredName "Atp12Special Supplemental Label Info List"@en ;
+    samm:description "List of Atp12Special Supplemental Label Info values."@en ;
     samm:dataType :Atp12SpecialSupplementalLabelInfo .
 
 :Atp12SupplementalHazardInformationEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Atp12Supplemental Hazard Information Enum Characteristic"@en ;
+    samm:description "Allowed values for Atp12Supplemental Hazard Information Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "006" "014" "018" "019" "044" "029" "031" "032" "066" "070" "071" "059" ) .
 
 :BioaccumulationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Bioaccumulation Characteristic"@en ;
+    samm:description "Single Bioaccumulation value."@en ;
     samm:dataType :Bioaccumulation .
 
 :BiocidesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Biocides Characteristic"@en ;
+    samm:description "Single Biocides value."@en ;
     samm:dataType :Biocides .
 
 :BioconcentrationFactorList a samm-c:List ;
     samm:preferredName "Bioconcentration Factor List"@en ;
+    samm:description "List of Bioconcentration Factor values."@en ;
     samm:dataType :BioconcentrationFactor .
 
 :BiologicalDegradationList a samm-c:List ;
     samm:preferredName "Biological Degradation List"@en ;
+    samm:description "List of Biological Degradation values."@en ;
     samm:dataType :BiologicalDegradation .
 
 :BiologicalLimitValueList a samm-c:List ;
     samm:preferredName "Biological Limit Value List"@en ;
+    samm:description "List of Biological Limit Value values."@en ;
     samm:dataType :BiologicalLimitValue .
 
 :BiologicalLimitValuesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Biological Limit Values Characteristic"@en ;
+    samm:description "Single Biological Limit Values value."@en ;
     samm:dataType :BiologicalLimitValues .
 
 :BoilingPointRelatedCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Boiling Point Related Characteristic"@en ;
+    samm:description "Single Boiling Point Related value."@en ;
     samm:dataType :BoilingPointRelated .
 
 :CaliforniaCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "California Characteristic"@en ;
+    samm:description "Single California value."@en ;
     samm:dataType :California .
 
 :CarcinogenicityCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Carcinogenicity Characteristic"@en ;
+    samm:description "Single Carcinogenicity value."@en ;
     samm:dataType :Carcinogenicity .
 
 :CertainFluorinatedGreenhouseGasesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Certain Fluorinated Greenhouse Gases Characteristic"@en ;
+    samm:description "Single Certain Fluorinated Greenhouse Gases value."@en ;
     samm:dataType :CertainFluorinatedGreenhouseGases .
 
 :ChemicalSafetyAssessmentInfoCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Chemical Safety Assessment Info Characteristic"@en ;
+    samm:description "Single Chemical Safety Assessment Info value."@en ;
     samm:dataType :ChemicalSafetyAssessmentInfo .
 
 :ChemicalSafetyReportCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Chemical Safety Report Characteristic"@en ;
+    samm:description "Single Chemical Safety Report value."@en ;
     samm:dataType :ChemicalSafetyReport .
 
 :ClassificationArCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Classification Ar Characteristic"@en ;
+    samm:description "Single Classification Ar value."@en ;
     samm:dataType :ClassificationAr .
 
 :ClassificationAssessmentCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Classification Assessment Characteristic"@en ;
+    samm:description "Single Classification Assessment value."@en ;
     samm:dataType :ClassificationAssessment .
 
 :ClassificationBrCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Classification Br Characteristic"@en ;
+    samm:description "Single Classification Br value."@en ;
     samm:dataType :ClassificationBr .
 
 :ClassificationCaCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Classification Ca Characteristic"@en ;
+    samm:description "Single Classification Ca value."@en ;
     samm:dataType :ClassificationCa .
+
+:ClassificationCnCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Classification Cn Characteristic"@en ;
+    samm:description "Single Classification Cn value."@en ;
+    samm:dataType :ClassificationCn .
 
 :ClassificationGbCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Classification Gb Characteristic"@en ;
+    samm:description "Single Classification Gb value."@en ;
     samm:dataType :ClassificationGb .
 
 :ClassificationList a samm-c:List ;
     samm:preferredName "Classification List"@en ;
+    samm:description "List of Classification values."@en ;
     samm:dataType :Classification .
 
 :ClassificationMxCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Classification Mx Characteristic"@en ;
+    samm:description "Single Classification Mx value."@en ;
     samm:dataType :ClassificationMx .
 
 :ClassificationTrCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Classification Tr Characteristic"@en ;
+    samm:description "Single Classification Tr value."@en ;
     samm:dataType :ClassificationTr .
 
 :ClassificationUsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Classification Us Characteristic"@en ;
+    samm:description "Single Classification Us value."@en ;
     samm:dataType :ClassificationUs .
 
 :CmrDataList a samm-c:List ;
     samm:preferredName "Cmr Data List"@en ;
+    samm:description "List of Cmr Data values."@en ;
     samm:dataType :CmrData .
 
 :ColourEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Colour Enum Characteristic"@en ;
+    samm:description "Allowed values for Colour Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "colourless" "black" "blue" "brown" "gold" "green" "grey" "orange" "pink" "purple" "red" "silver" "violet" "white" "yellow" "multicolour" "colouring agent" ) .
 
 :ColourIntensityEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Colour Intensity Enum Characteristic"@en ;
+    samm:description "Allowed values for Colour Intensity Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "translucent" "light" "dark" "fluorescent" ) .
 
 :CompanyContactList a samm-c:List ;
     samm:preferredName "Company Contact List"@en ;
+    samm:description "List of Company Contact values."@en ;
     samm:dataType :CompanyContact .
 
 :CompleteSdsWithEsIncorporatedCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Complete Sds With Es Incorporated Characteristic"@en ;
+    samm:description "Single Complete Sds With Es Incorporated value."@en ;
     samm:dataType :CompleteSdsWithEsIncorporated .
 
 :CompositionCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Composition Characteristic"@en ;
+    samm:description "Single Composition value."@en ;
     samm:dataType :Composition .
 
 :ConditionsForSafeStorageCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Conditions For Safe Storage Characteristic"@en ;
+    samm:description "Single Conditions For Safe Storage value."@en ;
     samm:dataType :ConditionsForSafeStorage .
 
 :ConsumerExposureControlCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Consumer Exposure Control Characteristic"@en ;
+    samm:description "Single Consumer Exposure Control value."@en ;
     samm:dataType :ConsumerExposureControl .
 
 :ContainmentAndCleaningUpCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Containment And Cleaning Up Characteristic"@en ;
+    samm:description "Single Containment And Cleaning Up value."@en ;
     samm:dataType :ContainmentAndCleaningUp .
 
 :ControlParametersCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Control Parameters Characteristic"@en ;
+    samm:description "Single Control Parameters value."@en ;
     samm:dataType :ControlParameters .
 
 :ControlParametersEuCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Control Parameters Eu Characteristic"@en ;
+    samm:description "Single Control Parameters Eu value."@en ;
     samm:dataType :ControlParametersEu .
 
 :CorrespondingExposureScenarioList a samm-c:List ;
     samm:preferredName "Corresponding Exposure Scenario List"@en ;
+    samm:description "List of Corresponding Exposure Scenario values."@en ;
     samm:dataType :CorrespondingExposureScenario .
 
 :CorrosionIrritationDataList a samm-c:List ;
     samm:preferredName "Corrosion Irritation Data List"@en ;
+    samm:description "List of Corrosion Irritation Data values."@en ;
     samm:dataType :CorrosionIrritationData .
 
 :CorrosiveToMetalsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Corrosive To Metals Characteristic"@en ;
+    samm:description "Single Corrosive To Metals value."@en ;
     samm:dataType :CorrosiveToMetals .
 
 :CountryCodeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Country Code Enum Characteristic"@en ;
+    samm:description "Allowed values for Country Code Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "AD" "AE" "AF" "AG" "AI" "AL" "AM" "AO" "AQ" "AR" "AS" "AT" "AU" "AW" "AX" "AZ" "BA" "BB" "BD" "BE" "BF" "BG" "BH" "BI" "BJ" "BL" "BM" "BN" "BO" "BQ" "BR" "BS" "BT" "BV" "BW" "BY" "BZ" "CA" "CC" "CD" "CF" "CG" "CH" "CI" "CK" "CL" "CM" "CN" "CO" "CR" "CU" "CV" "CW" "CX" "CY" "CZ" "DE" "DJ" "DK" "DM" "DO" "DZ" "EC" "EE" "EG" "EH" "ER" "ES" "ET" "FI" "FJ" "FK" "FM" "FO" "FR" "GA" "GB" "GD" "GE" "GF" "GG" "GH" "GI" "GL" "GM" "GN" "GP" "GQ" "GR" "GS" "GT" "GU" "GW" "GY" "HK" "HM" "HN" "HR" "HT" "HU" "ID" "IE" "IL" "IM" "IN" "IO" "IQ" "IR" "IS" "IT" "JE" "JM" "JO" "JP" "KE" "KG" "KH" "KI" "KM" "KN" "KP" "KR" "KW" "KY" "KZ" "LA" "LB" "LC" "LI" "LK" "LR" "LS" "LT" "LU" "LV" "LY" "MA" "MC" "MD" "ME" "MF" "MG" "MH" "MK" "ML" "MM" "MN" "MO" "MP" "MQ" "MR" "MS" "MT" "MU" "MV" "MW" "MX" "MY" "MZ" "NA" "NC" "NE" "NF" "NG" "NI" "NL" "NO" "NP" "NR" "NU" "NZ" "OM" "PA" "PE" "PF" "PG" "PH" "PK" "PL" "PM" "PN" "PR" "PS" "PT" "PW" "PY" "QA" "RE" "RO" "RS" "RU" "RW" "SA" "SB" "SC" "SD" "SE" "SG" "SH" "SI" "SJ" "SK" "SL" "SM" "SN" "SO" "SR" "SS" "ST" "SV" "SX" "SY" "SZ" "TC" "TD" "TF" "TG" "TH" "TJ" "TK" "TL" "TM" "TN" "TO" "TR" "TT" "TV" "TW" "TZ" "UA" "UG" "UM" "US" "UY" "UZ" "VA" "VC" "VE" "VG" "VI" "VN" "VU" "WF" "WS" "YE" "YT" "ZA" "ZM" "ZW" ) .
 
 :DatasheetList a samm-c:List ;
     samm:preferredName "Datasheet List"@en ;
+    samm:description "List of Datasheet values."@en ;
     samm:dataType :Datasheet .
 
 :DateCharacteristic a samm:Characteristic ;
     samm:preferredName "Date Characteristic"@en ;
+    samm:description "Value of XSD type xsd:date."@en ;
     samm:dataType xsd:date .
 
 :DegradationEliminationList a samm-c:List ;
     samm:preferredName "Degradation Elimination List"@en ;
+    samm:description "List of Degradation Elimination values."@en ;
     samm:dataType :DegradationElimination .
 
 :DensitiesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Densities Characteristic"@en ;
+    samm:description "Single Densities value."@en ;
     samm:dataType :Densities .
 
 :DescriptionOfFirstAidMeasuresCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Description Of First Aid Measures Characteristic"@en ;
+    samm:description "Single Description Of First Aid Measures value."@en ;
     samm:dataType :DescriptionOfFirstAidMeasures .
 
 :DetergentsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Detergents Characteristic"@en ;
+    samm:description "Single Detergents value."@en ;
     samm:dataType :Detergents .
 
 :DisposalConsiderationsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Disposal Considerations Characteristic"@en ;
+    samm:description "Single Disposal Considerations value."@en ;
     samm:dataType :DisposalConsiderations .
 
 :DisposalConsiderationsEuCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Disposal Considerations Eu Characteristic"@en ;
+    samm:description "Single Disposal Considerations Eu value."@en ;
     samm:dataType :DisposalConsiderationsEu .
 
 :DisposalConsiderationsUsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Disposal Considerations Us Characteristic"@en ;
+    samm:description "Single Disposal Considerations Us value."@en ;
     samm:dataType :DisposalConsiderationsUs .
 
 :DissociationConstantList a samm-c:List ;
     samm:preferredName "Dissociation Constant List"@en ;
+    samm:description "List of Dissociation Constant values."@en ;
     samm:dataType :DissociationConstant .
 
 :DmelList a samm-c:List ;
     samm:preferredName "Dmel List"@en ;
+    samm:description "List of Dmel values."@en ;
     samm:dataType :Dmel .
 
 :DnelList a samm-c:List ;
     samm:preferredName "Dnel List"@en ;
+    samm:description "List of Dnel values."@en ;
     samm:dataType :Dnel .
 
 :DoseCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Dose Characteristic"@en ;
+    samm:description "Single Dose value."@en ;
     samm:dataType :Dose .
 
 :DoseEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Dose Enum Characteristic"@en ;
+    samm:description "Allowed values for Dose Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "NOEC" "LOEC" "NOEL" "LOEL" "NOAEL" "LOAEL" "LC0" "LCLo" "LC50" "LC100" "LD0" "LDLo" "LD50" "LD100" "EC0" "EC3" "EC10" "EC20" "EC25" "EC50" "EC50 (+ UVA)" "EC50 (- UVA)" "EC80" "ATEmix" "cATpE" "ERC50" "ERCLo" "IC50" "other" ) .
 
 :EcologicalInformationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Ecological Information Characteristic"@en ;
+    samm:description "Single Ecological Information value."@en ;
     samm:dataType :EcologicalInformation .
 
 :EcotoxicityAquaticList a samm-c:List ;
     samm:preferredName "Ecotoxicity Aquatic List"@en ;
+    samm:description "List of Ecotoxicity Aquatic values."@en ;
     samm:dataType :EcotoxicityAquatic .
 
 :EcotoxicityList a samm-c:List ;
     samm:preferredName "Ecotoxicity List"@en ;
+    samm:description "List of Ecotoxicity values."@en ;
     samm:dataType :Ecotoxicity .
 
 :EcotoxicologicalInformationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Ecotoxicological Information Characteristic"@en ;
+    samm:description "Single Ecotoxicological Information value."@en ;
     samm:dataType :EcotoxicologicalInformation .
 
 :EffectLevelGroupEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Effect Level Group Enum Characteristic"@en ;
+    samm:description "Allowed values for Effect Level Group Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "Worker" "Consumer" ) .
 
 :EffectLevelTypeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Effect Level Type Enum Characteristic"@en ;
+    samm:description "Allowed values for Effect Level Type Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "Acute oral (systemic)" "Long-term oral (systemic)" "Acute dermal (local)" "Acute dermal (systemic)" "Long-term dermal (local)" "Long-term dermal (systemic)" "Acute inhalation (local)" "Acute inhalation (systemic)" "Long-term inhalation (local)" "Long-term inhalation (systemic)" ) .
 
 :EmergencyPhoneList a samm-c:List ;
     samm:preferredName "Emergency Phone List"@en ;
+    samm:description "List of Emergency Phone values."@en ;
     samm:dataType :EmergencyPhone .
-
-:EnvironmentalExposureControlsCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Environmental Exposure Controls Characteristic"@en ;
-    samm:dataType :EnvironmentalExposureControls .
 
 :EnvironmentalReleaseCategoryCodeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Environmental Release Category Code Enum Characteristic"@en ;
+    samm:description "Allowed values for Environmental Release Category Code Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "ERC1" "ERC2" "ERC3" "ERC4" "ERC5" "ERC6a" "ERC6b" "ERC6c" "ERC6d" "ERC7" "ERC8a" "ERC8b" "ERC8c" "ERC8d" "ERC8e" "ERC8f" "ERC9a" "ERC9b" "ERC10a" "ERC10b" "ERC11a" "ERC11b" "ERC12a" "ERC12b" ) .
 
 :EnvironmentalReleaseCategoryList a samm-c:List ;
     samm:preferredName "Environmental Release Category List"@en ;
+    samm:description "List of Environmental Release Category values."@en ;
     samm:dataType :EnvironmentalReleaseCategory .
 
 :EquipmentList a samm-c:List ;
     samm:preferredName "Equipment List"@en ;
+    samm:description "List of Equipment values."@en ;
     samm:dataType :Equipment .
 
 :EsdscomPhraseCatalogueIdCharacteristic a samm:Characteristic ;
     samm:preferredName "Esdscom Phrase Catalogue Id Characteristic"@en ;
+    samm:description "Value of XSD type xsd:integer."@en ;
     samm:dataType xsd:integer .
 
 :EsdscomPhraseIdCharacteristic a samm:Characteristic ;
     samm:preferredName "Esdscom Phrase Id Characteristic"@en ;
+    samm:description "Value of XSD type xsd:integer."@en ;
     samm:dataType xsd:integer .
 
 :EuLegislationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Eu Legislation Characteristic"@en ;
+    samm:description "Single Eu Legislation value."@en ;
     samm:dataType :EuLegislation .
 
 :EupcsCategoryCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Eupcs Category Characteristic"@en ;
+    samm:description "Single Eupcs Category value."@en ;
     samm:dataType :EupcsCategory .
 
 :EupcsCategoryCodeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Eupcs Category Code Enum Characteristic"@en ;
+    samm:description "Allowed values for Eupcs Category Code Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "F" "PC-ADH-1" "PC-ADH-2" "PC-ADH-3" "PC-ADH-4" "PC-ADH-5" "PC-ADH-6" "PC-ADH-7" "PC-ADH-8" "PC-ADH-OTH" "PC-AIR-1" "PC-AIR-2" "PC-AIR-3" "PC-AIR-4" "PC-AIR-5" "PC-AIR-6" "PC-AIR-7" "PC-AIR-8" "PC-AIR-OTH" "PC-ANI-1" "PC-ANI-2" "PC-ANI-OTH" "PC-ART-1" "PC-ART-2" "PC-ART-3" "PC-ART-4" "PC-ART-5" "PC-ART-6" "PC-ART-OTH" "PC-CLN-1" "PC-CLN-2" "PC-CLN-3" "PC-CLN-4" "PC-CLN-5" "PC-CLN-6" "PC-CLN-7" "PC-CLN-8" "PC-CLN-9" "PC-CLN-10.1" "PC-CLN-10.2" "PC-CLN-10.3" "PC-CLN-10.4" "PC-CLN-10.OTH" "PC-CLN-11.1" "PC-CLN-11.2" "PC-CLN-11.3" "PC-CLN-11.OTH" "PC-CLN-12.1" "PC-CLN-12.2" "PC-CLN-12.3" "PC-CLN-12.OTH" "PC-CLN-13.2" "PC-CLN-13.3" "PC-CLN-13.4" "PC-CLN-13.OTH" "PC-CLN-14.1" "PC-CLN-14.2" "PC-CLN-14.OTH" "PC-CLN-15.1" "PC-CLN-15.2" "PC-CLN-15.3" "PC-CLN-15.4" "PC-CLN-15.OTH" "PC-CLN-16.1" "PC-CLN-16.2" "PC-CLN-16.3" "PC-CLN-16.4" "PC-CLN-16.5" "PC-CLN-16.6" "PC-CLN-16.OTH" "PC-CLN-17.1" "PC-CLN-17.2" "PC-CLN-17.3" "PC-CLN-17.4" "PC-CLN-17.5" "PC-CLN-17.6" "PC-CLN-17.7" "PC-CLN-17.8" "PC-CLN-17.OTH" "PC-CLN-OTH" "PC-COL-1" "PC-COL-2" "PC-CON-1" "PC-CON-2" "PC-CON-3" "PC-CON-4" "PC-CON-5" "PC-CON-OTH" "PC-DET-1.1" "PC-DET-1.2" "PC-DET-1.3" "PC-DET-1.OTH" "PC-DET-2.1" "PC-DET-2.2" "PC-DET-2.3" "PC-DET-2.4" "PC-DET-2.5" "PC-DET-2.6" "PC-DET-2.7" "PC-DET-2.8" "PC-DET-2.OTH" "PC-DET-3.1" "PC-DET-3.2" "PC-DET-3.3" "PC-DET-3.OTH" "PC-DET-4.1" "PC-DET-4.2" "PC-DET-4.3" "PC-DET-4.4" "PC-DET-4.OTH" "PC-ELQ" "PC-FER-1" "PC-FER-2" "PC-FER-3" "PC-FER-4" "PC-FER-5" "PC-FER-6" "PC-FER-7" "PC-FUE-1" "PC-FUE-2" "PC-FUE-3" "PC-FUE-4" "PC-FUE-5" "PC-FUE-OTH" "PC-INK-1" "PC-INK-2" "PC-INK-3" "PC-INK-4" "PC-INK-5" "PC-INK-OTH" "PC-PNT-1" "PC-PNT-2" "PC-PNT-3" "PC-PNT-4" "PC-PNT-5" "PC-PNT-6" "PC-PNT-7" "PC-PNT-OTH" "PC-PYR-1" "PC-PYR-2" "PC-PYR-3" "PC-PYR-4" "PC-PYR-OTH" "PC-TAT" "PC-TEC-1" "PC-TEC-2" "PC-TEC-3" "PC-TEC-4" "PC-TEC-5" "PC-TEC-6" "PC-TEC-7" "PC-TEC-8" "PC-TEC-9" "PC-TEC-10" "PC-TEC-11" "PC-TEC-12" "PC-TEC-13" "PC-TEC-14" "PC-TEC-15" "PC-TEC-16" "PC-TEC-17" "PC-TEC-18" "PC-TEC-19" "PC-TEC-20" "PC-TEC-21" "PC-TEC-22" "PC-TEC-23" "PC-TEC-24" "PC-TEC-OTH" "PC-UNC" "PP-BIO-1" "PP-BIO-2" "PP-BIO-3" "PP-BIO-4" "PP-BIO-5" "PP-BIO-6" "PP-BIO-7" "PP-BIO-8" "PP-BIO-9" "PP-BIO-10" "PP-BIO-11" "PP-BIO-12" "PP-BIO-13" "PP-BIO-14" "PP-BIO-15" "PP-BIO-16" "PP-BIO-17" "PP-BIO-18" "PP-BIO-19" "PP-BIO-20" "PP-BIO-21" "PP-BIO-22" "PP-PRD-1" "PP-PRD-2" "PP-PRD-3" "PP-PRD-4" "PP-PRD-5" "PP-PRD-6" "PP-PRD-7" "PP-PRD-8" "PP-PRD-9" "PP-PRD-10" "PP-PRD-11" "PP-PRD-12" "PP-PRD-13" "PP-PRD-14" "PP-PRD-15" "PP-PRD-16" "PP-PRD-OTH" ) .
 
 :EupcsCategoryList a samm-c:List ;
     samm:preferredName "Eupcs Category List"@en ;
+    samm:description "List of Eupcs Category values."@en ;
     samm:dataType :EupcsCategory .
 
 :EuropeanWasteListCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "European Waste List Characteristic"@en ;
+    samm:description "Single European Waste List value."@en ;
     samm:dataType :EuropeanWasteList .
 
 :ExactQualifierEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Exact Qualifier Enum Characteristic"@en ;
+    samm:description "Allowed values for Exact Qualifier Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "eq" "ca" ) .
 
 :ExplosionLimitCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Explosion Limit Characteristic"@en ;
+    samm:description "Single Explosion Limit value."@en ;
     samm:dataType :ExplosionLimit .
 
 :ExplosivesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Explosives Characteristic"@en ;
+    samm:description "Single Explosives value."@en ;
     samm:dataType :Explosives .
 
 :ExposureControlAppropriateMeasuresCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Exposure Control Appropriate Measures Characteristic"@en ;
+    samm:description "Single Exposure Control Appropriate Measures value."@en ;
     samm:dataType :ExposureControlAppropriateMeasures .
 
 :ExposureControlPersonalProtectionCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Exposure Control Personal Protection Characteristic"@en ;
+    samm:description "Single Exposure Control Personal Protection value."@en ;
     samm:dataType :ExposureControlPersonalProtection .
 
 :ExposureGroupCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Exposure Group Characteristic"@en ;
+    samm:description "Single Exposure Group value."@en ;
     samm:dataType :ExposureGroup .
 
 :ExposureLimitFractionEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Exposure Limit Fraction Enum Characteristic"@en ;
+    samm:description "Allowed values for Exposure Limit Fraction Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "inhalable" "respirable" ) .
 
 :ExposureLimitValueTypeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Exposure Limit Value Type Enum Characteristic"@en ;
+    samm:description "Allowed values for Exposure Limit Value Type Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "AGW" "VLA" "MAC" "WEL" "OEL" "TWA" "STEL" "VLE" "AK" "PK" "MK" "PEL" "MAK" "NDS" "NDSCH" "NDSP" "GV" "NGV" "TGV" "KTV" "AN" "ADN" "HTP" ) .
 
 :ExposureRouteCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Exposure Route Characteristic"@en ;
+    samm:description "Single Exposure Route value."@en ;
     samm:dataType :ExposureRoute .
 
 :ExposureRouteEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Exposure Route Enum Characteristic"@en ;
+    samm:description "Allowed values for Exposure Route Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "Inhalation" "Oral" "Dermal" "Inhalation(Gas)" "Inhalation(Vapour)" "Inhalation(Dust/Mist)" "Subcutane" "Intraperitonial" "Intravenal" "Intraarterial" "Unreported" ) .
 
 :ExposureRouteFrequencyAndEffectCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Exposure Route Frequency And Effect Characteristic"@en ;
+    samm:description "Single Exposure Route Frequency And Effect value."@en ;
     samm:dataType :ExposureRouteFrequencyAndEffect .
 
 :ExposureScenarioCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Exposure Scenario Characteristic"@en ;
+    samm:description "Single Exposure Scenario value."@en ;
     samm:dataType :ExposureScenario .
 
 :ExtinguishingMediaCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Extinguishing Media Characteristic"@en ;
+    samm:description "Single Extinguishing Media value."@en ;
     samm:dataType :ExtinguishingMedia .
 
 :EyeDamageOrIrritationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Eye Damage Or Irritation Characteristic"@en ;
+    samm:description "Single Eye Damage Or Irritation value."@en ;
     samm:dataType :EyeDamageOrIrritation .
 
 :EyeProtectionCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Eye Protection Characteristic"@en ;
+    samm:description "Single Eye Protection value."@en ;
     samm:dataType :EyeProtection .
 
 :FederalCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Federal Characteristic"@en ;
+    samm:description "Single Federal value."@en ;
     samm:dataType :Federal .
 
 :FireFightingMeasuresCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Fire Fighting Measures Characteristic"@en ;
+    samm:description "Single Fire Fighting Measures value."@en ;
     samm:dataType :FireFightingMeasures .
 
 :FirstAidMeasuresCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "First Aid Measures Characteristic"@en ;
+    samm:description "Single First Aid Measures value."@en ;
     samm:dataType :FirstAidMeasures .
 
 :FlammableAerosolsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Flammable Aerosols Characteristic"@en ;
+    samm:description "Single Flammable Aerosols value."@en ;
     samm:dataType :FlammableAerosols .
 
 :FlammableGasesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Flammable Gases Characteristic"@en ;
+    samm:description "Single Flammable Gases value."@en ;
     samm:dataType :FlammableGases .
 
 :FlammableLiquidsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Flammable Liquids Characteristic"@en ;
+    samm:description "Single Flammable Liquids value."@en ;
     samm:dataType :FlammableLiquids .
 
 :FlammableSolidsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Flammable Solids Characteristic"@en ;
+    samm:description "Single Flammable Solids value."@en ;
     samm:dataType :FlammableSolids .
 
-:FlashPointList a samm-c:List ;
-    samm:preferredName "Flash Point List"@en ;
+:FlashPointCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Flash Point Characteristic"@en ;
+    samm:description "Single Flash Point value."@en ;
     samm:dataType :FlashPoint .
 
 :FloatCharacteristic a samm:Characteristic ;
     samm:preferredName "Float Characteristic"@en ;
+    samm:description "Value of XSD type xsd:float."@en ;
     samm:dataType xsd:float .
 
 :ForNonEmergencyPersonnelCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "For Non Emergency Personnel Characteristic"@en ;
+    samm:description "Single For Non Emergency Personnel value."@en ;
     samm:dataType :ForNonEmergencyPersonnel .
 
 :FormEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Form Enum Characteristic"@en ;
+    samm:description "Allowed values for Form Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "aerosol dispenser: not specified" "aerosol dispenser: foam aerosol" "aerosol dispenser: spray aerosol" "gas" "gas: vapour" "gas under pressure: compressed gas" "gas under pressure: dissolved gas" "gas under pressure: liquefied gas" "gas under pressure: refrigerated liquefied gas" "cream / paste" "foam" "gel" "liquid" "liquid: viscous" "liquid: volatile" "liquid - liquid: emulsion" "liquid - solid: mixture of" "semi-solid (amorphous): gel" "solid" "solid: bulk" "solid: compact" "solid: crystalline" "solid: fibres" "solid: filaments" "solid: flakes" "solid: granular" "solid: particulate/powder" "solid: pellets" "solid: pressed powder" "solid: nanomaterial, surface-treated" "solid: nanomaterial, no surface treatment" "solid: nanomaterial" "solid: tabs / tablets" "solid - liquid: aqueous solution" "solid - liquid: suspension" "solid - solid: alloy" "other" ) .
 
+:FullTextList a samm-c:List ;
+    samm:preferredName "Full Text List"@en ;
+    samm:description "List of Full Text values."@en ;
+    samm:dataType :FullText .
+
 :FurtherEcologicalDataList a samm-c:List ;
     samm:preferredName "Further Ecological Data List"@en ;
+    samm:description "List of Further Ecological Data values."@en ;
     samm:dataType :FurtherEcologicalData .
 
 :GasGroupEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Gas Group Enum Characteristic"@en ;
+    samm:description "Allowed values for Gas Group Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "IIA" "IIB" "IIC" ) .
 
 :GasGroupList a samm-c:List ;
     samm:preferredName "Gas Group List"@en ;
+    samm:description "List of Gas Group values."@en ;
     samm:dataType :GasGroup .
 
 :GasesUnderPressureCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Gases Under Pressure Characteristic"@en ;
+    samm:description "Single Gases Under Pressure value."@en ;
     samm:dataType :GasesUnderPressure .
 
 :GbClpHazardClassification2020Characteristic a samm-c:SingleEntity ;
     samm:preferredName "Gb Clp Hazard Classification2020Characteristic"@en ;
+    samm:description "Single Gb Clp Hazard Classification2020 value."@en ;
     samm:dataType :GbClpHazardClassification2020 .
 
 :GbClpHazardLabelling2020Characteristic a samm-c:SingleEntity ;
     samm:preferredName "Gb Clp Hazard Labelling2020Characteristic"@en ;
+    samm:description "Single Gb Clp Hazard Labelling2020 value."@en ;
     samm:dataType :GbClpHazardLabelling2020 .
+
+:Gbt2009HazardClassificationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Gbt2009Hazard Classification Characteristic"@en ;
+    samm:description "Single Gbt2009Hazard Classification value."@en ;
+    samm:dataType :Gbt2009HazardClassification .
 
 :GeneralDescriptionCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "General Description Characteristic"@en ;
+    samm:description "Single General Description value."@en ;
     samm:dataType :GeneralDescription .
 
 :GermCellMutagenicityCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Germ Cell Mutagenicity Characteristic"@en ;
+    samm:description "Single Germ Cell Mutagenicity value."@en ;
     samm:dataType :GermCellMutagenicity .
-
-:Ghs03HazardStatementUsList a samm-c:List ;
-    samm:preferredName "Ghs03Hazard Statement Us List"@en ;
-    samm:dataType :Ghs03HazardStatementUs .
-
-:Ghs03PrecautionaryStatementList a samm-c:List ;
-    samm:preferredName "Ghs03Precautionary Statement List"@en ;
-    samm:dataType :Ghs03PrecautionaryStatement .
 
 :Ghs05HazardStatementList a samm-c:List ;
     samm:preferredName "Ghs05Hazard Statement List"@en ;
+    samm:description "List of Ghs05Hazard Statement values."@en ;
     samm:dataType :Ghs05HazardStatement .
 
 :Ghs05PrecautionaryStatementList a samm-c:List ;
     samm:preferredName "Ghs05Precautionary Statement List"@en ;
+    samm:description "List of Ghs05Precautionary Statement values."@en ;
     samm:dataType :Ghs05PrecautionaryStatement .
-
-:Ghs07HazardStatementList a samm-c:List ;
-    samm:preferredName "Ghs07Hazard Statement List"@en ;
-    samm:dataType :Ghs07HazardStatement .
-
-:Ghs07PrecautionaryStatementList a samm-c:List ;
-    samm:preferredName "Ghs07Precautionary Statement List"@en ;
-    samm:dataType :Ghs07PrecautionaryStatement .
 
 :GhsPictogramCodeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Ghs Pictogram Code Enum Characteristic"@en ;
+    samm:description "Allowed values for Ghs Pictogram Code Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "GHS01" "GHS02" "GHS03" "GHS04" "GHS05" "GHS06" "GHS07" "GHS08" "GHS09" ) .
 
 :GhsSignalWordCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Ghs Signal Word Characteristic"@en ;
+    samm:description "Single Ghs Signal Word value."@en ;
     samm:dataType :GhsSignalWord .
 
 :GhsSignalWordEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Ghs Signal Word Enum Characteristic"@en ;
+    samm:description "Allowed values for Ghs Signal Word Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "DGR" "WNG" ) .
 
 :GoodPracticeAdviceCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Good Practice Advice Characteristic"@en ;
+    samm:description "Single Good Practice Advice value."@en ;
     samm:dataType :GoodPracticeAdvice .
 
 :HandProtectionCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Hand Protection Characteristic"@en ;
+    samm:description "Single Hand Protection value."@en ;
     samm:dataType :HandProtection .
 
 :HandlingAndStorageCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Handling And Storage Characteristic"@en ;
+    samm:description "Single Handling And Storage value."@en ;
     samm:dataType :HandlingAndStorage .
 
 :HazardIdentificationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Hazard Identification Characteristic"@en ;
+    samm:description "Single Hazard Identification value."@en ;
     samm:dataType :HazardIdentification .
 
 :HazardLabellingArCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Hazard Labelling Ar Characteristic"@en ;
+    samm:description "Single Hazard Labelling Ar value."@en ;
     samm:dataType :HazardLabellingAr .
-
-:HazardLabellingBrCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Hazard Labelling Br Characteristic"@en ;
-    samm:dataType :HazardLabellingBr .
-
-:HazardLabellingCaCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Hazard Labelling Ca Characteristic"@en ;
-    samm:dataType :HazardLabellingCa .
-
-:HazardLabellingGbCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Hazard Labelling Gb Characteristic"@en ;
-    samm:dataType :HazardLabellingGb .
-
-:HazardLabellingMxCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Hazard Labelling Mx Characteristic"@en ;
-    samm:dataType :HazardLabellingMx .
-
-:HazardLabellingTrCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Hazard Labelling Tr Characteristic"@en ;
-    samm:dataType :HazardLabellingTr .
-
-:HazardLabellingUsCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Hazard Labelling Us Characteristic"@en ;
-    samm:dataType :HazardLabellingUs .
 
 :Hazcom2012HazardClassificationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Hazcom2012Hazard Classification Characteristic"@en ;
+    samm:description "Single Hazcom2012Hazard Classification value."@en ;
     samm:dataType :Hazcom2012HazardClassification .
 
 :Hazcom2012HazardLabellingCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Hazcom2012Hazard Labelling Characteristic"@en ;
+    samm:description "Single Hazcom2012Hazard Labelling value."@en ;
     samm:dataType :Hazcom2012HazardLabelling .
 
 :HumanExperienceCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Human Experience Characteristic"@en ;
+    samm:description "Single Human Experience value."@en ;
     samm:dataType :HumanExperience .
 
 :HydrolysisRateList a samm-c:List ;
     samm:preferredName "Hydrolysis Rate List"@en ;
+    samm:description "List of Hydrolysis Rate values."@en ;
     samm:dataType :HydrolysisRate .
 
 :IataDgrCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Iata Dgr Characteristic"@en ;
+    samm:description "Single Iata Dgr value."@en ;
     samm:dataType :IataDgr .
 
 :IdentificationSubstPrepCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Identification Subst Prep Characteristic"@en ;
+    samm:description "Single Identification Subst Prep value."@en ;
     samm:dataType :IdentificationSubstPrep .
 
 :IdentifiedUseList a samm-c:List ;
     samm:preferredName "Identified Use List"@en ;
+    samm:description "List of Identified Use values."@en ;
     samm:dataType :IdentifiedUse .
 
 :ImdgCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Imdg Characteristic"@en ;
+    samm:description "Single Imdg value."@en ;
     samm:dataType :Imdg .
 
 :IndustrialEmissionsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Industrial Emissions Characteristic"@en ;
+    samm:description "Single Industrial Emissions value."@en ;
     samm:dataType :IndustrialEmissions .
 
 :InformationFromExportingSystemCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Information From Exporting System Characteristic"@en ;
+    samm:description "Single Information From Exporting System value."@en ;
     samm:dataType :InformationFromExportingSystem .
 
 :InformationToHealthProfessionalsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Information To Health Professionals Characteristic"@en ;
+    samm:description "Single Information To Health Professionals value."@en ;
     samm:dataType :InformationToHealthProfessionals .
 
 :IntegerCharacteristic a samm:Characteristic ;
     samm:preferredName "Integer Characteristic"@en ;
+    samm:description "Value of XSD type xsd:integer."@en ;
     samm:dataType xsd:integer .
 
 :InvestigationMethodCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Investigation Method Characteristic"@en ;
+    samm:description "Single Investigation Method value."@en ;
     samm:dataType :InvestigationMethod .
 
 :InvestigationMethodEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Investigation Method Enum Characteristic"@en ;
+    samm:description "Allowed values for Investigation Method Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "in-vivo" "in-vitro" ) .
 
 :LabellingAccordingToOtherLegislationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Labelling According To Other Legislation Characteristic"@en ;
+    samm:description "Single Labelling According To Other Legislation value."@en ;
     samm:dataType :LabellingAccordingToOtherLegislation .
 
 :LanguageCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Language Characteristic"@en ;
+    samm:description "Single Language value."@en ;
     samm:dataType :Language .
 
 :LanguageCodeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Language Code Enum Characteristic"@en ;
+    samm:description "Allowed values for Language Code Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "aa" "ab" "ae" "af" "ak" "am" "an" "ar" "as" "av" "ay" "az" "ba" "be" "bg" "bh" "bi" "bm" "bn" "bo" "br" "bs" "ca" "ce" "ch" "co" "cr" "cs" "cu" "cv" "cy" "da" "de" "dv" "dz" "ee" "el" "en" "eo" "es" "et" "eu" "fa" "ff" "fi" "fj" "fo" "fr" "fy" "ga" "gd" "gl" "gn" "gu" "gv" "ha" "he" "hi" "ho" "hr" "ht" "hu" "hy" "hz" "ia" "id" "ie" "ig" "ii" "ik" "io" "is" "it" "iu" "ja" "jv" "ka" "kg" "ki" "kj" "kk" "kl" "km" "kn" "ko" "kr" "ks" "ku" "kv" "kw" "ky" "la" "lb" "lg" "li" "ln" "lo" "lt" "lu" "lv" "mg" "mh" "mi" "mk" "ml" "mn" "mr" "ms" "mt" "my" "na" "nb" "nd" "ne" "ng" "nl" "nn" "no" "nr" "nv" "ny" "oc" "oj" "om" "or" "os" "pa" "pi" "pl" "ps" "pt" "qu" "rm" "rn" "ro" "ru" "rw" "sa" "sc" "sd" "se" "sg" "si" "sk" "sl" "sm" "sn" "so" "sq" "sr" "ss" "st" "su" "sv" "sw" "ta" "te" "tg" "th" "ti" "tk" "tl" "tn" "to" "tr" "ts" "tt" "tw" "ty" "ug" "uk" "ur" "uz" "ve" "vi" "vo" "wa" "wo" "xh" "yi" "yo" "za" "zh" "zu" ) .
 
 :LegalDocumentCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Legal Document Characteristic"@en ;
+    samm:description "Single Legal Document value."@en ;
     samm:dataType :LegalDocument .
 
 :LowerQualifierEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Lower Qualifier Enum Characteristic"@en ;
+    samm:description "Allowed values for Lower Qualifier Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "gt" "ge" ) .
 
 :LowerTierQuantityInlineCharacteristic a samm:Characteristic ;
     samm:preferredName "Lower Tier Quantity Inline Characteristic"@en ;
+    samm:description "Value of XSD type xsd:integer."@en ;
     samm:dataType xsd:integer .
 
 :MajorAccidentsOrdinanceCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Major Accidents Ordinance Characteristic"@en ;
+    samm:description "Single Major Accidents Ordinance value."@en ;
     samm:dataType :MajorAccidentsOrdinance .
 
 :MedicalAttentionAndSpecialTreatmentNeededCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Medical Attention And Special Treatment Needed Characteristic"@en ;
+    samm:description "Single Medical Attention And Special Treatment Needed value."@en ;
     samm:dataType :MedicalAttentionAndSpecialTreatmentNeeded .
 
 :MeltingPointRelatedCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Melting Point Related Characteristic"@en ;
+    samm:description "Single Melting Point Related value."@en ;
     samm:dataType :MeltingPointRelated .
 
 :MergePhraseList a samm-c:List ;
     samm:preferredName "Merge Phrase List"@en ;
+    samm:description "List of Merge Phrase values."@en ;
     samm:dataType :MergePhrase .
 
 :MobilityList a samm-c:List ;
     samm:preferredName "Mobility List"@en ;
+    samm:description "List of Mobility values."@en ;
     samm:dataType :Mobility .
 
 :MultiplyingFactorCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Multiplying Factor Characteristic"@en ;
+    samm:description "Single Multiplying Factor value."@en ;
     samm:dataType :MultiplyingFactor .
 
 :NationalLegislationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "National Legislation Characteristic"@en ;
+    samm:description "Single National Legislation value."@en ;
     samm:dataType :NationalLegislation .
 
 :NationalWasteLegislationChCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "National Waste Legislation Ch Characteristic"@en ;
+    samm:description "Single National Waste Legislation Ch value."@en ;
     samm:dataType :NationalWasteLegislationCh .
 
 :NationalWasteLegislationDeList a samm-c:List ;
     samm:preferredName "National Waste Legislation De List"@en ;
+    samm:description "List of National Waste Legislation De values."@en ;
     samm:dataType :NationalWasteLegislationDe .
 
 :NationalWasteLegislationNoList a samm-c:List ;
     samm:preferredName "National Waste Legislation No List"@en ;
+    samm:description "List of National Waste Legislation No values."@en ;
     samm:dataType :NationalWasteLegislationNo .
 
 :Nom2015HazardClassificationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Nom2015Hazard Classification Characteristic"@en ;
+    samm:description "Single Nom2015Hazard Classification value."@en ;
     samm:dataType :Nom2015HazardClassification .
 
 :Nom2015HazardLabellingCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Nom2015Hazard Labelling Characteristic"@en ;
+    samm:description "Single Nom2015Hazard Labelling value."@en ;
     samm:dataType :Nom2015HazardLabelling .
 
 :NonHumanToxicologicalDataList a samm-c:List ;
     samm:preferredName "Non Human Toxicological Data List"@en ;
+    samm:description "List of Non Human Toxicological Data values."@en ;
     samm:dataType :NonHumanToxicologicalData .
 
 :NumericRangeWithQualifierCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Numeric Range With Qualifier Characteristic"@en ;
+    samm:description "Single Numeric Range With Qualifier value."@en ;
     samm:dataType :NumericRangeWithQualifier .
 
 :NumericRangeWithUnitAndQualifierCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Numeric Range With Unit And Qualifier Characteristic"@en ;
+    samm:description "Single Numeric Range With Unit And Qualifier value."@en ;
     samm:dataType :NumericRangeWithUnitAndQualifier .
 
 :NumericRangeWithUnitAndQualifierList a samm-c:List ;
     samm:preferredName "Numeric Range With Unit And Qualifier List"@en ;
+    samm:description "List of Numeric Range With Unit And Qualifier values."@en ;
     samm:dataType :NumericRangeWithUnitAndQualifier .
 
 :NumericValueCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Numeric Value Characteristic"@en ;
+    samm:description "Single Numeric Value value."@en ;
     samm:dataType :NumericValue .
 
 :NumericValueWithUnitAndQualifierCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Numeric Value With Unit And Qualifier Characteristic"@en ;
+    samm:description "Single Numeric Value With Unit And Qualifier value."@en ;
     samm:dataType :NumericValueWithUnitAndQualifier .
 
 :NumericValueWithUnitCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Numeric Value With Unit Characteristic"@en ;
+    samm:description "Single Numeric Value With Unit value."@en ;
     samm:dataType :NumericValueWithUnit .
 
 :OccupationalAirRequirementNoCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Occupational Air Requirement No Characteristic"@en ;
+    samm:description "Single Occupational Air Requirement No value."@en ;
     samm:dataType :OccupationalAirRequirementNo .
 
 :OccupationalExposureLimitList a samm-c:List ;
     samm:preferredName "Occupational Exposure Limit List"@en ;
+    samm:description "List of Occupational Exposure Limit values."@en ;
     samm:dataType :OccupationalExposureLimit .
 
 :OccupationalExposureLimitsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Occupational Exposure Limits Characteristic"@en ;
+    samm:description "Single Occupational Exposure Limits value."@en ;
     samm:dataType :OccupationalExposureLimits .
 
 :OperationalConditionsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Operational Conditions Characteristic"@en ;
+    samm:description "Single Operational Conditions value."@en ;
     samm:dataType :OperationalConditions .
 
 :OrganicPeroxidesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Organic Peroxides Characteristic"@en ;
+    samm:description "Single Organic Peroxides value."@en ;
     samm:dataType :OrganicPeroxides .
 
 :OtherAdverseEffectsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Other Adverse Effects Characteristic"@en ;
+    samm:description "Single Other Adverse Effects value."@en ;
     samm:dataType :OtherAdverseEffects .
 
 :OtherHazardsInfoCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Other Hazards Info Characteristic"@en ;
+    samm:description "Single Other Hazards Info value."@en ;
     samm:dataType :OtherHazardsInfo .
 
 :OtherInformationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Other Information Characteristic"@en ;
+    samm:description "Single Other Information value."@en ;
     samm:dataType :OtherInformation .
 
 :OtherSafetyInformationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Other Safety Information Characteristic"@en ;
+    samm:description "Single Other Safety Information value."@en ;
     samm:dataType :OtherSafetyInformation .
 
 :OxidisingGasesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Oxidising Gases Characteristic"@en ;
+    samm:description "Single Oxidising Gases value."@en ;
     samm:dataType :OxidisingGases .
 
 :OxidisingLiquidsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Oxidising Liquids Characteristic"@en ;
+    samm:description "Single Oxidising Liquids value."@en ;
     samm:dataType :OxidisingLiquids .
 
 :OxidisingSolidsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Oxidising Solids Characteristic"@en ;
+    samm:description "Single Oxidising Solids value."@en ;
     samm:dataType :OxidisingSolids .
 
 :PackagingCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Packaging Characteristic"@en ;
+    samm:description "Single Packaging value."@en ;
     samm:dataType :Packaging .
 
 :PackagingMaterialEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Packaging Material Enum Characteristic"@en ;
+    samm:description "Allowed values for Packaging Material Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "glass" "plastic: HDPE" "plastic: LDPE" "plastic: PET" "plastic: composite" "metal" "paper, cardboard" "other" ) .
 
 :PackagingTypeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Packaging Type Enum Characteristic"@en ;
+    samm:description "Allowed values for Packaging Type Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "aerosol can" "airspray" "atomizer" "bag / sack" "baitbox" "blister" "bottle" "box" "brick" "bucket" "can / tin" "carboy" "case" "dispenser" "dropper" "drum" "envelope" "IBC (intermediate bulk container)" "jar" "jerry can" "jug" "packet" "sachet" "phial" "stick" "syringe" "talcum powder container" "tank" "tea bag (product disperses through the container when added to water)" "tube" "water soluble bag" "other" ) .
 
 :PackingGroupEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Packing Group Enum Characteristic"@en ;
+    samm:description "Allowed values for Packing Group Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "I" "II" "III" ) .
 
-:ParticleFractionCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Particle Fraction Characteristic"@en ;
-    samm:dataType :ParticleFraction .
-
 :PartitionCoefficientList a samm-c:List ;
     samm:preferredName "Partition Coefficient List"@en ;
+    samm:description "List of Partition Coefficient values."@en ;
     samm:dataType :PartitionCoefficient .
 
 :PdsclCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Pdscl Characteristic"@en ;
+    samm:description "Allowed values for Pdscl."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "deleterious" "poisonous" "special" ) .
 
 :PeakLimitationList a samm-c:List ;
     samm:preferredName "Peak Limitation List"@en ;
+    samm:description "List of Peak Limitation values."@en ;
     samm:dataType :PeakLimitation .
 
 :PercentageCharacteristic a samm:Characteristic ;
     samm:preferredName "Percentage Characteristic"@en ;
+    samm:description "Value of XSD type xsd:float."@en ;
     samm:dataType xsd:float .
 
 :PercentageRangeCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Percentage Range Characteristic"@en ;
+    samm:description "Single Percentage Range value."@en ;
     samm:dataType :PercentageRange .
 
 :PersistenceDegradabilityCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Persistence Degradability Characteristic"@en ;
+    samm:description "Single Persistence Degradability value."@en ;
     samm:dataType :PersistenceDegradability .
 
 :PersonalProtectionEquipmentCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Personal Protection Equipment Characteristic"@en ;
+    samm:description "Single Personal Protection Equipment value."@en ;
     samm:dataType :PersonalProtectionEquipment .
 
 :PhNotRelevantEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Ph Not Relevant Enum Characteristic"@en ;
+    samm:description "Allowed values for Ph Not Relevant Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "pH is below -3" "pH is above 15" "substance/mixture is a gas" "substance/mixture is non-polar/aprotic" "substance/mixture is non-soluble (in water)" "substance/mixture not stable" "substance/mixture reacts with water" ) .
 
 :PhValueList a samm-c:List ;
     samm:preferredName "Ph Value List"@en ;
+    samm:description "List of Ph Value values."@en ;
     samm:dataType :PhValue .
-
-:PhValueStateEnumCharacteristic a samm-c:Enumeration ;
-    samm:preferredName "Ph Value State Enum Characteristic"@en ;
-    samm:dataType xsd:string ;
-    samm-c:values ( "In delivery state" "In aqueous solution" ) .
 
 :PhototoxicityCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Phototoxicity Characteristic"@en ;
+    samm:description "Single Phototoxicity value."@en ;
     samm:dataType :Phototoxicity .
 
 :PhototoxicityTestResultsList a samm-c:List ;
     samm:preferredName "Phototoxicity Test Results List"@en ;
+    samm:description "List of Phototoxicity Test Results values."@en ;
     samm:dataType :PhototoxicityTestResults .
 
 :PhraseCatalogueList a samm-c:List ;
     samm:preferredName "Phrase Catalogue List"@en ;
+    samm:description "List of Phrase Catalogue values."@en ;
     samm:dataType :PhraseCatalogue .
 
 :PhraseCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Phrase Characteristic"@en ;
+    samm:description "Single Phrase value."@en ;
     samm:dataType :Phrase .
 
 :PhraseList a samm-c:List ;
     samm:preferredName "Phrase List"@en ;
+    samm:description "List of Phrase values."@en ;
     samm:dataType :Phrase .
 
 :PhysChemUnitValueCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Phys Chem Unit Value Characteristic"@en ;
+    samm:description "Single Phys Chem Unit Value value."@en ;
     samm:dataType :PhysChemUnitValue .
 
 :PhysChemUnitValueList a samm-c:List ;
     samm:preferredName "Phys Chem Unit Value List"@en ;
+    samm:description "List of Phys Chem Unit Value values."@en ;
     samm:dataType :PhysChemUnitValue .
 
 :PhysChemUnitValueWithTemperatureCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Phys Chem Unit Value With Temperature Characteristic"@en ;
+    samm:description "Single Phys Chem Unit Value With Temperature value."@en ;
     samm:dataType :PhysChemUnitValueWithTemperature .
 
 :PhysChemUnitValueWithTemperatureList a samm-c:List ;
     samm:preferredName "Phys Chem Unit Value With Temperature List"@en ;
+    samm:description "List of Phys Chem Unit Value With Temperature values."@en ;
     samm:dataType :PhysChemUnitValueWithTemperature .
 
 :PhysChemValueList a samm-c:List ;
     samm:preferredName "Phys Chem Value List"@en ;
+    samm:description "List of Phys Chem Value values."@en ;
     samm:dataType :PhysChemValue .
 
 :PhysChemValueWithTemperatureCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Phys Chem Value With Temperature Characteristic"@en ;
+    samm:description "Single Phys Chem Value With Temperature value."@en ;
     samm:dataType :PhysChemValueWithTemperature .
 
 :PhysChemValueWithTemperatureList a samm-c:List ;
     samm:preferredName "Phys Chem Value With Temperature List"@en ;
+    samm:description "List of Phys Chem Value With Temperature values."@en ;
     samm:dataType :PhysChemValueWithTemperature .
 
 :PhysicalChemicalPropertiesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Physical Chemical Properties Characteristic"@en ;
+    samm:description "Single Physical Chemical Properties value."@en ;
     samm:dataType :PhysicalChemicalProperties .
 
 :PhysicalHazardsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Physical Hazards Characteristic"@en ;
+    samm:description "Single Physical Hazards value."@en ;
     samm:dataType :PhysicalHazards .
-
-:PhysicalHazardsGeneralInformationCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Physical Hazards General Information Characteristic"@en ;
-    samm:dataType :PhysicalHazardsGeneralInformation .
 
 :PhysicalHazardsSafetyCharacteristicsList a samm-c:List ;
     samm:preferredName "Physical Hazards Safety Characteristics List"@en ;
+    samm:description "List of Physical Hazards Safety Characteristics values."@en ;
     samm:dataType :PhysicalHazardsSafetyCharacteristics .
 
 :PhysicalHazardsScreeningProceduresList a samm-c:List ;
     samm:preferredName "Physical Hazards Screening Procedures List"@en ;
+    samm:description "List of Physical Hazards Screening Procedures values."@en ;
     samm:dataType :PhysicalHazardsScreeningProcedures .
 
 :PnecList a samm-c:List ;
     samm:preferredName "Pnec List"@en ;
+    samm:description "List of Pnec values."@en ;
     samm:dataType :Pnec .
 
 :PnecTypeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Pnec Type Enum Characteristic"@en ;
+    samm:description "Allowed values for Pnec Type Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "Soil" "Sediment, marine water" "Sediment, freshwater" "Aquatic, intermittent release" "Aquatic, marine water" "Aquatic, freshwater" "Sewage treatment plant (STP)" "Secondary poisoning" "Air" ) .
 
 :PrProductRegistrationNoList a samm-c:List ;
     samm:preferredName "Pr Product Registration No List"@en ;
+    samm:description "List of Pr Product Registration No values."@en ;
     samm:dataType :PrProductRegistrationNo .
 
 :PrecautionaryMeasuresCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Precautionary Measures Characteristic"@en ;
+    samm:description "Single Precautionary Measures value."@en ;
     samm:dataType :PrecautionaryMeasures .
-
-:ProcessCategoryCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Process Category Characteristic"@en ;
-    samm:dataType :ProcessCategory .
 
 :ProcessCategoryCodeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Process Category Code Enum Characteristic"@en ;
+    samm:description "Allowed values for Process Category Code Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "PROC1" "PROC2" "PROC3" "PROC4" "PROC5" "PROC6" "PROC7" "PROC8a" "PROC8b" "PROC9" "PROC10" "PROC11" "PROC12" "PROC13" "PROC14" "PROC15" "PROC16" "PROC17" "PROC18" "PROC19" "PROC20" "PROC21" "PROC22" "PROC23" "PROC24" "PROC25" "PROC26" "PROC27a" "PROC27b" ) .
 
 :ProcessCategoryList a samm-c:List ;
     samm:preferredName "Process Category List"@en ;
+    samm:description "List of Process Category values."@en ;
     samm:dataType :ProcessCategory .
 
 :ProductCategoryCodeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Product Category Code Enum Characteristic"@en ;
+    samm:description "Allowed values for Product Category Code Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "PC1" "PC2" "PC3" "PC4" "PC7" "PC8" "PC9a" "PC9b" "PC9c" "PC11" "PC12" "PC13" "PC14" "PC15" "PC16" "PC17" "PC18" "PC19" "PC20" "PC21" "PC22" "PC23" "PC24" "PC25" "PC26" "PC27" "PC28" "PC29" "PC30" "PC31" "PC32" "PC33" "PC34" "PC35" "PC36" "PC37" "PC38" "PC39" "PC40" "PC0" ) .
 
 :ProductCategoryList a samm-c:List ;
     samm:preferredName "Product Category List"@en ;
+    samm:description "List of Product Category values."@en ;
     samm:dataType :ProductCategory .
 
 :ProductGtinList a samm-c:List ;
     samm:preferredName "Product Gtin List"@en ;
+    samm:description "List of Product Gtin values."@en ;
     samm:dataType :ProductGtin .
 
 :ProductIdentifiersCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Product Identifiers Characteristic"@en ;
+    samm:description "Single Product Identifiers value."@en ;
     samm:dataType :ProductIdentifiers .
 
 :PropertiesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Properties Characteristic"@en ;
+    samm:description "Single Properties value."@en ;
     samm:dataType :Properties .
 
 :ProtectionArticleList a samm-c:List ;
     samm:preferredName "Protection Article List"@en ;
+    samm:description "List of Protection Article values."@en ;
     samm:dataType :ProtectionArticle .
 
 :PyrophoricLiquidsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Pyrophoric Liquids Characteristic"@en ;
+    samm:description "Single Pyrophoric Liquids value."@en ;
     samm:dataType :PyrophoricLiquids .
 
 :PyrophoricSolidsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Pyrophoric Solids Characteristic"@en ;
+    samm:description "Single Pyrophoric Solids value."@en ;
     samm:dataType :PyrophoricSolids .
 
 :ReasonForWaivingCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Reason For Waiving Characteristic"@en ;
+    samm:description "Allowed values for Reason For Waiving."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "cannot be determined" "not applicable" "no data" ) .
 
 :RegionArCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Region Ar Characteristic"@en ;
+    samm:description "Single Region Ar value."@en ;
     samm:dataType :RegionAr .
 
 :RegionBrCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Region Br Characteristic"@en ;
+    samm:description "Single Region Br value."@en ;
     samm:dataType :RegionBr .
 
 :RegionCaCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Region Ca Characteristic"@en ;
+    samm:description "Single Region Ca value."@en ;
     samm:dataType :RegionCa .
+
+:RegionCnCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Region Cn Characteristic"@en ;
+    samm:description "Single Region Cn value."@en ;
+    samm:dataType :RegionCn .
 
 :RegionEuCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Region Eu Characteristic"@en ;
+    samm:description "Single Region Eu value."@en ;
     samm:dataType :RegionEu .
 
 :RegionGbCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Region Gb Characteristic"@en ;
+    samm:description "Single Region Gb value."@en ;
     samm:dataType :RegionGb .
 
 :RegionMxCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Region Mx Characteristic"@en ;
+    samm:description "Single Region Mx value."@en ;
     samm:dataType :RegionMx .
 
 :RegionTrCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Region Tr Characteristic"@en ;
+    samm:description "Single Region Tr value."@en ;
     samm:dataType :RegionTr .
 
 :RegionUsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Region Us Characteristic"@en ;
+    samm:description "Single Region Us value."@en ;
     samm:dataType :RegionUs .
-
-:RegulationsArCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Regulations Ar Characteristic"@en ;
-    samm:dataType :RegulationsAr .
 
 :RegulationsAtCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulations At Characteristic"@en ;
+    samm:description "Single Regulations At value."@en ;
     samm:dataType :RegulationsAt .
 
 :RegulationsBrCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulations Br Characteristic"@en ;
+    samm:description "Single Regulations Br value."@en ;
     samm:dataType :RegulationsBr .
-
-:RegulationsCaCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Regulations Ca Characteristic"@en ;
-    samm:dataType :RegulationsCa .
 
 :RegulationsChCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulations Ch Characteristic"@en ;
+    samm:description "Single Regulations Ch value."@en ;
     samm:dataType :RegulationsCh .
 
 :RegulationsDeCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulations De Characteristic"@en ;
+    samm:description "Single Regulations De value."@en ;
     samm:dataType :RegulationsDe .
 
 :RegulationsDkCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulations Dk Characteristic"@en ;
+    samm:description "Single Regulations Dk value."@en ;
     samm:dataType :RegulationsDk .
 
 :RegulationsEuCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulations Eu Characteristic"@en ;
+    samm:description "Single Regulations Eu value."@en ;
     samm:dataType :RegulationsEu .
-
-:RegulationsGbCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Regulations Gb Characteristic"@en ;
-    samm:dataType :RegulationsGb .
 
 :RegulationsJpCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulations Jp Characteristic"@en ;
+    samm:description "Single Regulations Jp value."@en ;
     samm:dataType :RegulationsJp .
 
 :RegulationsMxCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulations Mx Characteristic"@en ;
+    samm:description "Single Regulations Mx value."@en ;
     samm:dataType :RegulationsMx .
 
 :RegulationsNoCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulations No Characteristic"@en ;
+    samm:description "Single Regulations No value."@en ;
     samm:dataType :RegulationsNo .
 
 :RegulationsRelatedToCountryOrRegionList a samm-c:List ;
     samm:preferredName "Regulations Related To Country Or Region List"@en ;
+    samm:description "List of Regulations Related To Country Or Region values."@en ;
     samm:dataType :RegulationsRelatedToCountryOrRegion .
 
 :RegulationsRuCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulations Ru Characteristic"@en ;
+    samm:description "Single Regulations Ru value."@en ;
     samm:dataType :RegulationsRu .
-
-:RegulationsTrCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Regulations Tr Characteristic"@en ;
-    samm:dataType :RegulationsTr .
 
 :RegulationsUsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulations Us Characteristic"@en ;
+    samm:description "Single Regulations Us value."@en ;
     samm:dataType :RegulationsUs .
 
 :RegulatoryInformationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Regulatory Information Characteristic"@en ;
+    samm:description "Single Regulatory Information value."@en ;
     samm:dataType :RegulatoryInformation .
 
 :RelatedDocumentsList a samm-c:List ;
     samm:preferredName "Related Documents List"@en ;
+    samm:description "List of Related Documents values."@en ;
     samm:dataType :RelatedDocuments .
 
 :RelativeVapourDensityList a samm-c:List ;
     samm:preferredName "Relative Vapour Density List"@en ;
+    samm:description "List of Relative Vapour Density values."@en ;
     samm:dataType :RelativeVapourDensity .
 
 :RelevantIdentifiedUseCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Relevant Identified Use Characteristic"@en ;
+    samm:description "Single Relevant Identified Use value."@en ;
     samm:dataType :RelevantIdentifiedUse .
 
 :ReproductiveToxicityList a samm-c:List ;
     samm:preferredName "Reproductive Toxicity List"@en ;
+    samm:description "List of Reproductive Toxicity values."@en ;
     samm:dataType :ReproductiveToxicity .
 
 :ReproductiveToxicityTypeCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Reproductive Toxicity Type Characteristic"@en ;
+    samm:description "Single Reproductive Toxicity Type value."@en ;
     samm:dataType :ReproductiveToxicityType .
 
 :ReproductiveToxicityTypeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Reproductive Toxicity Type Enum Characteristic"@en ;
+    samm:description "Allowed values for Reproductive Toxicity Type Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "sexual function" "developmental" "lactation" ) .
 
 :RespiratoryOrSkinSensitisationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Respiratory Or Skin Sensitisation Characteristic"@en ;
+    samm:description "Single Respiratory Or Skin Sensitisation value."@en ;
     samm:dataType :RespiratoryOrSkinSensitisation .
 
 :RespiratoryOrSkinSensitisationTestResultsList a samm-c:List ;
     samm:preferredName "Respiratory Or Skin Sensitisation Test Results List"@en ;
+    samm:description "List of Respiratory Or Skin Sensitisation Test Results values."@en ;
     samm:dataType :RespiratoryOrSkinSensitisationTestResults .
 
 :RespiratoryProtectionArticleList a samm-c:List ;
     samm:preferredName "Respiratory Protection Article List"@en ;
+    samm:description "List of Respiratory Protection Article values."@en ;
     samm:dataType :RespiratoryProtectionArticle .
 
 :RespiratoryProtectionCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Respiratory Protection Characteristic"@en ;
+    samm:description "Single Respiratory Protection value."@en ;
     samm:dataType :RespiratoryProtection .
-
-:ResultsCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Results Characteristic"@en ;
-    samm:dataType :Results .
 
 :RiskManagementMeasuresCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Risk Management Measures Characteristic"@en ;
+    samm:description "Single Risk Management Measures value."@en ;
     samm:dataType :RiskManagementMeasures .
 
 :RmmControlBandingApproachList a samm-c:List ;
     samm:preferredName "Rmm Control Banding Approach List"@en ;
+    samm:description "List of Rmm Control Banding Approach values."@en ;
     samm:dataType :RmmControlBandingApproach .
 
 :RoleCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Role Characteristic"@en ;
+    samm:description "Single Role value."@en ;
     samm:dataType :Role .
 
 :RoleDescriptionEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Role Description Enum Characteristic"@en ;
+    samm:description "Allowed values for Role Description Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "Responsible company" "National responsible" "Manufacturer" "Importer" "Only representative" "Reimporter" "Formulator" "Distributor" "Downstream user" "Foreign manufacturer" ) .
 
 :SafeHandlingCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Safe Handling Characteristic"@en ;
+    samm:description "Single Safe Handling value."@en ;
     samm:dataType :SafeHandling .
 
 :SafetyRelevantInformationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Safety Relevant Information Characteristic"@en ;
+    samm:description "Single Safety Relevant Information value."@en ;
     samm:dataType :SafetyRelevantInformation .
 
 :SdsSupplierInfoCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Sds Supplier Info Characteristic"@en ;
+    samm:description "Single Sds Supplier Info value."@en ;
     samm:dataType :SdsSupplierInfo .
 
 :SdsSupplierInfoEuCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Sds Supplier Info Eu Characteristic"@en ;
+    samm:description "Single Sds Supplier Info Eu value."@en ;
     samm:dataType :SdsSupplierInfoEu .
 
 :SdscomSubsetEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Sdscom Subset Enum Characteristic"@en ;
+    samm:description "Allowed values for Sdscom Subset Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "SdsComXml Light" "SDScomBau" "SDScomChem" "full" "other" ) .
 
 :SdscomVersionEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Sdscom Version Enum Characteristic"@en ;
+    samm:description "Allowed values for Sdscom Version Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "5.6" ) .
 
 :SeaHazardClassification2021Characteristic a samm-c:SingleEntity ;
     samm:preferredName "Sea Hazard Classification2021Characteristic"@en ;
+    samm:description "Single Sea Hazard Classification2021 value."@en ;
     samm:dataType :SeaHazardClassification2021 .
 
 :SeaHazardLabelling2021Characteristic a samm-c:SingleEntity ;
     samm:preferredName "Sea Hazard Labelling2021Characteristic"@en ;
+    samm:description "Single Sea Hazard Labelling2021 value."@en ;
     samm:dataType :SeaHazardLabelling2021 .
-
-:SectorOfUseCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "Sector Of Use Characteristic"@en ;
-    samm:dataType :SectorOfUse .
 
 :SectorOfUseCodeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Sector Of Use Code Enum Characteristic"@en ;
+    samm:description "Allowed values for Sector Of Use Code Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "SU1" "SU2a" "SU2b" "SU3" "SU4" "SU5" "SU6a" "SU6b" "SU7" "SU8" "SU9" "SU10" "SU11" "SU12" "SU13" "SU14" "SU15" "SU16" "SU17" "SU18" "SU19" "SU20" "SU21" "SU22" "SU23" "SU24" "SU0" ) .
 
 :SectorOfUseList a samm-c:List ;
     samm:preferredName "Sector Of Use List"@en ;
+    samm:description "List of Sector Of Use values."@en ;
     samm:dataType :SectorOfUse .
 
 :SelfheatingSubstancesAndMixturesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Selfheating Substances And Mixtures Characteristic"@en ;
+    samm:description "Single Selfheating Substances And Mixtures value."@en ;
     samm:dataType :SelfheatingSubstancesAndMixtures .
 
 :SelfreactiveSubstancesAndMixturesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Selfreactive Substances And Mixtures Characteristic"@en ;
+    samm:description "Single Selfreactive Substances And Mixtures value."@en ;
     samm:dataType :SelfreactiveSubstancesAndMixtures .
 
 :SevesoDeCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Seveso De Characteristic"@en ;
+    samm:description "Single Seveso De value."@en ;
     samm:dataType :SevesoDe .
 
 :SevesoEntryDeCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Seveso Entry De Characteristic"@en ;
+    samm:description "Single Seveso Entry De value."@en ;
     samm:dataType :SevesoEntryDe .
 
 :SevesoEntryEuCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Seveso Entry Eu Characteristic"@en ;
+    samm:description "Single Seveso Entry Eu value."@en ;
     samm:dataType :SevesoEntryEu .
 
 :SevesoEuCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Seveso Eu Characteristic"@en ;
+    samm:description "Single Seveso Eu value."@en ;
     samm:dataType :SevesoEu .
 
 :SkinCorrosionAcidicOrAlkalineReserveCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Skin Corrosion Acidic Or Alkaline Reserve Characteristic"@en ;
+    samm:description "Single Skin Corrosion Acidic Or Alkaline Reserve value."@en ;
     samm:dataType :SkinCorrosionAcidicOrAlkalineReserve .
 
 :SkinCorrosionIrritationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Skin Corrosion Irritation Characteristic"@en ;
+    samm:description "Single Skin Corrosion Irritation value."@en ;
     samm:dataType :SkinCorrosionIrritation .
 
 :SkinProtectionCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Skin Protection Characteristic"@en ;
+    samm:description "Single Skin Protection value."@en ;
     samm:dataType :SkinProtection .
 
 :SolubilitiesList a samm-c:List ;
     samm:preferredName "Solubilities List"@en ;
+    samm:description "List of Solubilities values."@en ;
     samm:dataType :Solubilities .
 
 :SolubilityList a samm-c:List ;
     samm:preferredName "Solubility List"@en ;
+    samm:description "List of Solubility values."@en ;
     samm:dataType :Solubility .
 
 :SolubilityMediumEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Solubility Medium Enum Characteristic"@en ;
+    samm:description "Allowed values for Solubility Medium Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "Water" "Fat" "Undefined" "Other" ) .
 
 :SolutionExtractionBehaviourOfPolymersInWaterList a samm-c:List ;
     samm:preferredName "Solution Extraction Behaviour Of Polymers In Water List"@en ;
+    samm:description "List of Solution Extraction Behaviour Of Polymers In Water values."@en ;
     samm:dataType :SolutionExtractionBehaviourOfPolymersInWater .
 
 :SpeciesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Species Characteristic"@en ;
+    samm:description "Single Species value."@en ;
     samm:dataType :Species .
 
 :SpecificConcLimitList a samm-c:List ;
     samm:preferredName "Specific Conc Limit List"@en ;
+    samm:description "List of Specific Conc Limit values."@en ;
     samm:dataType :SpecificConcLimit .
 
 :SpecificEndUsesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Specific End Uses Characteristic"@en ;
+    samm:description "Single Specific End Uses value."@en ;
     samm:dataType :SpecificEndUses .
 
 :SpecificEnvironmentalReleaseCategoryList a samm-c:List ;
     samm:preferredName "Specific Environmental Release Category List"@en ;
+    samm:description "List of Specific Environmental Release Category values."@en ;
     samm:dataType :SpecificEnvironmentalReleaseCategory .
 
 :SpecificTargetOrganReCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Specific Target Organ Re Characteristic"@en ;
+    samm:description "Single Specific Target Organ Re value."@en ;
     samm:dataType :SpecificTargetOrganRe .
 
 :SpecificTargetOrganSe3Characteristic a samm-c:SingleEntity ;
     samm:preferredName "Specific Target Organ Se3Characteristic"@en ;
+    samm:description "Single Specific Target Organ Se3 value."@en ;
     samm:dataType :SpecificTargetOrganSe3 .
 
 :SpecificTargetOrganSeCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Specific Target Organ Se Characteristic"@en ;
+    samm:description "Single Specific Target Organ Se value."@en ;
     samm:dataType :SpecificTargetOrganSe .
 
 :Srt2015HazardClassificationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Srt2015Hazard Classification Characteristic"@en ;
+    samm:description "Single Srt2015Hazard Classification value."@en ;
     samm:dataType :Srt2015HazardClassification .
 
 :Srt2015HazardLabellingCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Srt2015Hazard Labelling Characteristic"@en ;
+    samm:description "Single Srt2015Hazard Labelling value."@en ;
     samm:dataType :Srt2015HazardLabelling .
 
 :StabilityReactivityCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Stability Reactivity Characteristic"@en ;
+    samm:description "Single Stability Reactivity value."@en ;
     samm:dataType :StabilityReactivity .
-
-:StateCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "State Characteristic"@en ;
-    samm:dataType :State .
-
-:StateUnderStandardConditionsCharacteristic a samm-c:SingleEntity ;
-    samm:preferredName "State Under Standard Conditions Characteristic"@en ;
-    samm:dataType :StateUnderStandardConditions .
 
 :StateUnderStandardConditionsEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "State Under Standard Conditions Enum Characteristic"@en ;
+    samm:description "Allowed values for State Under Standard Conditions Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "solid" "liquid" "gaseous" ) .
 
+:StateUnderStandardConditionsList a samm-c:List ;
+    samm:preferredName "State Under Standard Conditions List"@en ;
+    samm:description "List of State Under Standard Conditions values."@en ;
+    samm:dataType :StateUnderStandardConditions .
+
 :StelList a samm-c:List ;
     samm:preferredName "Stel List"@en ;
+    samm:description "List of Stel values."@en ;
     samm:dataType :Stel .
 
 :StorageClassEnumChCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Storage Class Enum Ch Characteristic"@en ;
+    samm:description "Allowed values for Storage Class Enum Ch."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "1" "2" "3" "4.1" "4.2" "4.3" "5" "6.1" "6.2" "7" "8" "9" "10/12" "11/13" "10" "11" "12" "13" "NK" ) .
 
 :StorageClassEnumDeCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Storage Class Enum De Characteristic"@en ;
+    samm:description "Allowed values for Storage Class Enum De."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "1" "2A" "2B" "3" "4.1A" "4.1B" "4.2" "4.3" "5.1A" "5.1B" "5.1C" "5.2" "6.1A" "6.1B" "6.1C" "6.1D" "6.2" "7" "8A" "8B" "9" "10" "11" "12" "13" "10-13" ) .
 
 :StorageStabilityList a samm-c:List ;
     samm:preferredName "Storage Stability List"@en ;
+    samm:description "List of Storage Stability values."@en ;
     samm:dataType :StorageStability .
 
 :StotDataList a samm-c:List ;
     samm:preferredName "Stot Data List"@en ;
+    samm:description "List of Stot Data values."@en ;
     samm:dataType :StotData .
 
 :SubstanceIdentifiersCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Substance Identifiers Characteristic"@en ;
+    samm:description "Single Substance Identifiers value."@en ;
     samm:dataType :SubstanceIdentifiers .
 
 :SubstanceIdentityEuCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Substance Identity Eu Characteristic"@en ;
+    samm:description "Single Substance Identity Eu value."@en ;
     samm:dataType :SubstanceIdentityEu .
 
 :SubstancesWhichInContactWithWaterEmitFlammableGasesCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Substances Which In Contact With Water Emit Flammable Gases Characteristic"@en ;
+    samm:description "Single Substances Which In Contact With Water Emit Flammable Gases value."@en ;
     samm:dataType :SubstancesWhichInContactWithWaterEmitFlammableGases .
 
 :SumiList a samm-c:List ;
     samm:preferredName "Sumi List"@en ;
+    samm:description "List of Sumi values."@en ;
     samm:dataType :Sumi .
 
 :SumiReferenceCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Sumi Reference Characteristic"@en ;
+    samm:description "Single Sumi Reference value."@en ;
     samm:dataType :SumiReference .
 
 :SummaryRmMeasuresCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Summary Rm Measures Characteristic"@en ;
+    samm:description "Single Summary Rm Measures value."@en ;
     samm:dataType :SummaryRmMeasures .
 
 :SupplementalHazardInformationList a samm-c:List ;
     samm:preferredName "Supplemental Hazard Information List"@en ;
+    samm:description "List of Supplemental Hazard Information values."@en ;
     samm:dataType :SupplementalHazardInformation .
 
 :SupplierInformationList a samm-c:List ;
     samm:preferredName "Supplier Information List"@en ;
+    samm:description "List of Supplier Information values."@en ;
     samm:dataType :SupplierInformation .
 
 :SurfaceTensionList a samm-c:List ;
     samm:preferredName "Surface Tension List"@en ;
+    samm:description "List of Surface Tension values."@en ;
     samm:dataType :SurfaceTension .
 
 :SymptomsOfExposureCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Symptoms Of Exposure Characteristic"@en ;
+    samm:description "Single Symptoms Of Exposure value."@en ;
     samm:dataType :SymptomsOfExposure .
 
 :TaLuftList a samm-c:List ;
     samm:preferredName "Ta Luft List"@en ;
+    samm:description "List of Ta Luft values."@en ;
     samm:dataType :TaLuft .
 
 :TargetGroupCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Target Group Characteristic"@en ;
+    samm:description "Single Target Group value."@en ;
     samm:dataType :TargetGroup .
 
 :TerrestrialToxicityCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Terrestrial Toxicity Characteristic"@en ;
+    samm:description "Single Terrestrial Toxicity value."@en ;
     samm:dataType :TerrestrialToxicity .
 
 :TestPerformedList a samm-c:List ;
     samm:preferredName "Test Performed List"@en ;
+    samm:description "List of Test Performed values."@en ;
     samm:dataType :TestPerformed .
-
-:TestResultsList a samm-c:List ;
-    samm:preferredName "Test Results List"@en ;
-    samm:dataType :TestResults .
 
 :ToxInfoStotSe3Characteristic a samm-c:SingleEntity ;
     samm:preferredName "Tox Info Stot Se3Characteristic"@en ;
+    samm:description "Single Tox Info Stot Se3 value."@en ;
     samm:dataType :ToxInfoStotSe3 .
 
 :ToxicokineticInfoCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Toxicokinetic Info Characteristic"@en ;
+    samm:description "Single Toxicokinetic Info value."@en ;
     samm:dataType :ToxicokineticInfo .
 
 :ToxicologicalInformationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Toxicological Information Characteristic"@en ;
+    samm:description "Single Toxicological Information value."@en ;
     samm:dataType :ToxicologicalInformation .
 
 :TradeProductIdentityList a samm-c:List ;
     samm:preferredName "Trade Product Identity List"@en ;
+    samm:description "List of Trade Product Identity values."@en ;
     samm:dataType :TradeProductIdentity .
 
 :TransportBrCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Transport Br Characteristic"@en ;
+    samm:description "Single Transport Br value."@en ;
     samm:dataType :TransportBr .
 
 :TransportCaCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Transport Ca Characteristic"@en ;
+    samm:description "Single Transport Ca value."@en ;
     samm:dataType :TransportCa .
 
 :TransportClassEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Transport Class Enum Characteristic"@en ;
+    samm:description "Allowed values for Transport Class Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "1" "2" "3" "4.1" "4.2" "4.3" "5.1" "5.2" "6.1" "6.2" "7" "8" "9" ) .
 
+:TransportCnCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Transport Cn Characteristic"@en ;
+    samm:description "Single Transport Cn value."@en ;
+    samm:dataType :TransportCn .
+
 :TransportEuCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Transport Eu Characteristic"@en ;
+    samm:description "Single Transport Eu value."@en ;
     samm:dataType :TransportEu .
 
 :TransportInBulkCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Transport In Bulk Characteristic"@en ;
+    samm:description "Single Transport In Bulk value."@en ;
     samm:dataType :TransportInBulk .
 
 :TransportInformationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Transport Information Characteristic"@en ;
+    samm:description "Single Transport Information value."@en ;
     samm:dataType :TransportInformation .
 
 :TransportMxCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Transport Mx Characteristic"@en ;
+    samm:description "Single Transport Mx value."@en ;
     samm:dataType :TransportMx .
 
 :TransportUsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Transport Us Characteristic"@en ;
+    samm:description "Single Transport Us value."@en ;
     samm:dataType :TransportUs .
 
 :TypeList a samm-c:List ;
     samm:preferredName "Type List"@en ;
+    samm:description "List of Type values."@en ;
     samm:dataType :Type .
 
 :UnitEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Unit Enum Characteristic"@en ;
+    samm:description "Allowed values for Unit Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "°C" "°F" "µg/Animal" "µg/cm3" "µg/dL" "µg/g" "µg/kg" "µg/L" "µg/mg" "µg/mL" "µg/mmol" "µg/mol" "µg" "µL/g" "µL/kg" "µL/L" "µL/m3" "µL/mg" "µL/mL" "µL/mmol" "µL/mol" "µm" "µmol/L" "µmol/mol" "µPa.s" "%" "1/K" "1/mol.s" "1/W" "A.h" "A" "a" "atm" "bar.m/s" "bar/s" "bar" "Bq" "C" "cal/kg" "cal/mol.K" "cal/mol" "cal" "cd" "Ci" "cL" "cm/d" "cm/h" "cm/min" "cm/s" "cm2" "cm3/g" "cm3/h" "cm3/min" "cm3/s" "cm3" "cm" "cP" "cSt" "d" "dL" "dm2" "dm3" "dm" "dyn/cm" "F" "fiber/cm3" "fiber/m3" "fiber/mL" "fm" "g O2/g" "g O2/L" "g/cm3" "g/dm3" "g/g" "g/h" "g/kg" "g/L.s" "g/L" "g/m3" "g/m" "g/min" "g/mL" "g/mol" "g/s" "g" "Gbq" "h" "hPa/s" "hPa" "J/kg" "J/mol" "J" "K/min" "K" "kA.h" "kcal/kg" "kcal/mol" "kcal" "kg/dm3" "kg/h" "kg/ha" "kg/L" "kg/m3" "kg/min" "kg/mol" "kg/s.m2" "kg/s" "kg" "kJ/kg" "kJ/mol" "kJ" "km/d" "km/h" "kPa/s" "kPa" "kV" "kW" "L/h" "L/kg.h" "L/kg.min" "L/kg.s" "L/kg" "L/L" "L/m3" "L/min" "L/mol" "L/s" "L" "lm" "lx" "m/d" "m/h" "m/min" "m/s" "m2" "m3/h" "m3/min" "m3/s" "m3" "m" "mA" "mbar" "mCi" "mg C/g" "mg C/L" "mg KOH/g" "mg O2/g" "mg O2/L" "mg/Animal" "mg/cm2" "mg/cm3" "mg/dm2" "mg/dm3" "mg/Eye" "mg/g" "mg/h" "mg/kg bw.d" "mg/kg bw" "mg/kg" "mg/L" "mg/m3" "mg/mg" "mg/min" "mg/mL" "mg/mmol" "mg/mol" "mg/s" "mg" "min" "mJ" "mL/Animal" "mL/Eye" "mL/g" "mL/h" "mL/kg" "mL/L" "mL/m3" "mL/mg" "mL/min" "mL/mL" "mL/mmol" "mL/mol" "mL/s" "mL" "mm H2O" "mm Hg" "mm/a" "mm/d" "mm/h" "mm/min" "mm/s" "mm2/s" "mm2" "mm3" "mm" "mmol/g" "mmol/kg" "mmol/L" "mmol/m3" "mmol/mg" "mmol/mL" "mmol/mmol" "mmol/mol" "mN/m" "mol-%" "mol/g" "mol/kg" "mol/L.s" "mol/L" "mol/m3" "mol/mg" "mol/mL" "mol/mmol" "mol/mol" "mPa.s" "mPa" "ms" "mV" "N/cm2" "N/m2" "N/m" "N/mm2" "ng/cm3" "ng/g" "ng/L" "ng/mg" "ng/mL" "ng/mmol" "ng/mol" "nm" "nmol/L" "P" "Pa.m3/mol" "Pa.s" "Pa/s" "Pa" "pm" "ppb" "ppm" "ppq" "ppt" "S" "s" "St" "t/h" "t/min" "t/s" "t" "Torr" "U/g" "U/kg" "U/L" "U/mg" "U/mL" "U/mmol" "U/mol" "V" "Vol-%" "W.h" "W.m" "W" "Wb" "Weight-%" ) .
 
 :UnknownToxicityCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Unknown Toxicity Characteristic"@en ;
+    samm:description "Single Unknown Toxicity value."@en ;
     samm:dataType :UnknownToxicity .
 
 :UpperQualifierEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Upper Qualifier Enum Characteristic"@en ;
+    samm:description "Allowed values for Upper Qualifier Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "lt" "le" ) .
 
 :UpperTierQuantityInlineCharacteristic a samm:Characteristic ;
     samm:preferredName "Upper Tier Quantity Inline Characteristic"@en ;
+    samm:description "Value of XSD type xsd:integer."@en ;
     samm:dataType xsd:integer .
 
 :UseDescriptorsCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Use Descriptors Characteristic"@en ;
+    samm:description "Single Use Descriptors value."@en ;
     samm:dataType :UseDescriptors .
 
 :VbfClassCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Vbf Class Characteristic"@en ;
+    samm:description "Allowed values for Vbf Class."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "A I" "A II" "A III" "B I" "B II" ) .
 
 :ViscosityList a samm-c:List ;
     samm:preferredName "Viscosity List"@en ;
+    samm:description "List of Viscosity values."@en ;
     samm:dataType :Viscosity .
 
 :ViscosityTypeEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Viscosity Type Enum Characteristic"@en ;
+    samm:description "Allowed values for Viscosity Type Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "Dynamic" "Kinematic" "Flow time" "Undefined" "Other" ) .
 
 :VocCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Voc Characteristic"@en ;
+    samm:description "Single Voc value."@en ;
     samm:dataType :Voc .
 
 :VocLabellingList a samm-c:List ;
     samm:preferredName "Voc Labelling List"@en ;
+    samm:description "List of Voc Labelling values."@en ;
     samm:dataType :VocLabelling .
 
 :WasteListEntryList a samm-c:List ;
     samm:preferredName "Waste List Entry List"@en ;
+    samm:description "List of Waste List Entry values."@en ;
     samm:dataType :WasteListEntry .
 
 :WasteTreatmentCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Waste Treatment Characteristic"@en ;
+    samm:description "Single Waste Treatment value."@en ;
     samm:dataType :WasteTreatment .
 
 :WaterHazardClassCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Water Hazard Class Characteristic"@en ;
+    samm:description "Single Water Hazard Class value."@en ;
     samm:dataType :WaterHazardClass .
 
 :WaterHazardClassEnumCharacteristic a samm-c:Enumeration ;
     samm:preferredName "Water Hazard Class Enum Characteristic"@en ;
+    samm:description "Allowed values for Water Hazard Class Enum."@en ;
     samm:dataType xsd:string ;
     samm-c:values ( "1" "2" "3" "nwg" "awg" ) .
 
 :Whmis2015HazardClassificationCharacteristic a samm-c:SingleEntity ;
     samm:preferredName "Whmis2015Hazard Classification Characteristic"@en ;
+    samm:description "Single Whmis2015Hazard Classification value."@en ;
     samm:dataType :Whmis2015HazardClassification .
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -5924,6 +6961,7 @@
 
 :AbntNrb2015HazardClassification a samm:Entity ;
     samm:preferredName "Abnt Nrb2015Hazard Classification"@en ;
+    samm:description "Abnt Nrb2015Hazard Classification structure from the eSDScom XML schema."@en ;
     samm:properties (
         :hazardClassCategory
         :hazardClassCategoryPrintable
@@ -5937,6 +6975,7 @@
 
 :AbntNrb2017HazardLabelling a samm:Entity ;
     samm:preferredName "Abnt Nrb2017Hazard Labelling"@en ;
+    samm:description "Abnt Nrb2017Hazard Labelling structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :hazardPictogram ; samm:optional true ]
         [ samm:property :signalWord ; samm:optional true ]
@@ -5947,6 +6986,7 @@
 
 :AbntNrb2019HazardClassification a samm:Entity ;
     samm:preferredName "Abnt Nrb2019Hazard Classification"@en ;
+    samm:description "Abnt Nrb2019Hazard Classification structure from the eSDScom XML schema."@en ;
     samm:properties (
         :hazardClassCategory
         :hazardClassCategoryPrintable
@@ -5972,6 +7012,7 @@
 
 :AcuteToxicity a samm:Entity ;
     samm:preferredName "Acute Toxicity"@en ;
+    samm:description "Acute Toxicity structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :testResults ; samm:optional true ]
         [ samm:property :acuteToxicityHumanExperience ; samm:optional true ]
@@ -5981,6 +7022,7 @@
 
 :AdditionalEcotoxInformation a samm:Entity ;
     samm:preferredName "Additional Ecotox Information"@en ;
+    samm:description "Additional Ecotox Information structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :dissolvedOrganicCarbon ; samm:optional true ]
         [ samm:property :theoreticalOxygenDemand ; samm:optional true ]
@@ -5998,6 +7040,7 @@
 
 :Address a samm:Entity ;
     samm:preferredName "Address"@en ;
+    samm:description "Address structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :visitingAddressLine1 ; samm:optional true ]
         [ samm:property :visitingAddressLine2 ; samm:optional true ]
@@ -6013,6 +7056,7 @@
 
 :Adn a samm:Entity ;
     samm:preferredName "Adn"@en ;
+    samm:description "Adn structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :unNo ; samm:optional true ]
         [ samm:property :properShippingNameEnglish ; samm:optional true ]
@@ -6028,6 +7072,7 @@
 
 :AdrRid a samm:Entity ;
     samm:preferredName "Adr Rid"@en ;
+    samm:description "Adr Rid structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :unNo ; samm:optional true ]
         [ samm:property :properShippingNameEnglish ; samm:optional true ]
@@ -6044,10 +7089,12 @@
 
 :AnnexesEu a samm:Entity ;
     samm:preferredName "Annexes Eu"@en ;
+    samm:description "Annexes Eu structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :safeUseInfoForMixtures ; samm:optional true ] ) .
 
 :Appearance a samm:Entity ;
     samm:preferredName "Appearance"@en ;
+    samm:description "Appearance structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :form ; samm:optional true ]
         [ samm:property :formDescription ; samm:optional true ]
@@ -6062,6 +7109,7 @@
 
 :AppropriateEnvionmentalExposureControl a samm:Entity ;
     samm:preferredName "Appropriate Envionmental Exposure Control"@en ;
+    samm:description "Appropriate Envionmental Exposure Control structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :productRelatedMeasures ; samm:optional true ]
         [ samm:property :instructionalMeasures ; samm:optional true ]
@@ -6071,6 +7119,7 @@
 
 :AquaticToxicity a samm:Entity ;
     samm:preferredName "Aquatic Toxicity"@en ;
+    samm:description "Aquatic Toxicity structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :acuteFishToxicity ; samm:optional true ]
         [ samm:property :chronicFishToxicity ; samm:optional true ]
@@ -6093,6 +7142,7 @@
 
 :AspirationHazard a samm:Entity ;
     samm:preferredName "Aspiration Hazard"@en ;
+    samm:description "Aspiration Hazard structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :testReference ; samm:optional true ]
         [ samm:property :aspirationHazardHydrocarbonContent ; samm:optional true ]
@@ -6103,6 +7153,7 @@
 
 :Assessment a samm:Entity ;
     samm:preferredName "Assessment"@en ;
+    samm:description "Assessment structure from the eSDScom XML schema."@en ;
     samm:properties (
         :assessmentAssessmentEnum
         [ samm:property :assessmentFulltext ; samm:optional true ]
@@ -6110,6 +7161,7 @@
 
 :Ate a samm:Entity ;
     samm:preferredName "Ate"@en ;
+    samm:description "Ate structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :inhalation ; samm:optional true ]
         [ samm:property :dermal ; samm:optional true ]
@@ -6140,6 +7192,7 @@
 
 :Bioaccumulation a samm:Entity ;
     samm:preferredName "Bioaccumulation"@en ;
+    samm:description "Bioaccumulation structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :bioconcentrationFactor ; samm:optional true ]
         [ samm:property :bioaccumulationEvaluation ; samm:optional true ]
@@ -6148,6 +7201,7 @@
 
 :Biocides a samm:Entity ;
     samm:preferredName "Biocides"@en ;
+    samm:description "Biocides structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :isBiocide ; samm:optional true ]
         [ samm:property :isTreatedArticle ; samm:optional true ]
@@ -6160,6 +7214,7 @@
 
 :BioconcentrationFactor a samm:Entity ;
     samm:preferredName "Bioconcentration Factor"@en ;
+    samm:description "Bioconcentration Factor structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
         [ samm:property :speciesSpecies ; samm:optional true ]
@@ -6194,6 +7249,7 @@
 
 :BiologicalLimitValues a samm:Entity ;
     samm:preferredName "Biological Limit Values"@en ;
+    samm:description "Biological Limit Values structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :biologicalLimitValue ; samm:optional true ]
         [ samm:property :intendedUseBiologicalLimitValue ; samm:optional true ]
@@ -6201,6 +7257,7 @@
 
 :BoilingPointRelated a samm:Entity ;
     samm:preferredName "Boiling Point Related"@en ;
+    samm:description "Boiling Point Related structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :boilingPoint ; samm:optional true ]
         [ samm:property :sublimationPoint ; samm:optional true ]
@@ -6208,6 +7265,7 @@
 
 :California a samm:Entity ;
     samm:preferredName "California"@en ;
+    samm:description "California structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :hazardousWasteCode ; samm:optional true ]
         [ samm:property :hazardousWasteStatus ; samm:optional true ]
@@ -6215,6 +7273,7 @@
 
 :Carcinogenicity a samm:Entity ;
     samm:preferredName "Carcinogenicity"@en ;
+    samm:description "Carcinogenicity structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :carcinogenicityTestResults ; samm:optional true ]
         [ samm:property :carcinogenicityHumanExperience ; samm:optional true ]
@@ -6224,6 +7283,7 @@
 
 :CertainFluorinatedGreenhouseGases a samm:Entity ;
     samm:preferredName "Certain Fluorinated Greenhouse Gases"@en ;
+    samm:description "Certain Fluorinated Greenhouse Gases structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :fluorinatedGreenhouseGasesMethod ; samm:optional true ]
         [ samm:property :additionalInfo ; samm:optional true ]
@@ -6231,6 +7291,7 @@
 
 :ChemicalSafetyAssessmentInfo a samm:Entity ;
     samm:preferredName "Chemical Safety Assessment Info"@en ;
+    samm:description "Chemical Safety Assessment Info structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :chemicalSafetyAssessmentCarriedOut ; samm:optional true ]
         [ samm:property :chemicalSafetyAssessment ; samm:optional true ]
@@ -6238,6 +7299,7 @@
 
 :ChemicalSafetyReport a samm:Entity ;
     samm:preferredName "Chemical Safety Report"@en ;
+    samm:description "Chemical Safety Report structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :csrRequired ; samm:optional true ]
         [ samm:property :csrLocation ; samm:optional true ]
@@ -6245,6 +7307,7 @@
 
 :Classification a samm:Entity ;
     samm:preferredName "Classification"@en ;
+    samm:description "Classification structure from the eSDScom XML schema."@en ;
     samm:properties (
         :hazardClassCategory
         :hazardClassCategoryPrintable
@@ -6255,10 +7318,12 @@
 
 :ClassificationAr a samm:Entity ;
     samm:preferredName "Classification Ar"@en ;
+    samm:description "Classification Ar structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :srt2015HazardClassification ; samm:optional true ] ) .
 
 :ClassificationAssessment a samm:Entity ;
     samm:preferredName "Classification Assessment"@en ;
+    samm:description "Classification Assessment structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :assessmentRespiratorySensitisationClassification ; samm:optional true ]
         [ samm:property :assessmentSkinSensitisationClassification ; samm:optional true ]
@@ -6266,6 +7331,7 @@
 
 :ClassificationBr a samm:Entity ;
     samm:preferredName "Classification Br"@en ;
+    samm:description "Classification Br structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :abntNrb2015HazardClassification ; samm:optional true ]
         [ samm:property :abntNrb2019HazardClassification ; samm:optional true ]
@@ -6273,22 +7339,32 @@
 
 :ClassificationCa a samm:Entity ;
     samm:preferredName "Classification Ca"@en ;
+    samm:description "Classification Ca structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :whmis2015HazardClassification ; samm:optional true ] ) .
+
+:ClassificationCn a samm:Entity ;
+    samm:preferredName "Classification Cn"@en ;
+    samm:description "Classification Cn structure from the eSDScom XML schema."@en ;
+    samm:properties ( [ samm:property :gbt2009HazardClassification ; samm:optional true ] ) .
 
 :ClassificationGb a samm:Entity ;
     samm:preferredName "Classification Gb"@en ;
+    samm:description "Classification Gb structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :gbClpHazardClassification2020 ; samm:optional true ] ) .
 
 :ClassificationMx a samm:Entity ;
     samm:preferredName "Classification Mx"@en ;
+    samm:description "Classification Mx structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :nom2015HazardClassification ; samm:optional true ] ) .
 
 :ClassificationTr a samm:Entity ;
     samm:preferredName "Classification Tr"@en ;
+    samm:description "Classification Tr structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :seaHazardClassification2021 ; samm:optional true ] ) .
 
 :ClassificationUs a samm:Entity ;
     samm:preferredName "Classification Us"@en ;
+    samm:description "Classification Us structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :hazcom2012HazardClassification ; samm:optional true ] ) .
 
 :CmrData a samm:Entity ;
@@ -6310,6 +7386,7 @@
 
 :CompanyContact a samm:Entity ;
     samm:preferredName "Company Contact"@en ;
+    samm:description "Company Contact structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :name ; samm:optional true ]
         [ samm:property :phone ; samm:optional true ]
@@ -6322,6 +7399,7 @@
 
 :CompleteSdsWithEsIncorporated a samm:Entity ;
     samm:preferredName "Complete Sds With Es Incorporated"@en ;
+    samm:description "Complete Sds With Es Incorporated structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :extendedSdsWithEsIncorporated ; samm:optional true ]
         [ samm:property :additionalInfo ; samm:optional true ]
@@ -6335,6 +7413,7 @@
         [ samm:property :regionAr ; samm:optional true ]
         [ samm:property :regionBr ; samm:optional true ]
         [ samm:property :regionCa ; samm:optional true ]
+        [ samm:property :regionCn ; samm:optional true ]
         [ samm:property :regionEu ; samm:optional true ]
         [ samm:property :regionGb ; samm:optional true ]
         [ samm:property :regionMx ; samm:optional true ]
@@ -6345,6 +7424,7 @@
 
 :ConditionsForSafeStorage a samm:Entity ;
     samm:preferredName "Conditions For Safe Storage"@en ;
+    samm:description "Conditions For Safe Storage structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :technicalMeasuresAndStorageConditions ; samm:optional true ]
         [ samm:property :packagingContainer ; samm:optional true ]
@@ -6359,6 +7439,7 @@
 
 :ConsumerExposureControl a samm:Entity ;
     samm:preferredName "Consumer Exposure Control"@en ;
+    samm:description "Consumer Exposure Control structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :measuresOnConsumerUseOfTheChemical ; samm:optional true ]
         [ samm:property :measuresOnServiceLifeInArticles ; samm:optional true ]
@@ -6366,6 +7447,7 @@
 
 :ContainmentAndCleaningUp a samm:Entity ;
     samm:preferredName "Containment And Cleaning Up"@en ;
+    samm:description "Containment And Cleaning Up structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :containment ; samm:optional true ]
         [ samm:property :cleaningUp ; samm:optional true ]
@@ -6374,6 +7456,7 @@
 
 :ControlParameters a samm:Entity ;
     samm:preferredName "Control Parameters"@en ;
+    samm:description "Control Parameters structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :occupationalExposureLimits ; samm:optional true ]
         [ samm:property :biologicalLimitValues ; samm:optional true ]
@@ -6383,6 +7466,7 @@
 
 :ControlParametersEu a samm:Entity ;
     samm:preferredName "Control Parameters Eu"@en ;
+    samm:description "Control Parameters Eu structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :derivedNoEffectLevel ; samm:optional true ]
         [ samm:property :derivedMinimalEffectLevel ; samm:optional true ]
@@ -6391,6 +7475,7 @@
 
 :CorrespondingExposureScenario a samm:Entity ;
     samm:preferredName "Corresponding Exposure Scenario"@en ;
+    samm:description "Corresponding Exposure Scenario structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :exposureScenarioName ; samm:optional true ]
         [ samm:property :legalDocumentFileName ; samm:optional true ]
@@ -6416,6 +7501,7 @@
 
 :CorrosiveToMetals a samm:Entity ;
     samm:preferredName "Corrosive To Metals"@en ;
+    samm:description "Corrosive To Metals structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -6426,6 +7512,7 @@
 
 :Datasheet a samm:Entity ;
     samm:preferredName "Datasheet"@en ;
+    samm:description "Datasheet structure from the eSDScom XML schema."@en ;
     samm:properties (
         :identificationSubstPrep
         :hazardIdentification
@@ -6457,6 +7544,7 @@
 
 :Densities a samm:Entity ;
     samm:preferredName "Densities"@en ;
+    samm:description "Densities structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :relativeDensity ; samm:optional true ]
         [ samm:property :density ; samm:optional true ]
@@ -6465,6 +7553,7 @@
 
 :DescriptionOfFirstAidMeasures a samm:Entity ;
     samm:preferredName "Description Of First Aid Measures"@en ;
+    samm:description "Description Of First Aid Measures structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :firstAidInhalation ; samm:optional true ]
@@ -6476,6 +7565,7 @@
 
 :Detergents a samm:Entity ;
     samm:preferredName "Detergents"@en ;
+    samm:description "Detergents structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :isDetergent ; samm:optional true ]
         [ samm:property :nameDetergentsRegulation ; samm:optional true ]
@@ -6494,6 +7584,7 @@
 
 :DisposalConsiderationsEu a samm:Entity ;
     samm:preferredName "Disposal Considerations Eu"@en ;
+    samm:description "Disposal Considerations Eu structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :europeanWasteList ; samm:optional true ]
         [ samm:property :euWasteRegulations ; samm:optional true ]
@@ -6501,6 +7592,7 @@
 
 :DisposalConsiderationsUs a samm:Entity ;
     samm:preferredName "Disposal Considerations Us"@en ;
+    samm:description "Disposal Considerations Us structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :federal ; samm:optional true ]
         [ samm:property :state ; samm:optional true ]
@@ -6539,6 +7631,7 @@
 
 :Dose a samm:Entity ;
     samm:preferredName "Dose"@en ;
+    samm:description "Dose structure from the eSDScom XML schema."@en ;
     samm:properties (
         :typeDoseEnum
         [ samm:property :typeFulltext ; samm:optional true ]
@@ -6588,6 +7681,7 @@
 
 :EcotoxicologicalInformation a samm:Entity ;
     samm:preferredName "Ecotoxicological Information"@en ;
+    samm:description "Ecotoxicological Information structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :aquaticToxicity ; samm:optional true ]
         [ samm:property :sedimentToxicity ; samm:optional true ]
@@ -6597,6 +7691,7 @@
 
 :EmergencyPhone a samm:Entity ;
     samm:preferredName "Emergency Phone"@en ;
+    samm:description "Emergency Phone structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :noString256 ; samm:optional true ]
         [ samm:property :emergencyPhoneDescription ; samm:optional true ]
@@ -6604,6 +7699,7 @@
 
 :EnvironmentalExposureControls a samm:Entity ;
     samm:preferredName "Environmental Exposure Controls"@en ;
+    samm:description "Environmental Exposure Controls structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :environmentalExposureControls ; samm:optional true ]
         [ samm:property :appropriateEnvionmentalExposureControl ; samm:optional true ]
@@ -6621,6 +7717,7 @@
 
 :Equipment a samm:Entity ;
     samm:preferredName "Equipment"@en ;
+    samm:description "Equipment structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :suitableGlovesType ; samm:optional true ]
         [ samm:property :suitableMaterial ; samm:optional true ]
@@ -6633,6 +7730,7 @@
 
 :EuLegislation a samm:Entity ;
     samm:preferredName "Eu Legislation"@en ;
+    samm:description "Eu Legislation structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :assessedLegislation ; samm:optional true ]
         [ samm:property :authorisationNo ; samm:optional true ]
@@ -6661,6 +7759,7 @@
 
 :EuropeanWasteList a samm:Entity ;
     samm:preferredName "European Waste List"@en ;
+    samm:description "European Waste List structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :ewlProduct ; samm:optional true ]
         [ samm:property :ewlPacking ; samm:optional true ]
@@ -6668,6 +7767,7 @@
 
 :ExplosionLimit a samm:Entity ;
     samm:preferredName "Explosion Limit"@en ;
+    samm:description "Explosion Limit structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :lowerExplosionLimit ; samm:optional true ]
         [ samm:property :upperExplosionLimit ; samm:optional true ]
@@ -6675,6 +7775,7 @@
 
 :Explosives a samm:Entity ;
     samm:preferredName "Explosives"@en ;
+    samm:description "Explosives structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :screeningProcedures ; samm:optional true ]
@@ -6683,6 +7784,7 @@
 
 :ExposureControlAppropriateMeasures a samm:Entity ;
     samm:preferredName "Exposure Control Appropriate Measures"@en ;
+    samm:description "Exposure Control Appropriate Measures structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :appropriateEngineeringControls ; samm:optional true ]
         [ samm:property :productRelatedMeasures ; samm:optional true ]
@@ -6710,6 +7812,7 @@
 
 :ExposureGroup a samm:Entity ;
     samm:preferredName "Exposure Group"@en ;
+    samm:description "Exposure Group structure from the eSDScom XML schema."@en ;
     samm:properties (
         :group
         [ samm:property :groupFulltext ; samm:optional true ]
@@ -6717,6 +7820,7 @@
 
 :ExposureRoute a samm:Entity ;
     samm:preferredName "Exposure Route"@en ;
+    samm:description "Exposure Route structure from the eSDScom XML schema."@en ;
     samm:properties (
         :route
         [ samm:property :routeFulltext ; samm:optional true ]
@@ -6724,6 +7828,7 @@
 
 :ExposureRouteFrequencyAndEffect a samm:Entity ;
     samm:preferredName "Exposure Route Frequency And Effect"@en ;
+    samm:description "Exposure Route Frequency And Effect structure from the eSDScom XML schema."@en ;
     samm:properties (
         :typeEffectLevelTypeEnum
         [ samm:property :typeFulltext ; samm:optional true ]
@@ -6731,6 +7836,7 @@
 
 :ExposureScenario a samm:Entity ;
     samm:preferredName "Exposure Scenario"@en ;
+    samm:description "Exposure Scenario structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :mixtureExposureScenarioInAnnex ; samm:optional true ]
         [ samm:property :additionalInfo ; samm:optional true ]
@@ -6738,6 +7844,7 @@
 
 :ExtinguishingMedia a samm:Entity ;
     samm:preferredName "Extinguishing Media"@en ;
+    samm:description "Extinguishing Media structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :mediaToBeUsed ; samm:optional true ]
         [ samm:property :mediaNotBeUsed ; samm:optional true ]
@@ -6745,6 +7852,7 @@
 
 :EyeDamageOrIrritation a samm:Entity ;
     samm:preferredName "Eye Damage Or Irritation"@en ;
+    samm:description "Eye Damage Or Irritation structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :eyeDamageOrIrritationTestResults ; samm:optional true ]
         [ samm:property :eyeIrritation ; samm:optional true ]
@@ -6756,6 +7864,7 @@
 
 :EyeProtection a samm:Entity ;
     samm:preferredName "Eye Protection"@en ;
+    samm:description "Eye Protection structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :requiredProperties ; samm:optional true ]
         [ samm:property :suitableEyeProtection ; samm:optional true ]
@@ -6768,6 +7877,7 @@
 
 :Federal a samm:Entity ;
     samm:preferredName "Federal"@en ;
+    samm:description "Federal structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :rcraWasteCode ; samm:optional true ]
         [ samm:property :hazardousWasteCharacteristics ; samm:optional true ]
@@ -6800,6 +7910,7 @@
 
 :FlammableAerosols a samm:Entity ;
     samm:preferredName "Flammable Aerosols"@en ;
+    samm:description "Flammable Aerosols structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -6807,6 +7918,7 @@
 
 :FlammableGases a samm:Entity ;
     samm:preferredName "Flammable Gases"@en ;
+    samm:description "Flammable Gases structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -6814,6 +7926,7 @@
 
 :FlammableLiquids a samm:Entity ;
     samm:preferredName "Flammable Liquids"@en ;
+    samm:description "Flammable Liquids structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -6821,6 +7934,7 @@
 
 :FlammableSolids a samm:Entity ;
     samm:preferredName "Flammable Solids"@en ;
+    samm:description "Flammable Solids structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -6838,10 +7952,19 @@
 
 :ForNonEmergencyPersonnel a samm:Entity ;
     samm:preferredName "For Non Emergency Personnel"@en ;
+    samm:description "For Non Emergency Personnel structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :personalPrecautions ; samm:optional true ]
         [ samm:property :protectiveEquipment ; samm:optional true ]
         [ samm:property :emergencyProcedures ; samm:optional true ]
+    ) .
+
+:FullText a samm:Entity ;
+    samm:preferredName "Full Text"@en ;
+    samm:description "Full Text structure from the eSDScom XML schema."@en ;
+    samm:properties (
+        [ samm:property :languange ; samm:optional true ]
+        [ samm:property :country ; samm:optional true ]
     ) .
 
 :FurtherEcologicalData a samm:Entity ;
@@ -6866,6 +7989,7 @@
 
 :GasesUnderPressure a samm:Entity ;
     samm:preferredName "Gases Under Pressure"@en ;
+    samm:description "Gases Under Pressure structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -6873,6 +7997,7 @@
 
 :GbClpHazardClassification2020 a samm:Entity ;
     samm:preferredName "Gb Clp Hazard Classification2020"@en ;
+    samm:description "Gb Clp Hazard Classification2020 structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :classification ; samm:optional true ]
         [ samm:property :multiplyingFactor ; samm:optional true ]
@@ -6886,6 +8011,7 @@
 
 :GbClpHazardLabelling2020 a samm:Entity ;
     samm:preferredName "Gb Clp Hazard Labelling2020"@en ;
+    samm:description "Gb Clp Hazard Labelling2020 structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :hazardPictogram ; samm:optional true ]
         [ samm:property :signalWord ; samm:optional true ]
@@ -6899,8 +8025,23 @@
         [ samm:property :childResistantOpening ; samm:optional true ]
     ) .
 
+:Gbt2009HazardClassification a samm:Entity ;
+    samm:preferredName "Gbt2009Hazard Classification"@en ;
+    samm:description "Gbt2009Hazard Classification structure from the eSDScom XML schema."@en ;
+    samm:properties (
+        :hazardClassCategory
+        :hazardClassCategoryPrintable
+        [ samm:property :organ ; samm:optional true ]
+        [ samm:property :exposureRoutePhrase ; samm:optional true ]
+        [ samm:property :classificationProcedure ; samm:optional true ]
+        [ samm:property :unknownToxicity ; samm:optional true ]
+        [ samm:property :ate ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+    ) .
+
 :GeneralDescription a samm:Entity ;
     samm:preferredName "General Description"@en ;
+    samm:description "General Description structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :useDescriptors ; samm:optional true ]
         [ samm:property :swedReference ; samm:optional true ]
@@ -6909,6 +8050,7 @@
 
 :GermCellMutagenicity a samm:Entity ;
     samm:preferredName "Germ Cell Mutagenicity"@en ;
+    samm:description "Germ Cell Mutagenicity structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :testResults ; samm:optional true ]
         [ samm:property :germCellMutagenicityHumanExperience ; samm:optional true ]
@@ -6999,6 +8141,7 @@
 
 :GoodPracticeAdvice a samm:Entity ;
     samm:preferredName "Good Practice Advice"@en ;
+    samm:description "Good Practice Advice structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :text ; samm:optional true ]
         [ samm:property :agpaPictogram ; samm:optional true ]
@@ -7006,6 +8149,7 @@
 
 :HandProtection a samm:Entity ;
     samm:preferredName "Hand Protection"@en ;
+    samm:description "Hand Protection structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :skinHandProtectionShortTermContact ; samm:optional true ]
         [ samm:property :skinHandProtectionLongTermContact ; samm:optional true ]
@@ -7035,6 +8179,7 @@
         [ samm:property :regionAr ; samm:optional true ]
         [ samm:property :regionBr ; samm:optional true ]
         [ samm:property :regionCa ; samm:optional true ]
+        [ samm:property :regionCn ; samm:optional true ]
         [ samm:property :regionEu ; samm:optional true ]
         [ samm:property :regionGb ; samm:optional true ]
         [ samm:property :regionMx ; samm:optional true ]
@@ -7044,30 +8189,32 @@
 
 :HazardLabellingAr a samm:Entity ;
     samm:preferredName "Hazard Labelling Ar"@en ;
+    samm:description "Hazard Labelling Ar structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :srt2015HazardLabelling ; samm:optional true ] ) .
 
 :HazardLabellingBr a samm:Entity ;
     samm:preferredName "Hazard Labelling Br"@en ;
+    samm:description "Hazard Labelling Br structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :abntNrb2017HazardLabelling ; samm:optional true ] ) .
-
-:HazardLabellingCa a samm:Entity ;
-    samm:preferredName "Hazard Labelling Ca"@en ;
-    samm:properties ( ) .
 
 :HazardLabellingGb a samm:Entity ;
     samm:preferredName "Hazard Labelling Gb"@en ;
+    samm:description "Hazard Labelling Gb structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :gbClpHazardLabelling2020 ; samm:optional true ] ) .
 
 :HazardLabellingMx a samm:Entity ;
     samm:preferredName "Hazard Labelling Mx"@en ;
+    samm:description "Hazard Labelling Mx structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :nom2015HazardLabelling ; samm:optional true ] ) .
 
 :HazardLabellingTr a samm:Entity ;
     samm:preferredName "Hazard Labelling Tr"@en ;
+    samm:description "Hazard Labelling Tr structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :seaHazardLabelling2021 ; samm:optional true ] ) .
 
 :HazardLabellingUs a samm:Entity ;
     samm:preferredName "Hazard Labelling Us"@en ;
+    samm:description "Hazard Labelling Us structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :hazcom2012HazardLabelling ; samm:optional true ]
         [ samm:property :labellingAccordingToOtherLegislation ; samm:optional true ]
@@ -7075,6 +8222,7 @@
 
 :Hazcom2012HazardClassification a samm:Entity ;
     samm:preferredName "Hazcom2012Hazard Classification"@en ;
+    samm:description "Hazcom2012Hazard Classification structure from the eSDScom XML schema."@en ;
     samm:properties (
         :hazardClassCategory
         :hazardClassCategoryPrintable
@@ -7088,6 +8236,7 @@
 
 :Hazcom2012HazardLabelling a samm:Entity ;
     samm:preferredName "Hazcom2012Hazard Labelling"@en ;
+    samm:description "Hazcom2012Hazard Labelling structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :hazardPictogram ; samm:optional true ]
         [ samm:property :signalWord ; samm:optional true ]
@@ -7100,6 +8249,7 @@
 
 :HumanExperience a samm:Entity ;
     samm:preferredName "Human Experience"@en ;
+    samm:description "Human Experience structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :respiratorySensitisationHumanExperience ; samm:optional true ]
         [ samm:property :skinSensitisationHumanExperience ; samm:optional true ]
@@ -7116,6 +8266,7 @@
 
 :IataDgr a samm:Entity ;
     samm:preferredName "Iata Dgr"@en ;
+    samm:description "Iata Dgr structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :unNo ; samm:optional true ]
         [ samm:property :properShippingNameEnglish ; samm:optional true ]
@@ -7137,12 +8288,14 @@
         [ samm:property :use ; samm:optional true ]
         [ samm:property :useAdvisedAgainst ; samm:optional true ]
         [ samm:property :regionCaSdsSupplierInfo ; samm:optional true ]
+        [ samm:property :regionCnSdsSupplierInfo ; samm:optional true ]
         [ samm:property :regionEuSdsSupplierInfoEu ; samm:optional true ]
         [ samm:property :regionUsSdsSupplierInfo ; samm:optional true ]
     ) .
 
 :IdentifiedUse a samm:Entity ;
     samm:preferredName "Identified Use"@en ;
+    samm:description "Identified Use structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :sectorOfUse ; samm:optional true ]
         [ samm:property :productCategory ; samm:optional true ]
@@ -7158,6 +8311,7 @@
 
 :Imdg a samm:Entity ;
     samm:preferredName "Imdg"@en ;
+    samm:description "Imdg structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :unNo ; samm:optional true ]
         [ samm:property :properShippingNameEnglish ; samm:optional true ]
@@ -7171,6 +8325,7 @@
 
 :IndustrialEmissions a samm:Entity ;
     samm:preferredName "Industrial Emissions"@en ;
+    samm:description "Industrial Emissions structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :vocInPercentByWeight ; samm:optional true ]
         [ samm:property :vocValue ; samm:optional true ]
@@ -7179,6 +8334,7 @@
 
 :InformationFromExportingSystem a samm:Entity ;
     samm:preferredName "Information From Exporting System"@en ;
+    samm:description "Information From Exporting System structure from the eSDScom XML schema."@en ;
     samm:properties (
         :sdscomVersionNo
         [ samm:property :sdscomSubset ; samm:optional true ]
@@ -7191,6 +8347,7 @@
 
 :InformationToHealthProfessionals a samm:Entity ;
     samm:preferredName "Information To Health Professionals"@en ;
+    samm:description "Information To Health Professionals structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :symptomsAndEffectsGeneral ; samm:optional true ]
         [ samm:property :acuteSymptomsAndEffects ; samm:optional true ]
@@ -7199,6 +8356,7 @@
 
 :InvestigationMethod a samm:Entity ;
     samm:preferredName "Investigation Method"@en ;
+    samm:description "Investigation Method structure from the eSDScom XML schema."@en ;
     samm:properties (
         :methodInvestigationMethodEnum
         [ samm:property :methodFulltext ; samm:optional true ]
@@ -7206,6 +8364,7 @@
 
 :LabellingAccordingToOtherLegislation a samm:Entity ;
     samm:preferredName "Labelling According To Other Legislation"@en ;
+    samm:description "Labelling According To Other Legislation structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :vocLabelling ; samm:optional true ]
         [ samm:property :detergentLabelling ; samm:optional true ]
@@ -7215,6 +8374,7 @@
 
 :Language a samm:Entity ;
     samm:preferredName "Language"@en ;
+    samm:description "Language structure from the eSDScom XML schema."@en ;
     samm:properties (
         :freetextLanguageCode
         [ samm:property :freetextLanguageCountryCode ; samm:optional true ]
@@ -7223,6 +8383,7 @@
 
 :LegalDocument a samm:Entity ;
     samm:preferredName "Legal Document"@en ;
+    samm:description "Legal Document structure from the eSDScom XML schema."@en ;
     samm:properties (
         :legalDocumentFileName
         [ samm:property :legalDocumentPrintDate ; samm:optional true ]
@@ -7232,6 +8393,7 @@
 
 :MajorAccidentsOrdinance a samm:Entity ;
     samm:preferredName "Major Accidents Ordinance"@en ;
+    samm:description "Major Accidents Ordinance structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :healthHazardThreshold ; samm:optional true ]
         [ samm:property :physicalHazardThreshold ; samm:optional true ]
@@ -7241,6 +8403,7 @@
 
 :MedicalAttentionAndSpecialTreatmentNeeded a samm:Entity ;
     samm:preferredName "Medical Attention And Special Treatment Needed"@en ;
+    samm:description "Medical Attention And Special Treatment Needed structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :medicalTreatment ; samm:optional true ]
         [ samm:property :requiredClinicalTesting ; samm:optional true ]
@@ -7251,6 +8414,7 @@
 
 :MeltingPointRelated a samm:Entity ;
     samm:preferredName "Melting Point Related"@en ;
+    samm:description "Melting Point Related structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :meltingPoint ; samm:optional true ]
         [ samm:property :freezingPoint ; samm:optional true ]
@@ -7276,6 +8440,7 @@
 
 :Mobility a samm:Entity ;
     samm:preferredName "Mobility"@en ;
+    samm:description "Mobility structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :distribution ; samm:optional true ]
         [ samm:property :transportType ; samm:optional true ]
@@ -7286,6 +8451,7 @@
 
 :MultiplyingFactor a samm:Entity ;
     samm:preferredName "Multiplying Factor"@en ;
+    samm:description "Multiplying Factor structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :acute ; samm:optional true ]
         [ samm:property :chronic ; samm:optional true ]
@@ -7293,6 +8459,7 @@
 
 :NationalLegislation a samm:Entity ;
     samm:preferredName "National Legislation"@en ;
+    samm:description "National Legislation structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :nationalLegislationAndorra ; samm:optional true ]
         [ samm:property :nationalLegislationAlbania ; samm:optional true ]
@@ -7357,6 +8524,7 @@
 
 :NationalWasteLegislationNo a samm:Entity ;
     samm:preferredName "National Waste Legislation No"@en ;
+    samm:description "National Waste Legislation No structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :nationalWasteCode ; samm:optional true ]
         [ samm:property :nationalRegulations ; samm:optional true ]
@@ -7364,6 +8532,7 @@
 
 :Nom2015HazardClassification a samm:Entity ;
     samm:preferredName "Nom2015Hazard Classification"@en ;
+    samm:description "Nom2015Hazard Classification structure from the eSDScom XML schema."@en ;
     samm:properties (
         :hazardClassCategory
         :hazardClassCategoryPrintable
@@ -7377,6 +8546,7 @@
 
 :Nom2015HazardLabelling a samm:Entity ;
     samm:preferredName "Nom2015Hazard Labelling"@en ;
+    samm:description "Nom2015Hazard Labelling structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :hazardPictogram ; samm:optional true ]
         [ samm:property :signalWord ; samm:optional true ]
@@ -7387,6 +8557,7 @@
 
 :NonHumanToxicologicalData a samm:Entity ;
     samm:preferredName "Non Human Toxicological Data"@en ;
+    samm:description "Non Human Toxicological Data structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :methodPhrase ; samm:optional true ]
         [ samm:property :speciesSpecies ; samm:optional true ]
@@ -7397,24 +8568,41 @@
 
 :NumericRangeWithQualifier a samm:Entity ;
     samm:preferredName "Numeric Range With Qualifier"@en ;
-    samm:description "eSDScom type NumericRangeWithQualifier (internal structure not expanded)."@en ;
-    samm:properties ( ) .
+    samm:description "Numeric ranges only make sense with qualifiers, thus no \"NumericRange\" or \"NumericRangeWithUnit\" types exist."@en ;
+    samm:properties (
+        [ samm:property :exactValueSymbol ; samm:optional true ]
+        [ samm:property :exactValue ; samm:optional true ]
+        [ samm:property :upperValueSymbol ; samm:optional true ]
+        [ samm:property :upperValue ; samm:optional true ]
+        [ samm:property :lowerValueSymbol ; samm:optional true ]
+        [ samm:property :lowerValue ; samm:optional true ]
+    ) .
 
 :NumericRangeWithUnitAndQualifier a samm:Entity ;
     samm:preferredName "Numeric Range With Unit And Qualifier"@en ;
-    samm:description "eSDScom type NumericRangeWithUnitAndQualifier (internal structure not expanded)."@en ;
-    samm:properties ( ) .
+    samm:description "Numeric Range With Unit And Qualifier structure from the eSDScom XML schema."@en ;
+    samm:properties (
+        [ samm:property :exactValueSymbol ; samm:optional true ]
+        [ samm:property :exactValue ; samm:optional true ]
+        [ samm:property :upperValueSymbol ; samm:optional true ]
+        [ samm:property :upperValue ; samm:optional true ]
+        [ samm:property :lowerValueSymbol ; samm:optional true ]
+        [ samm:property :lowerValue ; samm:optional true ]
+    ) .
 
 :NumericValue a samm:Entity ;
     samm:preferredName "Numeric Value"@en ;
+    samm:description "Numeric Value structure from the eSDScom XML schema."@en ;
     samm:properties ( :exactValue ) .
 
 :NumericValueWithUnit a samm:Entity ;
     samm:preferredName "Numeric Value With Unit"@en ;
+    samm:description "Numeric Value With Unit structure from the eSDScom XML schema."@en ;
     samm:properties ( :exactValue ) .
 
 :NumericValueWithUnitAndQualifier a samm:Entity ;
     samm:preferredName "Numeric Value With Unit And Qualifier"@en ;
+    samm:description "Numeric Value With Unit And Qualifier structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :exactValueSymbol ; samm:optional true ]
         :exactValue
@@ -7422,6 +8610,7 @@
 
 :OccupationalAirRequirementNo a samm:Entity ;
     samm:preferredName "Occupational Air Requirement No"@en ;
+    samm:description "Occupational Air Requirement No structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :oarGroup ; samm:optional true ]
         [ samm:property :oarValue ; samm:optional true ]
@@ -7443,6 +8632,7 @@
 
 :OccupationalExposureLimits a samm:Entity ;
     samm:preferredName "Occupational Exposure Limits"@en ;
+    samm:description "Occupational Exposure Limits structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :occupationalExposureLimit ; samm:optional true ]
         [ samm:property :intendedUseOccupationalExposureLimit ; samm:optional true ]
@@ -7450,6 +8640,7 @@
 
 :OperationalConditions a samm:Entity ;
     samm:preferredName "Operational Conditions"@en ;
+    samm:description "Operational Conditions structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :properties ; samm:optional true ]
         [ samm:property :text ; samm:optional true ]
@@ -7457,6 +8648,7 @@
 
 :OrganicPeroxides a samm:Entity ;
     samm:preferredName "Organic Peroxides"@en ;
+    samm:description "Organic Peroxides structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -7464,6 +8656,7 @@
 
 :OtherAdverseEffects a samm:Entity ;
     samm:preferredName "Other Adverse Effects"@en ;
+    samm:description "Other Adverse Effects structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :ozoneDepletionPotential ; samm:optional true ]
         [ samm:property :photochemicalOzoneCreationPotential ; samm:optional true ]
@@ -7474,6 +8667,7 @@
 
 :OtherHazardsInfo a samm:Entity ;
     samm:preferredName "Other Hazards Info"@en ;
+    samm:description "Other Hazards Info structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :hazardDescriptionGeneral ; samm:optional true ]
         [ samm:property :physicochemicalEffect ; samm:optional true ]
@@ -7485,6 +8679,7 @@
 
 :OtherInformation a samm:Entity ;
     samm:preferredName "Other Information"@en ;
+    samm:description "Other Information structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :limitedQty ; samm:optional true ]
         [ samm:property :exceptedQty ; samm:optional true ]
@@ -7495,6 +8690,7 @@
 
 :OtherSafetyInformation a samm:Entity ;
     samm:preferredName "Other Safety Information"@en ;
+    samm:description "Other Safety Information structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :miscibility ; samm:optional true ]
         [ samm:property :anilinePoint ; samm:optional true ]
@@ -7528,6 +8724,7 @@
 
 :OxidisingGases a samm:Entity ;
     samm:preferredName "Oxidising Gases"@en ;
+    samm:description "Oxidising Gases structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -7535,6 +8732,7 @@
 
 :OxidisingLiquids a samm:Entity ;
     samm:preferredName "Oxidising Liquids"@en ;
+    samm:description "Oxidising Liquids structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -7542,6 +8740,7 @@
 
 :OxidisingSolids a samm:Entity ;
     samm:preferredName "Oxidising Solids"@en ;
+    samm:description "Oxidising Solids structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -7549,6 +8748,7 @@
 
 :Packaging a samm:Entity ;
     samm:preferredName "Packaging"@en ;
+    samm:description "Packaging structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :packagingType ; samm:optional true ]
         [ samm:property :packagingTypeDescription ; samm:optional true ]
@@ -7559,6 +8759,7 @@
 
 :ParticleFraction a samm:Entity ;
     samm:preferredName "Particle Fraction"@en ;
+    samm:description "Particle Fraction structure from the eSDScom XML schema."@en ;
     samm:properties (
         :particleFraction
         [ samm:property :particleFractionFulltext ; samm:optional true ]
@@ -7575,6 +8776,7 @@
 
 :PeakLimitation a samm:Entity ;
     samm:preferredName "Peak Limitation"@en ;
+    samm:description "Peak Limitation structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
         [ samm:property :peakLimitationOverflowFactor ; samm:optional true ]
@@ -7594,6 +8796,7 @@
 
 :PersistenceDegradability a samm:Entity ;
     samm:preferredName "Persistence Degradability"@en ;
+    samm:description "Persistence Degradability structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :biologicalDegradability ; samm:optional true ]
         [ samm:property :abioticDegradation ; samm:optional true ]
@@ -7602,6 +8805,7 @@
 
 :PersonalProtectionEquipment a samm:Entity ;
     samm:preferredName "Personal Protection Equipment"@en ;
+    samm:description "Personal Protection Equipment structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :respiratoryProtection ; samm:optional true ]
         [ samm:property :eyeProtection ; samm:optional true ]
@@ -7626,6 +8830,7 @@
 
 :Phototoxicity a samm:Entity ;
     samm:preferredName "Phototoxicity"@en ;
+    samm:description "Phototoxicity structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :phototoxicityTestResults ; samm:optional true ]
         [ samm:property :additionalInfo ; samm:optional true ]
@@ -7633,6 +8838,7 @@
 
 :PhototoxicityTestResults a samm:Entity ;
     samm:preferredName "Phototoxicity Test Results"@en ;
+    samm:description "Phototoxicity Test Results structure from the eSDScom XML schema."@en ;
     samm:properties (
         :investigationMethod
         [ samm:property :testMethod ; samm:optional true ]
@@ -7647,8 +8853,16 @@
 
 :Phrase a samm:Entity ;
     samm:preferredName "Phrase"@en ;
-    samm:description "eSDScom type Phrase (internal structure not expanded)."@en ;
-    samm:properties ( ) .
+    samm:description "Phrase, using optional references to a coordination body assigning ids to all phrases. PhraseId is a unique identifier (primary key) that must exist in each phrase catalogue. PhraseId has precedence over textual phrase values if both are present. PhraseCode is any official or system-internal phrase identifier which may be unique or not (and is often empty). Example: In EuPhraC, PhraseIds 9278174452 to 9278174455 all refer to PhraseCode = H341, however EuPhraC decided to name the other codes as H341.1, H341.2 and H341.3. Note the use of MergePhrase restricts the nesting depth to one level."@en ;
+    samm:properties (
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCodeString64 ; samm:optional true ]
+        [ samm:property :fullText ; samm:optional true ]
+        [ samm:property :mergePhrase ; samm:optional true ]
+        [ samm:property :newLine ; samm:optional true ]
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+    ) .
 
 :PhraseCatalogue a samm:Entity ;
     samm:preferredName "Phrase Catalogue"@en ;
@@ -7674,8 +8888,14 @@
 
 :PhysChemUnitValueWithTemperature a samm:Entity ;
     samm:preferredName "Phys Chem Unit Value With Temperature"@en ;
-    samm:description "eSDScom type PhysChemUnitValueWithTemperature (internal structure not expanded)."@en ;
-    samm:properties ( ) .
+    samm:description "PhysChemUnitValueWithTemperature. Source: Chapter 9."@en ;
+    samm:properties (
+        [ samm:property :unitValue ; samm:optional true ]
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :reasonForWaiving ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
 
 :PhysChemValue a samm:Entity ;
     samm:preferredName "Phys Chem Value"@en ;
@@ -7714,6 +8934,7 @@
 
 :PhysicalHazards a samm:Entity ;
     samm:preferredName "Physical Hazards"@en ;
+    samm:description "Physical Hazards structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :explosives ; samm:optional true ]
         [ samm:property :flammableGases ; samm:optional true ]
@@ -7773,6 +8994,7 @@
 
 :PrProductRegistrationNo a samm:Entity ;
     samm:preferredName "Pr Product Registration No"@en ;
+    samm:description "Pr Product Registration No structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :prProductNo ; samm:optional true ]
         [ samm:property :notApplicableReason ; samm:optional true ]
@@ -7784,6 +9006,7 @@
 
 :PrecautionaryMeasures a samm:Entity ;
     samm:preferredName "Precautionary Measures"@en ;
+    samm:description "Precautionary Measures structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :protectiveMeasures ; samm:optional true ]
         [ samm:property :measuresToPreventFire ; samm:optional true ]
@@ -7819,6 +9042,7 @@
 
 :ProductIdentifiers a samm:Entity ;
     samm:preferredName "Product Identifiers"@en ;
+    samm:description "Product Identifiers structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :tradeName ; samm:optional true ]
         [ samm:property :regionEu ; samm:optional true ]
@@ -7826,6 +9050,7 @@
 
 :Properties a samm:Entity ;
     samm:preferredName "Properties"@en ;
+    samm:description "Properties structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :maxDuration ; samm:optional true ]
         [ samm:property :rangeOfApplication ; samm:optional true ]
@@ -7846,6 +9071,7 @@
 
 :PyrophoricLiquids a samm:Entity ;
     samm:preferredName "Pyrophoric Liquids"@en ;
+    samm:description "Pyrophoric Liquids structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -7853,6 +9079,7 @@
 
 :PyrophoricSolids a samm:Entity ;
     samm:preferredName "Pyrophoric Solids"@en ;
+    samm:description "Pyrophoric Solids structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -7860,6 +9087,7 @@
 
 :RegionAr a samm:Entity ;
     samm:preferredName "Region Ar"@en ;
+    samm:description "Region Ar structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :classificationClassificationAr ; samm:optional true ]
         [ samm:property :hazardLabelling ; samm:optional true ]
@@ -7867,6 +9095,7 @@
 
 :RegionBr a samm:Entity ;
     samm:preferredName "Region Br"@en ;
+    samm:description "Region Br structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :classificationClassificationBr ; samm:optional true ]
         [ samm:property :hazardLabelling ; samm:optional true ]
@@ -7874,17 +9103,28 @@
 
 :RegionCa a samm:Entity ;
     samm:preferredName "Region Ca"@en ;
+    samm:description "Region Ca structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :classificationClassificationCa ; samm:optional true ]
         [ samm:property :hazardLabelling ; samm:optional true ]
     ) .
 
+:RegionCn a samm:Entity ;
+    samm:preferredName "Region Cn"@en ;
+    samm:description "Region Cn structure from the eSDScom XML schema."@en ;
+    samm:properties (
+        [ samm:property :classificationClassificationCn ; samm:optional true ]
+        [ samm:property :hazardLabelling ; samm:optional true ]
+    ) .
+
 :RegionEu a samm:Entity ;
     samm:preferredName "Region Eu"@en ;
+    samm:description "Region Eu structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :ufi ; samm:optional true ] ) .
 
 :RegionGb a samm:Entity ;
     samm:preferredName "Region Gb"@en ;
+    samm:description "Region Gb structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :classificationClassificationGb ; samm:optional true ]
         [ samm:property :hazardLabelling ; samm:optional true ]
@@ -7892,6 +9132,7 @@
 
 :RegionMx a samm:Entity ;
     samm:preferredName "Region Mx"@en ;
+    samm:description "Region Mx structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :classificationClassificationMx ; samm:optional true ]
         [ samm:property :hazardLabelling ; samm:optional true ]
@@ -7899,6 +9140,7 @@
 
 :RegionTr a samm:Entity ;
     samm:preferredName "Region Tr"@en ;
+    samm:description "Region Tr structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :classificationClassificationTr ; samm:optional true ]
         [ samm:property :hazardLabelling ; samm:optional true ]
@@ -7906,6 +9148,7 @@
 
 :RegionUs a samm:Entity ;
     samm:preferredName "Region Us"@en ;
+    samm:description "Region Us structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :classificationClassificationUs ; samm:optional true ]
         [ samm:property :hazardLabelling ; samm:optional true ]
@@ -7927,11 +9170,6 @@
     samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentTR."@en ;
     samm:properties ( [ samm:property :otherLegislation ; samm:optional true ] ) .
 
-:RegulationsCa a samm:Entity ;
-    samm:preferredName "Regulations Ca"@en ;
-    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentCA."@en ;
-    samm:properties ( ) .
-
 :RegulationsCh a samm:Entity ;
     samm:preferredName "Regulations Ch"@en ;
     samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentCH."@en ;
@@ -7939,7 +9177,7 @@
         [ samm:property :majorAccidentsOrdinance ; samm:optional true ]
         [ samm:property :nationalWasteLegislationCh ; samm:optional true ]
         [ samm:property :storageClassCh ; samm:optional true ]
-        [ samm:property :cpid ; samm:optional true ]
+        [ samm:property :cpId ; samm:optional true ]
     ) .
 
 :RegulationsDe a samm:Entity ;
@@ -7978,11 +9216,6 @@
         [ samm:property :exposureScenario ; samm:optional true ]
     ) .
 
-:RegulationsGb a samm:Entity ;
-    samm:preferredName "Regulations Gb"@en ;
-    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentGB."@en ;
-    samm:properties ( ) .
-
 :RegulationsJp a samm:Entity ;
     samm:preferredName "Regulations Jp"@en ;
     samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentJP."@en ;
@@ -8007,6 +9240,7 @@
 
 :RegulationsRelatedToCountryOrRegion a samm:Entity ;
     samm:preferredName "Regulations Related To Country Or Region"@en ;
+    samm:description "Regulations Related To Country Or Region structure from the eSDScom XML schema."@en ;
     samm:properties (
         :regulationsRelatedToCountryOrRegionCode
         [ samm:property :regulationsRelatedToCountryOrRegionName ; samm:optional true ]
@@ -8043,7 +9277,6 @@
         [ samm:property :additionalInfo ; samm:optional true ]
         [ samm:property :regionAr ; samm:optional true ]
         [ samm:property :regionBrRegulationsBr ; samm:optional true ]
-        [ samm:property :regionCaRegulationsCa ; samm:optional true ]
         [ samm:property :regionEuRegulationsEu ; samm:optional true ]
         [ samm:property :regionGb ; samm:optional true ]
         [ samm:property :regionJp ; samm:optional true ]
@@ -8055,6 +9288,7 @@
 
 :RelatedDocuments a samm:Entity ;
     samm:preferredName "Related Documents"@en ;
+    samm:description "Related Documents structure from the eSDScom XML schema."@en ;
     samm:properties (
         :fileName
         [ samm:property :description ; samm:optional true ]
@@ -8064,12 +9298,13 @@
     samm:preferredName "Relative Vapour Density"@en ;
     samm:description "RelativeVapourDensity source: Chapter 9"@en ;
     samm:properties (
-        [ samm:property :valuePhysChemUnitValueWithTemperature ; samm:optional true ]
+        [ samm:property :valuePhysChemValueWithTemperature ; samm:optional true ]
         [ samm:property :referenceGas ; samm:optional true ]
     ) .
 
 :RelevantIdentifiedUse a samm:Entity ;
     samm:preferredName "Relevant Identified Use"@en ;
+    samm:description "Relevant Identified Use structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :identifiedUse ; samm:optional true ]
         [ samm:property :productType ; samm:optional true ]
@@ -8078,6 +9313,7 @@
 
 :ReproductiveToxicity a samm:Entity ;
     samm:preferredName "Reproductive Toxicity"@en ;
+    samm:description "Reproductive Toxicity structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :reproductiveToxicityType ; samm:optional true ]
         [ samm:property :reproductiveToxicityTestResults ; samm:optional true ]
@@ -8088,6 +9324,7 @@
 
 :ReproductiveToxicityType a samm:Entity ;
     samm:preferredName "Reproductive Toxicity Type"@en ;
+    samm:description "Reproductive Toxicity Type structure from the eSDScom XML schema."@en ;
     samm:properties (
         :typeReproductiveToxicityTypeEnum
         [ samm:property :typeFulltext ; samm:optional true ]
@@ -8095,6 +9332,7 @@
 
 :RespiratoryOrSkinSensitisation a samm:Entity ;
     samm:preferredName "Respiratory Or Skin Sensitisation"@en ;
+    samm:description "Respiratory Or Skin Sensitisation structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :respiratoryOrSkinSensitisationTestResults ; samm:optional true ]
         [ samm:property :humanExperience ; samm:optional true ]
@@ -8104,6 +9342,7 @@
 
 :RespiratoryOrSkinSensitisationTestResults a samm:Entity ;
     samm:preferredName "Respiratory Or Skin Sensitisation Test Results"@en ;
+    samm:description "Respiratory Or Skin Sensitisation Test Results structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :methodPhrase ; samm:optional true ]
         [ samm:property :dose ; samm:optional true ]
@@ -8119,6 +9358,7 @@
 
 :RespiratoryProtection a samm:Entity ;
     samm:preferredName "Respiratory Protection"@en ;
+    samm:description "Respiratory Protection structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :respiratoryProtectionGeneral ; samm:optional true ]
         [ samm:property :respiratoryProtectionNecessaryAt ; samm:optional true ]
@@ -8144,6 +9384,7 @@
 
 :Results a samm:Entity ;
     samm:preferredName "Results"@en ;
+    samm:description "Results structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
         [ samm:property :photoIrritationFactor ; samm:optional true ]
@@ -8153,6 +9394,7 @@
 
 :RiskManagementMeasures a samm:Entity ;
     samm:preferredName "Risk Management Measures"@en ;
+    samm:description "Risk Management Measures structure from the eSDScom XML schema."@en ;
     samm:properties (
         :rmmWorker
         [ samm:property :rmmPictogram ; samm:optional true ]
@@ -8161,6 +9403,7 @@
 
 :RmmControlBandingApproach a samm:Entity ;
     samm:preferredName "Rmm Control Banding Approach"@en ;
+    samm:description "Rmm Control Banding Approach structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :task ; samm:optional true ]
         [ samm:property :hazardBand ; samm:optional true ]
@@ -8172,6 +9415,7 @@
 
 :Role a samm:Entity ;
     samm:preferredName "Role"@en ;
+    samm:description "Role structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :roleCode ; samm:optional true ]
         [ samm:property :roleDescription ; samm:optional true ]
@@ -8179,6 +9423,7 @@
 
 :SafeHandling a samm:Entity ;
     samm:preferredName "Safe Handling"@en ;
+    samm:description "Safe Handling structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :handlingPrecautions ; samm:optional true ]
         [ samm:property :safeHandlingOfGasContainers ; samm:optional true ]
@@ -8189,6 +9434,7 @@
 
 :SafetyRelevantInformation a samm:Entity ;
     samm:preferredName "Safety Relevant Information"@en ;
+    samm:description "Safety Relevant Information structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :phValue ; samm:optional true ]
         [ samm:property :meltingPointRelated ; samm:optional true ]
@@ -8211,6 +9457,7 @@
 
 :SdsSupplierInfo a samm:Entity ;
     samm:preferredName "Sds Supplier Info"@en ;
+    samm:description "Sds Supplier Info structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :sdsName ; samm:optional true ]
         [ samm:property :sdsNotLegallyRequired ; samm:optional true ]
@@ -8225,6 +9472,7 @@
 
 :SdsSupplierInfoEu a samm:Entity ;
     samm:preferredName "Sds Supplier Info Eu"@en ;
+    samm:description "Sds Supplier Info Eu structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :sdsName ; samm:optional true ]
         [ samm:property :sdsNotLegallyRequired ; samm:optional true ]
@@ -8243,6 +9491,7 @@
 
 :SeaHazardClassification2021 a samm:Entity ;
     samm:preferredName "Sea Hazard Classification2021"@en ;
+    samm:description "Sea Hazard Classification2021 structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :classification ; samm:optional true ]
         [ samm:property :multiplyingFactor ; samm:optional true ]
@@ -8256,6 +9505,7 @@
 
 :SeaHazardLabelling2021 a samm:Entity ;
     samm:preferredName "Sea Hazard Labelling2021"@en ;
+    samm:description "Sea Hazard Labelling2021 structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :hazardPictogram ; samm:optional true ]
         [ samm:property :signalWord ; samm:optional true ]
@@ -8280,6 +9530,7 @@
 
 :SelfheatingSubstancesAndMixtures a samm:Entity ;
     samm:preferredName "Selfheating Substances And Mixtures"@en ;
+    samm:description "Selfheating Substances And Mixtures structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -8289,6 +9540,7 @@
 
 :SelfreactiveSubstancesAndMixtures a samm:Entity ;
     samm:preferredName "Selfreactive Substances And Mixtures"@en ;
+    samm:description "Selfreactive Substances And Mixtures structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :screeningProcedures ; samm:optional true ]
@@ -8297,6 +9549,7 @@
 
 :SevesoDe a samm:Entity ;
     samm:preferredName "Seveso De"@en ;
+    samm:description "Seveso De structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :healthHazardsSevesoEntryDe ; samm:optional true ]
         [ samm:property :physicalHazardsSevesoEntryDe ; samm:optional true ]
@@ -8306,6 +9559,7 @@
 
 :SevesoEntryDe a samm:Entity ;
     samm:preferredName "Seveso Entry De"@en ;
+    samm:description "Seveso Entry De structure from the eSDScom XML schema."@en ;
     samm:properties (
         :code
         :lowerTierQuantity
@@ -8324,6 +9578,7 @@
 
 :SevesoEu a samm:Entity ;
     samm:preferredName "Seveso Eu"@en ;
+    samm:description "Seveso Eu structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :healthHazardsSevesoEntryEu ; samm:optional true ]
         [ samm:property :physicalHazardsSevesoEntryEu ; samm:optional true ]
@@ -8333,6 +9588,7 @@
 
 :SkinCorrosionAcidicOrAlkalineReserve a samm:Entity ;
     samm:preferredName "Skin Corrosion Acidic Or Alkaline Reserve"@en ;
+    samm:description "Skin Corrosion Acidic Or Alkaline Reserve structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :skinCorrosionAcidicReserve ; samm:optional true ]
         [ samm:property :skinCorrosionAlkalineReserve ; samm:optional true ]
@@ -8340,6 +9596,7 @@
 
 :SkinCorrosionIrritation a samm:Entity ;
     samm:preferredName "Skin Corrosion Irritation"@en ;
+    samm:description "Skin Corrosion Irritation structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :skinCorrosionIrritationTestResults ; samm:optional true ]
         [ samm:property :skinCorrosionAcidicOrAlkalineReserve ; samm:optional true ]
@@ -8352,6 +9609,7 @@
 
 :SkinProtection a samm:Entity ;
     samm:preferredName "Skin Protection"@en ;
+    samm:description "Skin Protection structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :suitableProtectiveClothing ; samm:optional true ]
         [ samm:property :unsuitableProtectiveClothing ; samm:optional true ]
@@ -8375,6 +9633,7 @@
 
 :Solubility a samm:Entity ;
     samm:preferredName "Solubility"@en ;
+    samm:description "Solubility structure from the eSDScom XML schema."@en ;
     samm:properties (
         :medium
         [ samm:property :mediumDescription ; samm:optional true ]
@@ -8399,6 +9658,7 @@
 
 :SpecificConcLimit a samm:Entity ;
     samm:preferredName "Specific Conc Limit"@en ;
+    samm:description "Specific Conc Limit structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :hazardClassCategory ; samm:optional true ]
         [ samm:property :hazardClassCategoryPrintable ; samm:optional true ]
@@ -8412,6 +9672,7 @@
 
 :SpecificEndUses a samm:Entity ;
     samm:preferredName "Specific End Uses"@en ;
+    samm:description "Specific End Uses structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :recommendations ; samm:optional true ]
         [ samm:property :industrialSectorSpecificSolutions ; samm:optional true ]
@@ -8428,6 +9689,7 @@
 
 :SpecificTargetOrganRe a samm:Entity ;
     samm:preferredName "Specific Target Organ Re"@en ;
+    samm:description "Specific Target Organ Re structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :specificTargetOrganReTestResults ; samm:optional true ]
         [ samm:property :specificTargetOrganReHumanExperience ; samm:optional true ]
@@ -8437,6 +9699,7 @@
 
 :SpecificTargetOrganSe a samm:Entity ;
     samm:preferredName "Specific Target Organ Se"@en ;
+    samm:description "Specific Target Organ Se structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :specificTargetOrganSeTestResults ; samm:optional true ]
         [ samm:property :specificTargetOrganSeHumanExperience ; samm:optional true ]
@@ -8446,6 +9709,7 @@
 
 :SpecificTargetOrganSe3 a samm:Entity ;
     samm:preferredName "Specific Target Organ Se3"@en ;
+    samm:description "Specific Target Organ Se3 structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :irritationToRespiratoryTract ; samm:optional true ]
         [ samm:property :narcoticEffects ; samm:optional true ]
@@ -8456,6 +9720,7 @@
 
 :Srt2015HazardClassification a samm:Entity ;
     samm:preferredName "Srt2015Hazard Classification"@en ;
+    samm:description "Srt2015Hazard Classification structure from the eSDScom XML schema."@en ;
     samm:properties (
         :hazardClassCategory
         :hazardClassCategoryPrintable
@@ -8469,6 +9734,7 @@
 
 :Srt2015HazardLabelling a samm:Entity ;
     samm:preferredName "Srt2015Hazard Labelling"@en ;
+    samm:description "Srt2015Hazard Labelling structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :hazardPictogram ; samm:optional true ]
         [ samm:property :signalWord ; samm:optional true ]
@@ -8492,10 +9758,12 @@
 
 :State a samm:Entity ;
     samm:preferredName "State"@en ;
+    samm:description "State structure from the eSDScom XML schema."@en ;
     samm:properties ( [ samm:property :california ; samm:optional true ] ) .
 
 :StateUnderStandardConditions a samm:Entity ;
     samm:preferredName "State Under Standard Conditions"@en ;
+    samm:description "State Under Standard Conditions structure from the eSDScom XML schema."@en ;
     samm:properties (
         :state
         [ samm:property :stateFulltext ; samm:optional true ]
@@ -8511,6 +9779,7 @@
 
 :StorageStability a samm:Entity ;
     samm:preferredName "Storage Stability"@en ;
+    samm:description "Storage Stability structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :storageTemperature ; samm:optional true ]
         [ samm:property :pressure ; samm:optional true ]
@@ -8539,6 +9808,7 @@
 
 :SubstanceIdentifiers a samm:Entity ;
     samm:preferredName "Substance Identifiers"@en ;
+    samm:description "Substance Identifiers structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :iupacName ; samm:optional true ]
         [ samm:property :casInventoryName ; samm:optional true ]
@@ -8550,6 +9820,7 @@
 
 :SubstanceIdentityEu a samm:Entity ;
     samm:preferredName "Substance Identity Eu"@en ;
+    samm:description "Substance Identity Eu structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :indexNo ; samm:optional true ]
         [ samm:property :ecNo ; samm:optional true ]
@@ -8558,6 +9829,7 @@
 
 :SubstancesWhichInContactWithWaterEmitFlammableGases a samm:Entity ;
     samm:preferredName "Substances Which In Contact With Water Emit Flammable Gases"@en ;
+    samm:description "Substances Which In Contact With Water Emit Flammable Gases structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :generalInformation ; samm:optional true ]
         [ samm:property :safetyCharacteristics ; samm:optional true ]
@@ -8579,6 +9851,7 @@
 
 :SumiReference a samm:Entity ;
     samm:preferredName "Sumi Reference"@en ;
+    samm:description "Sumi Reference structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :sectorSumiCode ; samm:optional true ]
         [ samm:property :versionNumber ; samm:optional true ]
@@ -8586,6 +9859,7 @@
 
 :SummaryRmMeasures a samm:Entity ;
     samm:preferredName "Summary Rm Measures"@en ;
+    samm:description "Summary Rm Measures structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :summaryRmMeasuresMan ; samm:optional true ]
         [ samm:property :summaryRmMeasuresEnvironm ; samm:optional true ]
@@ -8606,6 +9880,7 @@
 
 :SupplierInformation a samm:Entity ;
     samm:preferredName "Supplier Information"@en ;
+    samm:description "Supplier Information structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :role ; samm:optional true ]
         :country
@@ -8629,6 +9904,7 @@
 
 :SymptomsOfExposure a samm:Entity ;
     samm:preferredName "Symptoms Of Exposure"@en ;
+    samm:description "Symptoms Of Exposure structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :inCaseOfIngestion ; samm:optional true ]
         [ samm:property :inCaseOfSkinContact ; samm:optional true ]
@@ -8638,6 +9914,7 @@
 
 :TaLuft a samm:Entity ;
     samm:preferredName "Ta Luft"@en ;
+    samm:description "Ta Luft structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :weightFraction ; samm:optional true ]
         [ samm:property :classOrClasses ; samm:optional true ]
@@ -8647,6 +9924,7 @@
 
 :TargetGroup a samm:Entity ;
     samm:preferredName "Target Group"@en ;
+    samm:description "Target Group structure from the eSDScom XML schema."@en ;
     samm:properties (
         :industrialUse
         :professionalUse
@@ -8655,6 +9933,7 @@
 
 :TerrestrialToxicity a samm:Entity ;
     samm:preferredName "Terrestrial Toxicity"@en ;
+    samm:description "Terrestrial Toxicity structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :soilMicroorganismsToxicity ; samm:optional true ]
         [ samm:property :acuteEarthwormToxicity ; samm:optional true ]
@@ -8668,6 +9947,7 @@
 
 :TestPerformed a samm:Entity ;
     samm:preferredName "Test Performed"@en ;
+    samm:description "Test Performed structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :parameterTested ; samm:optional true ]
         [ samm:property :testResult ; samm:optional true ]
@@ -8675,6 +9955,7 @@
 
 :TestResults a samm:Entity ;
     samm:preferredName "Test Results"@en ;
+    samm:description "Test Results structure from the eSDScom XML schema."@en ;
     samm:properties (
         :effectTested
         :exposureRouteExposureRoute
@@ -8688,6 +9969,7 @@
 
 :ToxInfoStotSe3 a samm:Entity ;
     samm:preferredName "Tox Info Stot Se3"@en ;
+    samm:description "Tox Info Stot Se3 structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :humanExperience ; samm:optional true ]
         [ samm:property :source ; samm:optional true ]
@@ -8697,6 +9979,7 @@
 
 :ToxicokineticInfo a samm:Entity ;
     samm:preferredName "Toxicokinetic Info"@en ;
+    samm:description "Toxicokinetic Info structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :nonHumanToxicologicalData ; samm:optional true ]
         [ samm:property :humanToxicologicalData ; samm:optional true ]
@@ -8729,6 +10012,7 @@
 
 :TradeProductIdentity a samm:Entity ;
     samm:preferredName "Trade Product Identity"@en ;
+    samm:description "Trade Product Identity structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :userId ; samm:optional true ]
         :productNoUser
@@ -8742,6 +10026,7 @@
 
 :TransportBr a samm:Entity ;
     samm:preferredName "Transport Br"@en ;
+    samm:description "Transport Br structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :unNo ; samm:optional true ]
         [ samm:property :properShippingName ; samm:optional true ]
@@ -8756,6 +10041,7 @@
 
 :TransportCa a samm:Entity ;
     samm:preferredName "Transport Ca"@en ;
+    samm:description "Transport Ca structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :unNo ; samm:optional true ]
         [ samm:property :properShippingName ; samm:optional true ]
@@ -8766,8 +10052,23 @@
         [ samm:property :otherInformation ; samm:optional true ]
     ) .
 
+:TransportCn a samm:Entity ;
+    samm:preferredName "Transport Cn"@en ;
+    samm:description "Transport Cn structure from the eSDScom XML schema."@en ;
+    samm:properties (
+        [ samm:property :unNo ; samm:optional true ]
+        [ samm:property :properShippingName ; samm:optional true ]
+        [ samm:property :dangerReleasingSubstance ; samm:optional true ]
+        [ samm:property :classTransportClassEnum ; samm:optional true ]
+        [ samm:property :classCode ; samm:optional true ]
+        [ samm:property :packingGroup ; samm:optional true ]
+        [ samm:property :placard ; samm:optional true ]
+        [ samm:property :otherInformation ; samm:optional true ]
+    ) .
+
 :TransportEu a samm:Entity ;
     samm:preferredName "Transport Eu"@en ;
+    samm:description "Transport Eu structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :adrRid ; samm:optional true ]
         [ samm:property :adn ; samm:optional true ]
@@ -8776,6 +10077,7 @@
 
 :TransportInBulk a samm:Entity ;
     samm:preferredName "Transport In Bulk"@en ;
+    samm:description "Transport In Bulk structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :productName ; samm:optional true ]
         [ samm:property :shipType ; samm:optional true ]
@@ -8792,6 +10094,7 @@
         [ samm:property :additionalInfo ; samm:optional true ]
         [ samm:property :regionBrTransportBr ; samm:optional true ]
         [ samm:property :regionCaTransportCa ; samm:optional true ]
+        [ samm:property :regionCnTransportCn ; samm:optional true ]
         [ samm:property :regionEuTransportEu ; samm:optional true ]
         [ samm:property :regionMxTransportMx ; samm:optional true ]
         [ samm:property :regionUsTransportUs ; samm:optional true ]
@@ -8799,6 +10102,7 @@
 
 :TransportMx a samm:Entity ;
     samm:preferredName "Transport Mx"@en ;
+    samm:description "Transport Mx structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :unNo ; samm:optional true ]
         [ samm:property :properShippingName ; samm:optional true ]
@@ -8811,6 +10115,7 @@
 
 :TransportUs a samm:Entity ;
     samm:preferredName "Transport Us"@en ;
+    samm:description "Transport Us structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :idNoUsaDot ; samm:optional true ]
         [ samm:property :properShippingName ; samm:optional true ]
@@ -8824,6 +10129,7 @@
 
 :Type a samm:Entity ;
     samm:preferredName "Type"@en ;
+    samm:description "Type structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :equipmentForSelfRescue ; samm:optional true ]
         [ samm:property :maskType ; samm:optional true ]
@@ -8832,6 +10138,7 @@
 
 :UnknownToxicity a samm:Entity ;
     samm:preferredName "Unknown Toxicity"@en ;
+    samm:description "Unknown Toxicity structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :inhalation ; samm:optional true ]
         [ samm:property :dermal ; samm:optional true ]
@@ -8841,6 +10148,7 @@
 
 :UseDescriptors a samm:Entity ;
     samm:preferredName "Use Descriptors"@en ;
+    samm:description "Use Descriptors structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :sectorOfUse ; samm:optional true ]
         [ samm:property :processCategory ; samm:optional true ]
@@ -8859,6 +10167,7 @@
 
 :Voc a samm:Entity ;
     samm:preferredName "Voc"@en ;
+    samm:description "Voc structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :vocInPercentByWeight ; samm:optional true ]
         [ samm:property :vocValue ; samm:optional true ]
@@ -8867,6 +10176,7 @@
 
 :VocLabelling a samm:Entity ;
     samm:preferredName "Voc Labelling"@en ;
+    samm:description "Voc Labelling structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :productSubcategory ; samm:optional true ]
         [ samm:property :vocLimitForSubcategory ; samm:optional true ]
@@ -8884,6 +10194,7 @@
 
 :WasteTreatment a samm:Entity ;
     samm:preferredName "Waste Treatment"@en ;
+    samm:description "Waste Treatment structure from the eSDScom XML schema."@en ;
     samm:properties (
         [ samm:property :productWaste ; samm:optional true ]
         [ samm:property :packagingWaste ; samm:optional true ]
@@ -8901,6 +10212,7 @@
 
 :Whmis2015HazardClassification a samm:Entity ;
     samm:preferredName "Whmis2015Hazard Classification"@en ;
+    samm:description "Whmis2015Hazard Classification structure from the eSDScom XML schema."@en ;
     samm:properties (
         :hazardClassCategory
         :hazardClassCategoryPrintable

--- a/io.catenax.esdscom/1.0.0/eSDScom.ttl
+++ b/io.catenax.esdscom/1.0.0/eSDScom.ttl
@@ -1,0 +1,8913 @@
+@prefix :       <urn:samm:eSDScom.eu:5.6.0#> .
+@prefix samm:   <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit:   <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+
+# ──────────────────────────────────────────────────────────────────────────
+# Aspect
+# ──────────────────────────────────────────────────────────────────────────
+
+:DatasheetFeed a samm:Aspect ;
+    samm:preferredName "Datasheet Feed"@en ;
+    samm:description "The SDScom root element"@en ;
+    samm:properties (
+        :informationFromExportingSystem
+        :datasheet
+    ) ;
+    samm:operations ( ) ;
+    samm:events ( ) .
+
+# ──────────────────────────────────────────────────────────────────────────
+# Properties
+# ──────────────────────────────────────────────────────────────────────────
+
+:abilityToBecomeAirborne a samm:Property ;
+    samm:preferredName "Ability To Become Airborne"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:abioticDegradation a samm:Property ;
+    samm:preferredName "Abiotic Degradation"@en ;
+    samm:characteristic :DegradationEliminationList .
+
+:abntNrb2015HazardClassification a samm:Property ;
+    samm:preferredName "Abnt Nrb2015Hazard Classification"@en ;
+    samm:description "according to GHS revision 4"@en ;
+    samm:characteristic :AbntNrb2015HazardClassificationCharacteristic .
+
+:abntNrb2017HazardLabelling a samm:Property ;
+    samm:preferredName "Abnt Nrb2017Hazard Labelling"@en ;
+    samm:description "according to GHS revision 5"@en ;
+    samm:characteristic :AbntNrb2017HazardLabellingCharacteristic .
+
+:abntNrb2019HazardClassification a samm:Property ;
+    samm:preferredName "Abnt Nrb2019Hazard Classification"@en ;
+    samm:description "according to GHS revision 7. Adopted, but does not (yet) officially replace revision 4."@en ;
+    samm:characteristic :AbntNrb2019HazardClassificationCharacteristic .
+
+:acCode a samm:Property ;
+    samm:preferredName "Ac Code"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ArticleCategoryCodeEnumCharacteristic .
+
+:acFulltext a samm:Property ;
+    samm:preferredName "Ac Fulltext"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:accidentalReleaseMeasures a samm:Property ;
+    samm:preferredName "Accidental Release Measures"@en ;
+    samm:description "Accidental release measures: Information on response to spills - in cases where the spill volume has an impact on the hazard, distinguish between responses to large and small spills. If different practices for containment and recovery are required, this should be indicated."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :AccidentalReleaseMeasuresCharacteristic .
+
+:acidNo a samm:Property ;
+    samm:preferredName "Acid No"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:acute a samm:Property ;
+    samm:preferredName "Acute"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:acuteAlgaeToxicity a samm:Property ;
+    samm:preferredName "Acute Algae Toxicity"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EcotoxicityAquaticList .
+
+:acuteEarthwormToxicity a samm:Property ;
+    samm:preferredName "Acute Earthworm Toxicity"@en ;
+    samm:characteristic :EcotoxicityList .
+
+:acuteFishToxicity a samm:Property ;
+    samm:preferredName "Acute Fish Toxicity"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EcotoxicityAquaticList .
+
+:acuteInvertebrateToxicity a samm:Property ;
+    samm:preferredName "Acute Invertebrate Toxicity"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EcotoxicityAquaticList .
+
+:acutePlantToxicity a samm:Property ;
+    samm:preferredName "Acute Plant Toxicity"@en ;
+    samm:characteristic :EcotoxicityList .
+
+:acuteSubchronicBirdToxicity a samm:Property ;
+    samm:preferredName "Acute Subchronic Bird Toxicity"@en ;
+    samm:characteristic :EcotoxicityList .
+
+:acuteSymptomsAndEffects a samm:Property ;
+    samm:preferredName "Acute Symptoms And Effects"@en ;
+    samm:description "Acute symptoms and effects: Information on"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:acuteToxicity a samm:Property ;
+    samm:preferredName "Acute Toxicity"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :AcuteToxicityCharacteristic .
+
+:acuteToxicityHumanExperience a samm:Property ;
+    samm:preferredName "Acute Toxicity Human Experience"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:additionalEcotoxInformation a samm:Property ;
+    samm:preferredName "Additional Ecotox Information"@en ;
+    samm:characteristic :AdditionalEcotoxInformationCharacteristic .
+
+:additionalEyeProtectionMeasures a samm:Property ;
+    samm:preferredName "Additional Eye Protection Measures"@en ;
+    samm:characteristic :PhraseList .
+
+:additionalHandProtectionMeasures a samm:Property ;
+    samm:preferredName "Additional Hand Protection Measures"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:additionalInfo a samm:Property ;
+    samm:preferredName "Additional Info"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:additionalInformation a samm:Property ;
+    samm:preferredName "Additional Information"@en ;
+    samm:description "Additional information on classification: If the chemical do not meet the classification criteria etc."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:additionalLabellingInfo a samm:Property ;
+    samm:preferredName "Additional Labelling Info"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:additionalRespiratoryProtectionMeasures a samm:Property ;
+    samm:preferredName "Additional Respiratory Protection Measures"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:additionalSkinProtectionMeasures a samm:Property ;
+    samm:preferredName "Additional Skin Protection Measures"@en ;
+    samm:characteristic :PhraseList .
+
+:address a samm:Property ;
+    samm:preferredName "Address"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :AddressCharacteristic .
+
+:adn a samm:Property ;
+    samm:preferredName "Adn"@en ;
+    samm:characteristic :AdnCharacteristic .
+
+:adrRid a samm:Property ;
+    samm:preferredName "Adr Rid"@en ;
+    samm:characteristic :AdrRidCharacteristic .
+
+:aerosolLabelling a samm:Property ;
+    samm:preferredName "Aerosol Labelling"@en ;
+    samm:description "Aerosol labelling: Labelling of aerosol dispensers in accordance with EU directive (75/324/EEC with later amendments)"@en ;
+    samm:characteristic :PhraseList .
+
+:agpaPictogram a samm:Property ;
+    samm:preferredName "Agpa Pictogram"@en ;
+    samm:characteristic samm-c:Text .
+
+:airExchangeRate a samm:Property ;
+    samm:preferredName "Air Exchange Rate"@en ;
+    samm:description "Air exchange rate (equals VentilationRate in ESCom XML) is a minimum value."@en ;
+    samm:characteristic :NumericValueWithUnitAndQualifierCharacteristic .
+
+:airReactive a samm:Property ;
+    samm:preferredName "Air Reactive"@en ;
+    samm:characteristic :PhraseList .
+
+:anilinePoint a samm:Property ;
+    samm:preferredName "Aniline Point"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:aoxAdsorbableOrganohalogens a samm:Property ;
+    samm:preferredName "Aox Adsorbable Organohalogens"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:appearance a samm:Property ;
+    samm:preferredName "Appearance"@en ;
+    samm:description "Product appearance: Description of the shape and other basic conditions of the product."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :AppearanceCharacteristic .
+
+:appraisalPeriod a samm:Property ;
+    samm:preferredName "Appraisal Period"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:appropriateEngineeringControls a samm:Property ;
+    samm:preferredName "Appropriate Engineering Controls"@en ;
+    samm:characteristic :PhraseList .
+
+:appropriateEnvionmentalExposureControl a samm:Property ;
+    samm:preferredName "Appropriate Envionmental Exposure Control"@en ;
+    samm:characteristic :AppropriateEnvionmentalExposureControlCharacteristic .
+
+:aquatic a samm:Property ;
+    samm:preferredName "Aquatic"@en ;
+    samm:characteristic :PercentageCharacteristic .
+
+:aquaticToxicity a samm:Property ;
+    samm:preferredName "Aquatic Toxicity"@en ;
+    samm:characteristic :AquaticToxicityCharacteristic .
+
+:article a samm:Property ;
+    samm:preferredName "Article"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ProtectionArticleList .
+
+:articleCategoryNoIntendedRelease a samm:Property ;
+    samm:preferredName "Article Category No Intended Release"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ArticleCategoryList .
+
+:articleCategoryWithIntendedRelease a samm:Property ;
+    samm:preferredName "Article Category With Intended Release"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ArticleCategoryList .
+
+:aspirationHazard a samm:Property ;
+    samm:preferredName "Aspiration Hazard"@en ;
+    samm:characteristic :AspirationHazardCharacteristic .
+
+:aspirationHazardHydrocarbonContent a samm:Property ;
+    samm:preferredName "Aspiration Hazard Hydrocarbon Content"@en ;
+    samm:description "Aspiration hazard hydrocarbon content: Concentration of hydrocarbons in the mixture with a kinematic viscosity of 20,5 mm2/s or less, measured at 40 C."@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:aspirationHazardKinematicViscosity40 a samm:Property ;
+    samm:preferredName "Aspiration Hazard Kinematic Viscosity40"@en ;
+    samm:description "Kinematic viscosity value at 40°C"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:assessedLegislation a samm:Property ;
+    samm:preferredName "Assessed Legislation"@en ;
+    samm:characteristic :AssessmentCharacteristic .
+
+:assessedRegulations a samm:Property ;
+    samm:preferredName "Assessed Regulations"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:assessmentAcuteToxicityClassification a samm:Property ;
+    samm:preferredName "Assessment Acute Toxicity Classification"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:assessmentAspirationHazardClassification a samm:Property ;
+    samm:preferredName "Assessment Aspiration Hazard Classification"@en ;
+    samm:characteristic :PhraseList .
+
+:assessmentAssessmentEnum a samm:Property ;
+    samm:preferredName "Assessment"@en ;
+    samm:characteristic :AssessmentEnumCharacteristic .
+
+:assessmentCarcinogenicityClassification a samm:Property ;
+    samm:preferredName "Assessment Carcinogenicity Classification"@en ;
+    samm:characteristic :PhraseList .
+
+:assessmentCorrosionIrritationClassification a samm:Property ;
+    samm:preferredName "Assessment Corrosion Irritation Classification"@en ;
+    samm:characteristic :PhraseList .
+
+:assessmentEyeDamageOrIrritationClassification a samm:Property ;
+    samm:preferredName "Assessment Eye Damage Or Irritation Classification"@en ;
+    samm:characteristic :PhraseList .
+
+:assessmentFactor a samm:Property ;
+    samm:preferredName "Assessment Factor"@en ;
+    samm:description "May be important in those cases where the DNEL is very low and where more than 1 DNEL existing to show how high the influence on the deviation was."@en ;
+    samm:characteristic :NumericValueCharacteristic .
+
+:assessmentFulltext a samm:Property ;
+    samm:preferredName "Assessment Fulltext"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:assessmentGermCellMutagenicityClassification a samm:Property ;
+    samm:preferredName "Assessment Germ Cell Mutagenicity Classification"@en ;
+    samm:characteristic :PhraseList .
+
+:assessmentOrClassification a samm:Property ;
+    samm:preferredName "Assessment Or Classification"@en ;
+    samm:characteristic :PhraseList .
+
+:assessmentPhrase a samm:Property ;
+    samm:preferredName "Assessment"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:assessmentReproductiveToxicityClassification a samm:Property ;
+    samm:preferredName "Assessment Reproductive Toxicity Classification"@en ;
+    samm:characteristic :PhraseList .
+
+:assessmentRespiratorySensitisationClassification a samm:Property ;
+    samm:preferredName "Assessment Respiratory Sensitisation Classification"@en ;
+    samm:characteristic :PhraseList .
+
+:assessmentSkinSensitisationClassification a samm:Property ;
+    samm:preferredName "Assessment Skin Sensitisation Classification"@en ;
+    samm:characteristic :PhraseList .
+
+:assessmentSpecificTargetOrganReClassification a samm:Property ;
+    samm:preferredName "Assessment Specific Target Organ Re Classification"@en ;
+    samm:characteristic :PhraseList .
+
+:assessmentSpecificTargetOrganSeClassification a samm:Property ;
+    samm:preferredName "Assessment Specific Target Organ Se Classification"@en ;
+    samm:characteristic :PhraseList .
+
+:ate a samm:Property ;
+    samm:preferredName "Ate"@en ;
+    samm:description "Acute Toxicity Estimate as provided by the supplier. Necessary according to UN GHS if the mixture is ingredient of another mixture, to derive this product's toxicity classification. In CLP, ATE values may also be specified in harmonized classifications (CLP Annex VI)"@en ;
+    samm:characteristic :AteCharacteristic .
+
+:atmosphericLifetime a samm:Property ;
+    samm:preferredName "Atmospheric Lifetime"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:authorisationNo a samm:Property ;
+    samm:preferredName "Authorisation No"@en ;
+    samm:description "Authorisation number: For chemicals subject to authorisation according to REACH Annex XIV, which have been granted authorisation for the actual use."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:authorizationNo a samm:Property ;
+    samm:preferredName "Authorization No"@en ;
+    samm:characteristic samm-c:Text .
+
+:autoignitionTemperature a samm:Property ;
+    samm:preferredName "Autoignition Temperature"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:bimschNumber a samm:Property ;
+    samm:preferredName "Bimsch Number"@en ;
+    samm:description "Number according to Table 1 of 12 BImSchV, the German implementation of EU's Seveso III Directive"@en ;
+    samm:characteristic samm-c:Text .
+
+:bioaccumulation a samm:Property ;
+    samm:preferredName "Bioaccumulation"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :BioaccumulationCharacteristic .
+
+:bioaccumulationEvaluation a samm:Property ;
+    samm:preferredName "Bioaccumulation Evaluation"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:biochemicalOxygenDemand a samm:Property ;
+    samm:preferredName "Biochemical Oxygen Demand"@en ;
+    samm:description "a.k.a. BOD"@en ;
+    samm:characteristic :FurtherEcologicalDataList .
+
+:biocides a samm:Property ;
+    samm:preferredName "Biocides"@en ;
+    samm:description "Biocidal Products according to to Regulation (EU) No 528/2012 can be either a biocide or a treated article, and if treadted articles should be covered here remains an extert decision (see issue #265)."@en ;
+    samm:characteristic :BiocidesCharacteristic .
+
+:bioconcentrationFactor a samm:Property ;
+    samm:preferredName "Bioconcentration Factor"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :BioconcentrationFactorList .
+
+:biologicalDegradability a samm:Property ;
+    samm:preferredName "Biological Degradability"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :BiologicalDegradationList .
+
+:biologicalLimitValue a samm:Property ;
+    samm:preferredName "Biological Limit Value"@en ;
+    samm:description "aims at the product in delivery state"@en ;
+    samm:characteristic :BiologicalLimitValueList .
+
+:biologicalLimitValues a samm:Property ;
+    samm:preferredName "Biological Limit Values"@en ;
+    samm:description "Biological limit value: aims at the product in delivery state. Information regarding biological limit values - e.g. concentration of lead in blood. Biological limits will refer to individual components, not preparations."@en ;
+    samm:characteristic :BiologicalLimitValuesCharacteristic .
+
+:birdReproductionToxicity a samm:Property ;
+    samm:preferredName "Bird Reproduction Toxicity"@en ;
+    samm:characteristic :EcotoxicityList .
+
+:bod5CodRatio a samm:Property ;
+    samm:preferredName "Bod5Cod Ratio"@en ;
+    samm:characteristic :PhysChemValueList .
+
+:boilingPoint a samm:Property ;
+    samm:preferredName "Boiling Point"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:boilingPointRelated a samm:Property ;
+    samm:preferredName "Boiling Point Related"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :BoilingPointRelatedCharacteristic .
+
+:bulkDensity a samm:Property ;
+    samm:preferredName "Bulk Density"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+
+:california a samm:Property ;
+    samm:preferredName "California"@en ;
+    samm:characteristic :CaliforniaCharacteristic .
+
+:carcinogenicity a samm:Property ;
+    samm:preferredName "Carcinogenicity"@en ;
+    samm:characteristic :CarcinogenicityCharacteristic .
+
+:carcinogenicityHumanExperience a samm:Property ;
+    samm:preferredName "Carcinogenicity Human Experience"@en ;
+    samm:characteristic :PhraseList .
+
+:carcinogenicityTestResults a samm:Property ;
+    samm:preferredName "Carcinogenicity Test Results"@en ;
+    samm:characteristic :CmrDataList .
+
+:casInventoryName a samm:Property ;
+    samm:preferredName "Cas Inventory Name"@en ;
+    samm:description "a.k.a CAIN, Name in the CAS Online Inventory"@en ;
+    samm:characteristic samm-c:Text .
+
+:casNo a samm:Property ;
+    samm:preferredName "Cas No"@en ;
+    samm:description "CAS RN: Registration Number for chemical substances, including some groups and more complex cases like polymers and reaction products, issued by Chemical Abstract Service. For a discussion why there is just one CAS RN per substance, see issue #111."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:certainFluorinatedGreenhouseGases a samm:Property ;
+    samm:preferredName "Certain Fluorinated Greenhouse Gases"@en ;
+    samm:characteristic :CertainFluorinatedGreenhouseGasesCharacteristic .
+
+:certification a samm:Property ;
+    samm:preferredName "Certification"@en ;
+    samm:description "Safety Data Sheets according to KKDIK require certification by an approved person who will provide a specific wording containing their approval/listing number."@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:chemicalCharacterization a samm:Property ;
+    samm:preferredName "Chemical Characterization"@en ;
+    samm:description "was \"DescriptionOfTheMixture\" up to v4.2.3; see issue #95"@en ;
+    samm:characteristic :PhraseList .
+
+:chemicalOxygenDemand a samm:Property ;
+    samm:preferredName "Chemical Oxygen Demand"@en ;
+    samm:description "a.k.a. COD"@en ;
+    samm:characteristic :FurtherEcologicalDataList .
+
+:chemicalSafetyAssessment a samm:Property ;
+    samm:preferredName "Chemical Safety Assessment"@en ;
+    samm:characteristic :PhraseList .
+
+:chemicalSafetyAssessmentCarriedOut a samm:Property ;
+    samm:preferredName "Chemical Safety Assessment Carried Out"@en ;
+    samm:description "Chemical safety assessment (CSA) carried out: To state if CSA has been performed on the substance or the individual substances of a mixture."@en ;
+    samm:characteristic samm-c:Boolean .
+
+:chemicalSafetyAssessmentInfo a samm:Property ;
+    samm:preferredName "Chemical Safety Assessment Info"@en ;
+    samm:characteristic :ChemicalSafetyAssessmentInfoCharacteristic .
+
+:chemicalSafetyReport a samm:Property ;
+    samm:preferredName "Chemical Safety Report"@en ;
+    samm:characteristic :ChemicalSafetyReportCharacteristic .
+
+:childResistantOpening a samm:Property ;
+    samm:preferredName "Child Resistant Opening"@en ;
+    samm:description "Child Resistant Fastening: To inform if the packaging must be supplied with such fastening if the chemical is supplied to the general public."@en ;
+    samm:characteristic samm-c:Boolean .
+
+:chronic a samm:Property ;
+    samm:preferredName "Chronic"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:chronicAlgaeToxicity a samm:Property ;
+    samm:preferredName "Chronic Algae Toxicity"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EcotoxicityAquaticList .
+
+:chronicEarthwormToxicity a samm:Property ;
+    samm:preferredName "Chronic Earthworm Toxicity"@en ;
+    samm:characteristic :EcotoxicityList .
+
+:chronicFishToxicity a samm:Property ;
+    samm:preferredName "Chronic Fish Toxicity"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EcotoxicityAquaticList .
+
+:chronicInvertebrateToxicity a samm:Property ;
+    samm:preferredName "Chronic Invertebrate Toxicity"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EcotoxicityAquaticList .
+
+:chronicPlantToxicity a samm:Property ;
+    samm:preferredName "Chronic Plant Toxicity"@en ;
+    samm:characteristic :EcotoxicityList .
+
+:classCode a samm:Property ;
+    samm:preferredName "Class Code"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:classOrClasses a samm:Property ;
+    samm:preferredName "Class Or Classes"@en ;
+    samm:characteristic :PhraseList .
+
+:classTransportClassEnum a samm:Property ;
+    samm:preferredName "Class"@en ;
+    samm:description "IMDG hazard class: The chemical’s most important transport hazard class."@en ;
+    samm:characteristic :TransportClassEnumCharacteristic .
+
+:classWaterHazardClassEnum a samm:Property ;
+    samm:preferredName "Class"@en ;
+    samm:description "Water hazard class (WGK):"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :WaterHazardClassEnumCharacteristic .
+
+:classification a samm:Property ;
+    samm:preferredName "Classification"@en ;
+    samm:characteristic :ClassificationList .
+
+:classificationAssessment a samm:Property ;
+    samm:preferredName "Classification Assessment"@en ;
+    samm:characteristic :ClassificationAssessmentCharacteristic .
+
+:classificationClassificationAr a samm:Property ;
+    samm:preferredName "Classification"@en ;
+    samm:characteristic :ClassificationArCharacteristic .
+
+:classificationClassificationBr a samm:Property ;
+    samm:preferredName "Classification"@en ;
+    samm:characteristic :ClassificationBrCharacteristic .
+
+:classificationClassificationCa a samm:Property ;
+    samm:preferredName "Classification"@en ;
+    samm:characteristic :ClassificationCaCharacteristic .
+
+:classificationClassificationGb a samm:Property ;
+    samm:preferredName "Classification"@en ;
+    samm:characteristic :ClassificationGbCharacteristic .
+
+:classificationClassificationMx a samm:Property ;
+    samm:preferredName "Classification"@en ;
+    samm:characteristic :ClassificationMxCharacteristic .
+
+:classificationClassificationTr a samm:Property ;
+    samm:preferredName "Classification"@en ;
+    samm:characteristic :ClassificationTrCharacteristic .
+
+:classificationClassificationUs a samm:Property ;
+    samm:preferredName "Classification"@en ;
+    samm:characteristic :ClassificationUsCharacteristic .
+
+:classificationNotes a samm:Property ;
+    samm:preferredName "Classification Notes"@en ;
+    samm:description "Classification notes: To identify classification notes (letters and/or figures) in the case that the trade product is a substance. This information shall be stated in the SDS together with the classifications of the substance."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:classificationPhrase a samm:Property ;
+    samm:preferredName "Classification"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:classificationProcedure a samm:Property ;
+    samm:preferredName "Classification Procedure"@en ;
+    samm:description "To state how the individual classification is prepared. (This information should be shown in section 16). Only relevant for instances of type Classification in section 2. For components in section 3, this info should not be part of the SDS."@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:cleaningUp a samm:Property ;
+    samm:preferredName "Cleaning Up"@en ;
+    samm:description "Cleaning up: Ways of cleaning-up spills, for instance by application of absorbing material, and the application of water to dilute effluent or restrict emission of gas or fume. Description of cleaning-up methods may be divided into small and large spills (specifications must be made by the individual SDS preparer)."@en ;
+    samm:characteristic :PhraseList .
+
+:cloudPoint a samm:Property ;
+    samm:preferredName "Cloud Point"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:code a samm:Property ;
+    samm:preferredName "Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:colour a samm:Property ;
+    samm:preferredName "Colour"@en ;
+    samm:description "Multiple entries (only) in case of \"multicolour\" and \"colouring agent\""@en ;
+    samm:characteristic :ColourEnumCharacteristic .
+
+:colourDescription a samm:Property ;
+    samm:preferredName "Colour Description"@en ;
+    samm:description "Product colour: Indicate the colour of the substance or preparation as supplied. May be omitted if Colour is used. This field is also used if none of ColourEnum matches."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:colourIntensity a samm:Property ;
+    samm:preferredName "Colour Intensity"@en ;
+    samm:characteristic :ColourIntensityEnumCharacteristic .
+
+:colourIntensityDescription a samm:Property ;
+    samm:preferredName "Colour Intensity Description"@en ;
+    samm:characteristic :PhraseList .
+
+:companyContact a samm:Property ;
+    samm:preferredName "Company Contact"@en ;
+    samm:description "Company contact: This field covers all contact persons related to the company. Department or person within the company that can be contacted regarding information on the actual chemical."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :CompanyContactList .
+
+:companyUrl a samm:Property ;
+    samm:preferredName "Company Url"@en ;
+    samm:description "Company URL: Web address to the company’s home page"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:ResourcePath .
+
+:completeSdsWithEsIncorporated a samm:Property ;
+    samm:preferredName "Complete Sds With Es Incorporated"@en ;
+    samm:description "Exposure scenarioes incorporated in the SDS: If the SDS is complete (an eSDS) - meaning that the user has to adapt to the information in the SDS within 12 months, the user must be informed about this. This element is to help the user distinguish between eSDSs and normal SDSs."@en ;
+    samm:characteristic :CompleteSdsWithEsIncorporatedCharacteristic .
+
+:composition a samm:Property ;
+    samm:preferredName "Composition"@en ;
+    samm:characteristic :CompositionCharacteristic .
+
+:compositionInformation a samm:Property ;
+    samm:preferredName "Composition Information"@en ;
+    samm:description "Composition according to Biocidal Products Regulation (EU) No 528/2012. This can differ from the composition in section 3 of the SDS and is for labelling purposes only."@en ;
+    samm:characteristic :PhraseList .
+
+:concentration a samm:Property ;
+    samm:preferredName "Concentration"@en ;
+    samm:description "In aqueous solution"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:conditionsForSafeStorage a samm:Property ;
+    samm:preferredName "Conditions For Safe Storage"@en ;
+    samm:description "Conditions for safe storage: Information on how to control the effects of weather conditions, ambient pressure, temperature, sunlight, humidity, vibration etc."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ConditionsForSafeStorageCharacteristic .
+
+:conditionsToAvoid a samm:Property ;
+    samm:preferredName "Conditions To Avoid"@en ;
+    samm:description "Conditions to avoid: Materials that must not get in contact with each other during storage etc."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:consumerExposureControl a samm:Property ;
+    samm:preferredName "Consumer Exposure Control"@en ;
+    samm:characteristic :ConsumerExposureControlCharacteristic .
+
+:consumerUse a samm:Property ;
+    samm:preferredName "Consumer Use"@en ;
+    samm:characteristic samm-c:Boolean .
+
+:containment a samm:Property ;
+    samm:preferredName "Containment"@en ;
+    samm:description "Containment: Advice on how to contain a spill."@en ;
+    samm:characteristic :PhraseList .
+
+:containmentAndCleaningUp a samm:Property ;
+    samm:preferredName "Containment And Cleaning Up"@en ;
+    samm:characteristic :ContainmentAndCleaningUpCharacteristic .
+
+:contentOfVoc a samm:Property ;
+    samm:preferredName "Content Of Voc"@en ;
+    samm:description "Content of volatile organic compounts (often solvents), measured in g/L and/or weight percent (% w/w)."@en ;
+    samm:characteristic :PhysChemValueList .
+
+:contraindications a samm:Property ;
+    samm:preferredName "Contraindications"@en ;
+    samm:description "Contraindications: Information on"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:controlApproach a samm:Property ;
+    samm:preferredName "Control Approach"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:controlParameters a samm:Property ;
+    samm:preferredName "Control Parameters"@en ;
+    samm:characteristic :ControlParametersCharacteristic .
+
+:correspondingExposureScenario a samm:Property ;
+    samm:preferredName "Corresponding Exposure Scenario"@en ;
+    samm:characteristic :CorrespondingExposureScenarioList .
+
+:corrosiveToMetals a samm:Property ;
+    samm:preferredName "Corrosive To Metals"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :CorrosiveToMetalsCharacteristic .
+
+:corrosivity a samm:Property ;
+    samm:preferredName "Corrosivity"@en ;
+    samm:characteristic :PhraseList .
+
+:country a samm:Property ;
+    samm:preferredName "Country"@en ;
+    samm:description "This country informaion applies to all addresses and contacts and LegalRegistrationNumber within SupplierInformation."@en ;
+    samm:characteristic :CountryCodeEnumCharacteristic .
+
+:cpid a samm:Property ;
+    samm:preferredName "Cpid"@en ;
+    samm:description "The product registration number for Swiss FOPH. Part of section 15 of SDS"@en ;
+    samm:characteristic samm-c:Text .
+
+:criticalPressure a samm:Property ;
+    samm:preferredName "Critical Pressure"@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+
+:crystallisationPoint a samm:Property ;
+    samm:preferredName "Crystallisation Point"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:csrLocation a samm:Property ;
+    samm:preferredName "Csr Location"@en ;
+    samm:characteristic :PhraseList .
+
+:csrRequired a samm:Property ;
+    samm:preferredName "Csr Required"@en ;
+    samm:characteristic samm-c:Boolean .
+
+:dangerReleasingSubstance a samm:Property ;
+    samm:preferredName "Danger Releasing Substance"@en ;
+    samm:characteristic :PhraseList .
+
+:dangerReleasingSubstanceEnglish a samm:Property ;
+    samm:preferredName "Danger Releasing Substance English"@en ;
+    samm:description "Content should be in English language - see issue #13"@en ;
+    samm:characteristic :PhraseList .
+
+:dangerReleasingSubstanceNational a samm:Property ;
+    samm:preferredName "Danger Releasing Substance National"@en ;
+    samm:description "Content should be in the language of the SDS - see issue #13"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:datasheet a samm:Property ;
+    samm:preferredName "Datasheet"@en ;
+    samm:description "In fact, this is a product data set, i.e. data for a collection of safety data sheets for the same product."@en ;
+    samm:characteristic :DatasheetList .
+
+:dateGeneratedExport a samm:Property ;
+    samm:preferredName "Date Generated Export"@en ;
+    samm:description "Date of generation of this export file"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DateCharacteristic .
+
+:decompositionTemperature a samm:Property ;
+    samm:preferredName "Decomposition Temperature"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:degradationRate a samm:Property ;
+    samm:preferredName "Degradation Rate"@en ;
+    samm:description "always in %. Parameter should go into DegradationRate/TestReference."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueCharacteristic .
+
+:delayedSymptomsAndEffects a samm:Property ;
+    samm:preferredName "Delayed Symptoms And Effects"@en ;
+    samm:description "Delayed symptoms and effects: Information on delayed symptoms"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:delimiter a samm:Property ;
+    samm:preferredName "Delimiter"@en ;
+    samm:characteristic samm-c:Text .
+
+:densities a samm:Property ;
+    samm:preferredName "Densities"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DensitiesCharacteristic .
+
+:density a samm:Property ;
+    samm:preferredName "Density"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+
+:derivedMinimalEffectLevel a samm:Property ;
+    samm:preferredName "Derived Minimal Effect Level"@en ;
+    samm:characteristic :DmelList .
+
+:derivedNoEffectLevel a samm:Property ;
+    samm:preferredName "Derived No Effect Level"@en ;
+    samm:description "Derived no effect level (DNEL): Where a Chemical Safety Report is required, the relevant DNELs for the substance shall be given. For preparations, it is useful to provide values for those constituent substances which are required to be listed in the safety data sheet."@en ;
+    samm:characteristic :DnelList .
+
+:dermal a samm:Property ;
+    samm:preferredName "Dermal"@en ;
+    samm:characteristic :PercentageCharacteristic .
+
+:description a samm:Property ;
+    samm:preferredName "Description"@en ;
+    samm:description "Description of the file type etc."@en ;
+    samm:characteristic samm-c:Text .
+
+:descriptionOfFirstAidMeasures a samm:Property ;
+    samm:preferredName "Description Of First Aid Measures"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DescriptionOfFirstAidMeasuresCharacteristic .
+
+:detergentInformation a samm:Property ;
+    samm:preferredName "Detergent Information"@en ;
+    samm:characteristic :PhraseList .
+
+:detergentLabelling a samm:Property ;
+    samm:preferredName "Detergent Labelling"@en ;
+    samm:description "Detergent labelling: Labelling requirements according to detergents regulation (648/2004/EC with later amanedments). Includes dosing recommendations. Concentration groups: _lt 5 weight%, 5 - _lt 15 vekt%, 15 - _lt 30 weight%, og _ge 30 weight%."@en ;
+    samm:characteristic :PhraseList .
+
+:detergents a samm:Property ;
+    samm:preferredName "Detergents"@en ;
+    samm:description "Restrictions related to regulation on detergents:"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DetergentsCharacteristic .
+
+:disclaimerBoundaries a samm:Property ;
+    samm:preferredName "Disclaimer Boundaries"@en ;
+    samm:description "Describes the boundaries of the SUMI. Mandatory according to some sources, optional according to others."@en ;
+    samm:characteristic :PhraseList .
+
+:disposalConsiderations a samm:Property ;
+    samm:preferredName "Disposal Considerations"@en ;
+    samm:description "Disposal considerations: The section shall describe information for proper waste management of the chemical and/or its container to assist in the determination of safe and environmentally preferred waste management options, consistent with the requirements in accordance with EU and national legislation. Information relevant for the safety of persons conducting waste management activities shall complement the information given in Section 8. The information on the waste management measures shall be consistent with the identified uses. If the disposal of the chemical presents a danger, a description of the residues and their safe handling shall be given."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DisposalConsiderationsCharacteristic .
+
+:dissociationConstant a samm:Property ;
+    samm:preferredName "Dissociation Constant"@en ;
+    samm:characteristic :DissociationConstantList .
+
+:dissolvedOrganicCarbon a samm:Property ;
+    samm:preferredName "Dissolved Organic Carbon"@en ;
+    samm:description "a.k.a. DOC"@en ;
+    samm:characteristic :FurtherEcologicalDataList .
+
+:distribution a samm:Property ;
+    samm:preferredName "Distribution"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:distributionStoppedDate a samm:Property ;
+    samm:preferredName "Distribution Stopped Date"@en ;
+    samm:description "Date when manufacturer stopped distribution. See also ProductDiscontinuedFromMarket."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DateCharacteristic .
+
+:division a samm:Property ;
+    samm:preferredName "Division"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:dmelValue a samm:Property ;
+    samm:preferredName "Dmel Value"@en ;
+    samm:characteristic :NumericValueWithUnitCharacteristic .
+
+:dnelValue a samm:Property ;
+    samm:preferredName "Dnel Value"@en ;
+    samm:characteristic :NumericValueWithUnitCharacteristic .
+
+:dose a samm:Property ;
+    samm:preferredName "Dose"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DoseCharacteristic .
+
+:droppingPoint a samm:Property ;
+    samm:preferredName "Dropping Point"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:duns a samm:Property ;
+    samm:preferredName "Duns"@en ;
+    samm:description "The D-U-N-S Number references a legal entity and allows access to what could be considered a self-maintaining address book, created for the automotive and chemical industry. It should be added to any address in SDScom to help data integration. See also https://www.upik.de/"@en ;
+    samm:characteristic samm-c:Text .
+
+:ecNo a samm:Property ;
+    samm:preferredName "Ec No"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:ecologicalInformationEcologicalInformation a samm:Property ;
+    samm:preferredName "Ecological Information"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EcologicalInformationCharacteristic .
+
+:ecotoxicologicalInformation a samm:Property ;
+    samm:preferredName "Ecotoxicological Information"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EcotoxicologicalInformationCharacteristic .
+
+:ecotoxicologyOverallEvaluation a samm:Property ;
+    samm:preferredName "Ecotoxicology Overall Evaluation"@en ;
+    samm:characteristic :PhraseList .
+
+:editingDate a samm:Property ;
+    samm:preferredName "Editing Date"@en ;
+    samm:description "If the exporting system is the SDS authoring system, the value of EditingDate should be omitted or be equal to RevisionDate. If the export is prepared by another system, e.g. from a service provider, the EditingDate is the status of data entry of the SDS and is equal to or larger than RevisionDate."@en ;
+    samm:characteristic :DateCharacteristic .
+
+:effectDoseConcentration a samm:Property ;
+    samm:preferredName "Effect Dose Concentration"@en ;
+    samm:characteristic :DoseCharacteristic .
+
+:effectTested a samm:Property ;
+    samm:preferredName "Effect Tested"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DoseCharacteristic .
+
+:effectValue a samm:Property ;
+    samm:preferredName "Effect Value"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:effectsOfMisuse a samm:Property ;
+    samm:preferredName "Effects Of Misuse"@en ;
+    samm:description "Effects of misuse: Description of the most important adverse effects and symptoms of possible misuses that can be reasonably foreseen."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:electricConductivity a samm:Property ;
+    samm:preferredName "Electric Conductivity"@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+
+:email a samm:Property ;
+    samm:preferredName "Email"@en ;
+    samm:description "e-mail address to the company:"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:emailCompetentPerson a samm:Property ;
+    samm:preferredName "Email Competent Person"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:emergencyPhone a samm:Property ;
+    samm:preferredName "Emergency Phone"@en ;
+    samm:description "Emergency phone: Contacts that can be used in case of an accident or trouble, e.g. the supplier’s own emergency phone or the phone number to an official advisory body. A Poison Information Center gives advice and instruction regarding treatment of acute poisoning caused by chemicals etc."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EmergencyPhoneList .
+
+:emergencyPhoneDescription a samm:Property ;
+    samm:preferredName "Emergency Phone Description"@en ;
+    samm:description "Information: This field is used to state what kind of assistance that can be obtained from the actual emergency telephone, if it is available only during office hours, etc."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:emergencyProcedures a samm:Property ;
+    samm:preferredName "Emergency Procedures"@en ;
+    samm:characteristic :PhraseList .
+
+:emsCode a samm:Property ;
+    samm:preferredName "Ems Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:endocrineDisruptingPotential a samm:Property ;
+    samm:preferredName "Endocrine Disrupting Potential"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:endocrineDisruption a samm:Property ;
+    samm:preferredName "Endocrine Disruption"@en ;
+    samm:characteristic :PhraseList .
+
+:environmantalHazardThreshold a samm:Property ;
+    samm:preferredName "Environmantal Hazard Threshold"@en ;
+    samm:description "in kg"@en ;
+    samm:characteristic :IntegerCharacteristic .
+
+:environmentalEffect a samm:Property ;
+    samm:preferredName "Environmental Effect"@en ;
+    samm:description "Environmental effects: The most important adverse environmental effects and symptoms."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:environmentalExposureControls a samm:Property ;
+    samm:preferredName "Environmental Exposure Controls"@en ;
+    samm:characteristic :PhraseList .
+
+:environmentalHazardsSevesoEntryDe a samm:Property ;
+    samm:preferredName "Environmental Hazards"@en ;
+    samm:characteristic :SevesoEntryDeCharacteristic .
+
+:environmentalHazardsSevesoEntryEu a samm:Property ;
+    samm:preferredName "Environmental Hazards"@en ;
+    samm:characteristic :SevesoEntryEuCharacteristic .
+
+:environmentalPrecautions a samm:Property ;
+    samm:preferredName "Environmental Precautions"@en ;
+    samm:description "Environmental precautions: Information on preventive measures to be taken to protect environment."@en ;
+    samm:characteristic :PhraseList .
+
+:environmentalReleaseCategory a samm:Property ;
+    samm:preferredName "Environmental Release Category"@en ;
+    samm:description "Environment release category: ERC"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EnvironmentalReleaseCategoryList .
+
+:eoxExtractableOrganohalogens a samm:Property ;
+    samm:preferredName "Eox Extractable Organohalogens"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:equipment a samm:Property ;
+    samm:preferredName "Equipment"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EquipmentList .
+
+:equipmentForSelfRescue a samm:Property ;
+    samm:preferredName "Equipment For Self Rescue"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:ercCode a samm:Property ;
+    samm:preferredName "Erc Code"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EnvironmentalReleaseCategoryCodeEnumCharacteristic .
+
+:ercFulltext a samm:Property ;
+    samm:preferredName "Erc Fulltext"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:escomFileName a samm:Property ;
+    samm:preferredName "Escom File Name"@en ;
+    samm:description "File name if the exposure scenarios is available in EScom XML format."@en ;
+    samm:characteristic samm-c:Text .
+
+:euAuthorisation a samm:Property ;
+    samm:preferredName "Eu Authorisation"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:euLegislation a samm:Property ;
+    samm:preferredName "Eu Legislation"@en ;
+    samm:description "EU legislations: Restrictions and other regulatory requirements related to the chemical in accordance with EU legislations."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EuLegislationCharacteristic .
+
+:euRestrictionsOfOccupation a samm:Property ;
+    samm:preferredName "Eu Restrictions Of Occupation"@en ;
+    samm:characteristic :PhraseList .
+
+:euRestrictionsOnUse a samm:Property ;
+    samm:preferredName "Eu Restrictions On Use"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:euWasteRegulations a samm:Property ;
+    samm:preferredName "Eu Waste Regulations"@en ;
+    samm:description "EU legislation: EU legislation related to waste that applies to the product or its packaging."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:eupcsCode a samm:Property ;
+    samm:preferredName "Eupcs Code"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EupcsCategoryCodeEnumCharacteristic .
+
+:eupcsFulltext a samm:Property ;
+    samm:preferredName "Eupcs Fulltext"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:europeanWasteList a samm:Property ;
+    samm:preferredName "European Waste List"@en ;
+    samm:description "European waste list: EU classification of waste."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EuropeanWasteListCharacteristic .
+
+:evaluationGasGroupEnum a samm:Property ;
+    samm:preferredName "Evaluation"@en ;
+    samm:characteristic :GasGroupEnumCharacteristic .
+
+:evaluationPhrase a samm:Property ;
+    samm:preferredName "Evaluation"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:evaporationRate a samm:Property ;
+    samm:preferredName "Evaporation Rate"@en ;
+    samm:characteristic :PhysChemValueWithTemperatureList .
+
+:ewlPacking a samm:Property ;
+    samm:preferredName "Ewl Packing"@en ;
+    samm:description "European waste list for the packaging: Identification number (EWL No.) and description of the waste under the actual EWL No."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :WasteListEntryList .
+
+:ewlProduct a samm:Property ;
+    samm:preferredName "Ewl Product"@en ;
+    samm:description "European waste list for the product: Identification number (EWL No.) and description of the waste under the actual EWL No."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :WasteListEntryList .
+
+:exactValue a samm:Property ;
+    samm:preferredName "Exact Value"@en ;
+    samm:characteristic :FloatCharacteristic .
+
+:exactValueSymbol a samm:Property ;
+    samm:preferredName "Exact Value Symbol"@en ;
+    samm:characteristic :ExactQualifierEnumCharacteristic .
+
+:exceptedQty a samm:Property ;
+    samm:preferredName "Excepted Qty"@en ;
+    samm:characteristic samm-c:Text .
+
+:expansionCoefficient a samm:Property ;
+    samm:preferredName "Expansion Coefficient"@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+
+:explosionLimit a samm:Property ;
+    samm:preferredName "Explosion Limit"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ExplosionLimitCharacteristic .
+
+:explosiveProperties a samm:Property ;
+    samm:preferredName "Explosive Properties"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:explosives a samm:Property ;
+    samm:preferredName "Explosives"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ExplosivesCharacteristic .
+
+:exposureControlAppropriateMeasures a samm:Property ;
+    samm:preferredName "Exposure Control Appropriate Measures"@en ;
+    samm:characteristic :ExposureControlAppropriateMeasuresCharacteristic .
+
+:exposureControlPersonalProtectionExposureControlPersonalProtection a samm:Property ;
+    samm:preferredName "Exposure Control Personal Protection"@en ;
+    samm:description "Exposure control and personal protection: This section shall describe the applicable occupational exposure limits and necessary risk management measures. Where a chemical safety report is required, the information in this section shall be consistent with the chemical safety report and the exposure scenarios showing control of risk from the chemical safety report set out in the annex to the safety data sheet."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ExposureControlPersonalProtectionCharacteristic .
+
+:exposureControlsPersonalProtectionAdditionalInfo a samm:Property ;
+    samm:preferredName "Exposure Controls Personal Protection Additional Info"@en ;
+    samm:characteristic :PhraseList .
+
+:exposureFrequency a samm:Property ;
+    samm:preferredName "Exposure Frequency"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:exposureGroup a samm:Property ;
+    samm:preferredName "Exposure Group"@en ;
+    samm:characteristic :ExposureGroupCharacteristic .
+
+:exposureRouteExposureRoute a samm:Property ;
+    samm:preferredName "Exposure Route"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ExposureRouteCharacteristic .
+
+:exposureRouteFrequencyAndEffect a samm:Property ;
+    samm:preferredName "Exposure Route Frequency And Effect"@en ;
+    samm:description "Exposure route, frequency and type of effect:"@en ;
+    samm:characteristic :ExposureRouteFrequencyAndEffectCharacteristic .
+
+:exposureRoutePhrase a samm:Property ;
+    samm:preferredName "Exposure Route"@en ;
+    samm:description "For Specific Target Organ Toxicity (STOT), the entry can be limited to a way of exposure (e.g. inhalation). Although there is currently no known case with more than one route of exposure, we cannot exclude this biologically and thus technically."@en ;
+    samm:characteristic :PhraseList .
+
+:exposureScenario a samm:Property ;
+    samm:preferredName "Exposure Scenario"@en ;
+    samm:characteristic :ExposureScenarioCharacteristic .
+
+:exposureScenarioIdentificationString a samm:Property ;
+    samm:preferredName "Exposure Scenario Identification String"@en ;
+    samm:description "Link to ESCom exposure scenario. The referenced exposure scenario(s) must be delivered in one or more separate file(s) in ESCom format. In its element ExposureScenario/IdentificationString, ESCom provides the UUID which is referenced here."@en ;
+    samm:characteristic samm-c:Text .
+
+:exposureScenarioName a samm:Property ;
+    samm:preferredName "Exposure Scenario Name"@en ;
+    samm:characteristic samm-c:Text .
+
+:exposureTime a samm:Property ;
+    samm:preferredName "Exposure Time"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:extendedSdsWithEsIncorporated a samm:Property ;
+    samm:preferredName "Extended Sds With Es Incorporated"@en ;
+    samm:description "Exposure scenarios incorporated in the SDS: To state if the SDS is complete (eSDS) - meaning that the user has to adapt to the information in the SDS within 12 months."@en ;
+    samm:characteristic samm-c:Boolean .
+
+:extinguishingMedia a samm:Property ;
+    samm:preferredName "Extinguishing Media"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ExtinguishingMediaCharacteristic .
+
+:eyeCorrosivity a samm:Property ;
+    samm:preferredName "Eye Corrosivity"@en ;
+    samm:characteristic :PhraseList .
+
+:eyeDamageOrIrritation a samm:Property ;
+    samm:preferredName "Eye Damage Or Irritation"@en ;
+    samm:characteristic :EyeDamageOrIrritationCharacteristic .
+
+:eyeDamageOrIrritationHumanExperience a samm:Property ;
+    samm:preferredName "Eye Damage Or Irritation Human Experience"@en ;
+    samm:characteristic :PhraseList .
+
+:eyeDamageOrIrritationTestResults a samm:Property ;
+    samm:preferredName "Eye Damage Or Irritation Test Results"@en ;
+    samm:characteristic :CorrosionIrritationDataList .
+
+:eyeIrritation a samm:Property ;
+    samm:preferredName "Eye Irritation"@en ;
+    samm:characteristic :PhraseList .
+
+:eyeProtection a samm:Property ;
+    samm:preferredName "Eye Protection"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EyeProtectionCharacteristic .
+
+:eyeProtectionEquipment a samm:Property ;
+    samm:preferredName "Eye Protection Equipment"@en ;
+    samm:characteristic :ProtectionArticleList .
+
+:fax a samm:Property ;
+    samm:preferredName "Fax"@en ;
+    samm:description "Faximile number:"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:federal a samm:Property ;
+    samm:preferredName "Federal"@en ;
+    samm:characteristic :FederalCharacteristic .
+
+:fileName a samm:Property ;
+    samm:preferredName "File Name"@en ;
+    samm:description "File name: For example, a locked PDF document. A fixed URL is possible."@en ;
+    samm:characteristic samm-c:Text .
+
+:filterApparatusType a samm:Property ;
+    samm:preferredName "Filter Apparatus Type"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:fireAndExplosionHazards a samm:Property ;
+    samm:preferredName "Fire And Explosion Hazards"@en ;
+    samm:description "Fire and explosion hazards: Elements of risk in case of a fire or explosion, for instance a particular risk of exposure to the chemical or its decomposition products."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:fireFightingMeasures a samm:Property ;
+    samm:preferredName "Fire Fighting Measures"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :FireFightingMeasuresCharacteristic .
+
+:fireFightingPrecautions a samm:Property ;
+    samm:preferredName "Fire Fighting Precautions"@en ;
+    samm:description "Precautionary measures in case of fire fighting: Measures and special protective equipment for fire-fighters."@en ;
+    samm:characteristic :PhraseList .
+
+:fireFightingProcedures a samm:Property ;
+    samm:preferredName "Fire Fighting Procedures"@en ;
+    samm:description "Fire fighting procedures: Information on how to handle a fire in the chemical."@en ;
+    samm:characteristic :PhraseList .
+
+:firstAidEye a samm:Property ;
+    samm:preferredName "First Aid Eye"@en ;
+    samm:description "First aid eyes: First aid measures to be taken if the chemical gets in contact with the eyes."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:firstAidIngestion a samm:Property ;
+    samm:preferredName "First Aid Ingestion"@en ;
+    samm:description "First aid ingestion: First aid measures to be taken after ingestion of the chemical."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:firstAidInhalation a samm:Property ;
+    samm:preferredName "First Aid Inhalation"@en ;
+    samm:description "First aid inhalation: First aid measures to be taken after inhalation of the chemical."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:firstAidMeasures a samm:Property ;
+    samm:preferredName "First Aid Measures"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :FirstAidMeasuresCharacteristic .
+
+:firstAidSkin a samm:Property ;
+    samm:preferredName "First Aid Skin"@en ;
+    samm:description "First aid skin: First aid measures to be taken after skin contact with the chemical."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:flammability a samm:Property ;
+    samm:preferredName "Flammability"@en ;
+    samm:description "Flammability description:"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:flammableAerosols a samm:Property ;
+    samm:preferredName "Flammable Aerosols"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :FlammableAerosolsCharacteristic .
+
+:flammableGases a samm:Property ;
+    samm:preferredName "Flammable Gases"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :FlammableGasesCharacteristic .
+
+:flammableLiquids a samm:Property ;
+    samm:preferredName "Flammable Liquids"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :FlammableLiquidsCharacteristic .
+
+:flammableSolids a samm:Property ;
+    samm:preferredName "Flammable Solids"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :FlammableSolidsCharacteristic .
+
+:flashPoint a samm:Property ;
+    samm:preferredName "Flash Point"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :FlashPointList .
+
+:fluorinatedGreenhouseGasesMethod a samm:Property ;
+    samm:preferredName "Fluorinated Greenhouse Gases Method"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:forEmergencyResponders a samm:Property ;
+    samm:preferredName "For Emergency Responders"@en ;
+    samm:description "For emergency responders: Information on personal protection, suitable fabric for personal protective clothing, etc."@en ;
+    samm:characteristic :PhraseList .
+
+:forNonEmergencyPersonnel a samm:Property ;
+    samm:preferredName "For Non Emergency Personnel"@en ;
+    samm:characteristic :ForNonEmergencyPersonnelCharacteristic .
+
+:form a samm:Property ;
+    samm:preferredName "Form"@en ;
+    samm:characteristic :FormEnumCharacteristic .
+
+:formDescription a samm:Property ;
+    samm:preferredName "Form Description"@en ;
+    samm:description "Indicate the form (solid, liquid, gas or other descriptive terms) of the substance or mixture as supplied. May be omitted if specified in field Form. If Form is \"other\", put more details in this field."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:freetextLanguageCode a samm:Property ;
+    samm:preferredName "Freetext Language Code"@en ;
+    samm:description "Enumeration with defined code set. Language independent. ISO 639-1 (2 letters)"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :LanguageCodeEnumCharacteristic .
+
+:freetextLanguageCountryCode a samm:Property ;
+    samm:preferredName "Freetext Language Country Code"@en ;
+    samm:description "If languages are used in more than one country, there might be national flavours that are significantly different (like pt-BR, en-US). In this case, indicate the country here. If empty, this field defaults to the originating country (pt-PT, en-GB)."@en ;
+    samm:characteristic :CountryCodeEnumCharacteristic .
+
+:freetextLanguageName a samm:Property ;
+    samm:preferredName "Freetext Language Name"@en ;
+    samm:description "String with actual language name. Possible to print. Automatic translation possible if a PhraseId is also given."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:freezingPoint a samm:Property ;
+    samm:preferredName "Freezing Point"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:fullText a samm:Property ;
+    samm:preferredName "Full Text"@en ;
+    samm:characteristic samm-c:Text .
+
+:gasGroup a samm:Property ;
+    samm:preferredName "Gas Group"@en ;
+    samm:characteristic :GasGroupList .
+
+:gasesUnderPressure a samm:Property ;
+    samm:preferredName "Gases Under Pressure"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :GasesUnderPressureCharacteristic .
+
+:gbClpHazardClassification2020 a samm:Property ;
+    samm:preferredName "Gb Clp Hazard Classification2020"@en ;
+    samm:description "The chemical’s individual hazard classifications according to GB-CLP (2020), which adopted EU regulation 1272/2008 as modified by ATP 12."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :GbClpHazardClassification2020Characteristic .
+
+:gbClpHazardLabelling2020 a samm:Property ;
+    samm:preferredName "Gb Clp Hazard Labelling2020"@en ;
+    samm:description "Labelling according to GB-CLP, which is based on EU regulation 1272/2008, revised until and including EU regulation 2019/521, based on GHS revision 7.."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :GbClpHazardLabelling2020Characteristic .
+
+:gender a samm:Property ;
+    samm:preferredName "Gender"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:generalDescription a samm:Property ;
+    samm:preferredName "General Description"@en ;
+    samm:characteristic :GeneralDescriptionCharacteristic .
+
+:generalInformation a samm:Property ;
+    samm:preferredName "General Information"@en ;
+    samm:description "General first aid measures: Brief and easy to understand informationfor the victim, bystanders and first-aiders. Information if immediate medical attention is required, on what can be done on the spot in the case of an accident, and whether delayed effects can be expected after exposure."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:generalOccupationalHygiene a samm:Property ;
+    samm:preferredName "General Occupational Hygiene"@en ;
+    samm:description "Advice on general occupational hygiene, such as not to eat, drink and smoke in work areas, to wash hands after use, and to remove contaminated clothing and protective equipment before entering eating areas."@en ;
+    samm:characteristic :PhraseList .
+
+:genericName a samm:Property ;
+    samm:preferredName "Generic Name"@en ;
+    samm:description "Alternative chemical name to protect Confidential Business Information (in Europe, according to CLP article 24)"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:germCellMutagenicity a samm:Property ;
+    samm:preferredName "Germ Cell Mutagenicity"@en ;
+    samm:characteristic :GermCellMutagenicityCharacteristic .
+
+:germCellMutagenicityHumanExperience a samm:Property ;
+    samm:preferredName "Germ Cell Mutagenicity Human Experience"@en ;
+    samm:characteristic :PhraseList .
+
+:gisCode a samm:Property ;
+    samm:preferredName "Gis Code"@en ;
+    samm:description "German GisCode of the BGBau for the construction industrie"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:globalWarmingPotential a samm:Property ;
+    samm:preferredName "Global Warming Potential"@en ;
+    samm:description "a.k.a. GWP"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:gloveBreakthroughTime a samm:Property ;
+    samm:preferredName "Glove Breakthrough Time"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:goodPracticeAdvice a samm:Property ;
+    samm:preferredName "Good Practice Advice"@en ;
+    samm:description "In Exposure Scenarios, also known as AGPA = Additional Good Practice Advice"@en ;
+    samm:characteristic :GoodPracticeAdviceCharacteristic .
+
+:group a samm:Property ;
+    samm:preferredName "Group"@en ;
+    samm:characteristic :EffectLevelGroupEnumCharacteristic .
+
+:groupFulltext a samm:Property ;
+    samm:preferredName "Group Fulltext"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:halfLifeTime a samm:Property ;
+    samm:preferredName "Half Life Time"@en ;
+    samm:description "Time unit, e.g. d or h. Test type should go into HalfLifeTime/TestReference"@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureCharacteristic .
+
+:handProtection a samm:Property ;
+    samm:preferredName "Hand Protection"@en ;
+    samm:characteristic :HandProtectionCharacteristic .
+
+:handProtectionNecessaryProperties a samm:Property ;
+    samm:preferredName "Hand Protection Necessary Properties"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:handlingAndStorage a samm:Property ;
+    samm:preferredName "Handling And Storage"@en ;
+    samm:description "Handling and storage: Advice on safe handling practices with emphasise on precautions that are appropriate to the identified uses referred to under subsection 1.2 and to the unique properties of the chemical. Information shall relate to the protection of human health, safety and the environment. It shall assist the employer in devising suitable working procedures and organisational measures according to Article 5 of Directive 98/24/EC and Article 5 of Directive 2004/37/EC. Where a chemical safety report is required, the information shall be consistent with the information given for the identified uses in the chemical safety report and the exposure scenarios showing control of risk."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :HandlingAndStorageCharacteristic .
+
+:handlingPrecautions a samm:Property ;
+    samm:preferredName "Handling Precautions"@en ;
+    samm:description "Handling precautions: Recommendations to allow safe handling of the chemical, such as containment etc."@en ;
+    samm:characteristic :PhraseList .
+
+:hazardBand a samm:Property ;
+    samm:preferredName "Hazard Band"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:hazardClassCategory a samm:Property ;
+    samm:preferredName "Hazard Class Category"@en ;
+    samm:characteristic samm-c:Text .
+
+:hazardClassCategoryPrintable a samm:Property ;
+    samm:preferredName "Hazard Class Category Printable"@en ;
+    samm:description "Printable, phrase based representation of HazardClassCategory. While this may be identical to HazardClassCatgory in its string representation, it provides a translated version linked to a phrase library for applications where this is useful."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:hazardCombustionProd a samm:Property ;
+    samm:preferredName "Hazard Combustion Prod"@en ;
+    samm:description "Hazardous combustion products: Information on hazardous components that may be formed during combustion of the chemical."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:hazardDescriptionGeneral a samm:Property ;
+    samm:preferredName "Hazard Description General"@en ;
+    samm:description "Hazard identification: Description of the most important hazardous effects connected to the chemical in normal use and foreseeable misuse. This element should not be used in the compilation of SDSs - only to receive information from existing SDSs in import!"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:hazardIdentification a samm:Property ;
+    samm:preferredName "Hazard Identification"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :HazardIdentificationCharacteristic .
+
+:hazardLabel a samm:Property ;
+    samm:preferredName "Hazard Label"@en ;
+    samm:characteristic samm-c:Text .
+
+:hazardLabelAdr a samm:Property ;
+    samm:preferredName "Hazard Label Adr"@en ;
+    samm:characteristic samm-c:Text .
+
+:hazardLabelEnglish a samm:Property ;
+    samm:preferredName "Hazard Label English"@en ;
+    samm:description "In analogy to issue #13, this content should be in English language because it is never used in other languages in shipping papers. Nevertheless, the phrase type makes it translatable."@en ;
+    samm:characteristic :PhraseList .
+
+:hazardLabelRid a samm:Property ;
+    samm:preferredName "Hazard Label Rid"@en ;
+    samm:characteristic samm-c:Text .
+
+:hazardLabelling a samm:Property ;
+    samm:preferredName "Hazard Labelling"@en ;
+    samm:description "Hazard labelling: To collect all information on the trade product’s hazard labelling in one group."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :HazardLabellingArCharacteristic .
+
+:hazardNumber a samm:Property ;
+    samm:preferredName "Hazard Number"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:hazardPictogram a samm:Property ;
+    samm:preferredName "Hazard Pictogram"@en ;
+    samm:description "Pictogram: A graphical presentation that includes a symbol plus other graphic elements, such as a border, background pattern or colour that is intended to convey specific information on the hazard concerned."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :GhsPictogramCodeEnumCharacteristic .
+
+:hazardStatement a samm:Property ;
+    samm:preferredName "Hazard Statement"@en ;
+    samm:description "Hazard statement: A phrase assigned to a hazard class and category that describes the nature of the hazards of a hazardous substance or mixture, including, where appropriate, the degree of hazard."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :Ghs05HazardStatementList .
+
+:hazardousDecompositionProducts a samm:Property ;
+    samm:preferredName "Hazardous Decomposition Products"@en ;
+    samm:description "Hazardous decomposition products: Hazardous chemicals which may be formed in dangerous quantity during decomposition. Address specifically hazardous decomposition products, if any, formed upon contact with water, and possibility of degradation to unstable products. Hazardous combustion products shall be included in Section 5."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:hazardousReactions a samm:Property ;
+    samm:preferredName "Hazardous Reactions"@en ;
+    samm:description "Hazardous reactions: If relevant, state if the chemical will react or polymerise, releasing excess pressure or heat, or creating other hazardous conditions. The conditions under which the hazardous reactions may occur shall be described."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:hazardousWaste a samm:Property ;
+    samm:preferredName "Hazardous Waste"@en ;
+    samm:description "optional because this property can be dreived from WasteCode"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Boolean .
+
+:hazardousWasteCharacteristics a samm:Property ;
+    samm:preferredName "Hazardous Waste Characteristics"@en ;
+    samm:characteristic :PhraseList .
+
+:hazardousWasteCode a samm:Property ;
+    samm:preferredName "Hazardous Waste Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:hazardousWasteStatus a samm:Property ;
+    samm:preferredName "Hazardous Waste Status"@en ;
+    samm:characteristic :PhraseList .
+
+:hazcom2012HazardClassification a samm:Property ;
+    samm:preferredName "Hazcom2012Hazard Classification"@en ;
+    samm:description "Classification according to 29 CFR 1910.1200"@en ;
+    samm:characteristic :Hazcom2012HazardClassificationCharacteristic .
+
+:hazcom2012HazardLabelling a samm:Property ;
+    samm:preferredName "Hazcom2012Hazard Labelling"@en ;
+    samm:description "Labelling according to EU regulation 1272/2008, revised until and including EU regulation 2016/918, based of GHS revision 5."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :Hazcom2012HazardLabellingCharacteristic .
+
+:healthEffect a samm:Property ;
+    samm:preferredName "Health Effect"@en ;
+    samm:description "Health effects: The most important adverse health effects and symptoms."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:healthHazardThreshold a samm:Property ;
+    samm:preferredName "Health Hazard Threshold"@en ;
+    samm:description "in kg"@en ;
+    samm:characteristic :IntegerCharacteristic .
+
+:healthHazardsSevesoEntryDe a samm:Property ;
+    samm:preferredName "Health Hazards"@en ;
+    samm:characteristic :SevesoEntryDeCharacteristic .
+
+:healthHazardsSevesoEntryEu a samm:Property ;
+    samm:preferredName "Health Hazards"@en ;
+    samm:characteristic :SevesoEntryEuCharacteristic .
+
+:hintsOnStorageAssembly a samm:Property ;
+    samm:preferredName "Hints On Storage Assembly"@en ;
+    samm:characteristic :PhraseList .
+
+:humanExperience a samm:Property ;
+    samm:preferredName "Human Experience"@en ;
+    samm:characteristic :HumanExperienceCharacteristic .
+
+:humanToxicologicalData a samm:Property ;
+    samm:preferredName "Human Toxicological Data"@en ;
+    samm:characteristic :PhraseList .
+
+:hydrolysisRate a samm:Property ;
+    samm:preferredName "Hydrolysis Rate"@en ;
+    samm:characteristic :HydrolysisRateList .
+
+:iataDgr a samm:Property ;
+    samm:preferredName "Iata Dgr"@en ;
+    samm:characteristic :IataDgrCharacteristic .
+
+:idNoUsaDot a samm:Property ;
+    samm:preferredName "Id No Usa Dot"@en ;
+    samm:description "U.S. transportation numbers are either preceded with \"UN\" or with \"NA\""@en ;
+    samm:characteristic samm-c:Text .
+
+:identificationSubstPrep a samm:Property ;
+    samm:preferredName "Identification Subst Prep"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :IdentificationSubstPrepCharacteristic .
+
+:identifiedUse a samm:Property ;
+    samm:preferredName "Identified Use"@en ;
+    samm:description "NB: Optional attribute IdentifiedUseId to identify the actual identified use (ExposureScenario). The optional attribute PrintAsAttachment can be used to toggle printing the exposue scenario inline in the Sds or as an attachment."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :IdentifiedUseList .
+
+:identifiedUseId a samm:Property ;
+    samm:preferredName "Identified Use Id"@en ;
+    samm:characteristic :IntegerCharacteristic .
+
+:imdg a samm:Property ;
+    samm:preferredName "Imdg"@en ;
+    samm:characteristic :ImdgCharacteristic .
+
+:inCaseOfEyeContact a samm:Property ;
+    samm:preferredName "In Case Of Eye Contact"@en ;
+    samm:characteristic :PhraseList .
+
+:inCaseOfIngestion a samm:Property ;
+    samm:preferredName "In Case Of Ingestion"@en ;
+    samm:characteristic :PhraseList .
+
+:inCaseOfInhalation a samm:Property ;
+    samm:preferredName "In Case Of Inhalation"@en ;
+    samm:characteristic :PhraseList .
+
+:inCaseOfSkinContact a samm:Property ;
+    samm:preferredName "In Case Of Skin Contact"@en ;
+    samm:characteristic :PhraseList .
+
+:inciName a samm:Property ;
+    samm:preferredName "Inci Name"@en ;
+    samm:description "according to EU cosmetics regulation"@en ;
+    samm:characteristic samm-c:Text .
+
+:indexNo a samm:Property ;
+    samm:preferredName "Index No"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:inductionTime a samm:Property ;
+    samm:preferredName "Induction Time"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:industrialEmissions a samm:Property ;
+    samm:preferredName "Industrial Emissions"@en ;
+    samm:description "Directive 2010/75/EU This should be an exact value, not a range. But for reasons of ingredient nondisclosure, some companies decide to provide a range here."@en ;
+    samm:characteristic :IndustrialEmissionsCharacteristic .
+
+:industrialSectorSpecificSolutions a samm:Property ;
+    samm:preferredName "Industrial Sector Specific Solutions"@en ;
+    samm:description "Industrial sector specific solutions: Information on industrial sector specific solutions."@en ;
+    samm:characteristic :PhraseList .
+
+:industrialUse a samm:Property ;
+    samm:preferredName "Industrial Use"@en ;
+    samm:characteristic samm-c:Boolean .
+
+:informationFromExportingSystem a samm:Property ;
+    samm:preferredName "Information From Exporting System"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :InformationFromExportingSystemCharacteristic .
+
+:informationToHealthProfessionals a samm:Property ;
+    samm:preferredName "Information To Health Professionals"@en ;
+    samm:description "Information to physician:"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :InformationToHealthProfessionalsCharacteristic .
+
+:inhalation a samm:Property ;
+    samm:preferredName "Inhalation"@en ;
+    samm:characteristic :PercentageCharacteristic .
+
+:inoculum a samm:Property ;
+    samm:preferredName "Inoculum"@en ;
+    samm:characteristic :PhraseList .
+
+:inorganicCarbon a samm:Property ;
+    samm:preferredName "Inorganic Carbon"@en ;
+    samm:description "a.k.a. IC"@en ;
+    samm:characteristic :FurtherEcologicalDataList .
+
+:insectToxicity a samm:Property ;
+    samm:preferredName "Insect Toxicity"@en ;
+    samm:characteristic :EcotoxicityList .
+
+:instructionalMeasures a samm:Property ;
+    samm:preferredName "Instructional Measures"@en ;
+    samm:characteristic :PhraseList .
+
+:instructionsForUse a samm:Property ;
+    samm:preferredName "Instructions For Use"@en ;
+    samm:description "Specific for labels according to to Biocidal Products Regulation (EU) No 528/2012."@en ;
+    samm:characteristic :PhraseList .
+
+:intendedUseBiologicalLimitValue a samm:Property ;
+    samm:preferredName "Intended Use Biological Limit Value"@en ;
+    samm:description "aims at degradation product limit values during use"@en ;
+    samm:characteristic :BiologicalLimitValueList .
+
+:intendedUseOccupationalExposureLimit a samm:Property ;
+    samm:preferredName "Intended Use Occupational Exposure Limit"@en ;
+    samm:description "aims at degradation product limit values during use"@en ;
+    samm:characteristic :OccupationalExposureLimitList .
+
+:internalSdsId a samm:Property ;
+    samm:preferredName "Internal Sds Id"@en ;
+    samm:description "Internal SDS identitifier: The identity of the SDS in the system that generates the XML file. This field will usually not be shown in the SDS, but will be useful in future updates with new versions of previously received data sheets. This field is sufficiently large to accept GUID (Global Unique ID) on each SDS. System generated identity – not to be displayed. Use the same id independetly of the version of the SDS."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:intrusionDepth a samm:Property ;
+    samm:preferredName "Intrusion Depth"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:investigationMethod a samm:Property ;
+    samm:preferredName "Investigation Method"@en ;
+    samm:characteristic :InvestigationMethodCharacteristic .
+
+:investigationParameter a samm:Property ;
+    samm:preferredName "Investigation Parameter"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:irritation a samm:Property ;
+    samm:preferredName "Irritation"@en ;
+    samm:characteristic :PhraseList .
+
+:irritationToRespiratoryTract a samm:Property ;
+    samm:preferredName "Irritation To Respiratory Tract"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ToxInfoStotSe3Characteristic .
+
+:isBiocide a samm:Property ;
+    samm:preferredName "Is Biocide"@en ;
+    samm:characteristic samm-c:Boolean .
+
+:isDetergent a samm:Property ;
+    samm:preferredName "Is Detergent"@en ;
+    samm:characteristic samm-c:Boolean .
+
+:isTreatedArticle a samm:Property ;
+    samm:preferredName "Is Treated Article"@en ;
+    samm:characteristic samm-c:Boolean .
+
+:issueDate a samm:Property ;
+    samm:preferredName "Issue Date"@en ;
+    samm:description "Date of issue: The date when this SDS was prepared for the first time."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DateCharacteristic .
+
+:iupacName a samm:Property ;
+    samm:preferredName "Iupac Name"@en ;
+    samm:description "IUPAC or chemical name"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:justificationForDataWaiving a samm:Property ;
+    samm:preferredName "Justification For Data Waiving"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:labellingAccordingToOtherLegislation a samm:Property ;
+    samm:preferredName "Labelling According To Other Legislation"@en ;
+    samm:description "Other elements of the hazard label in accordance with EU legislation: Labelling required by other EU legislation"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :LabellingAccordingToOtherLegislationCharacteristic .
+
+:language a samm:Property ;
+    samm:preferredName "Language"@en ;
+    samm:description "The default language of the information, stated in a format according to ISO 639-1 (2 letters) followed by textual name"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :LanguageCharacteristic .
+
+:legalDocument a samm:Property ;
+    samm:preferredName "Legal Document"@en ;
+    samm:description "Legal documents:"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :LegalDocumentCharacteristic .
+
+:legalDocumentFileName a samm:Property ;
+    samm:preferredName "Legal Document File Name"@en ;
+    samm:description "File name: For example, a locked PDF document. A fixed URL is possible."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:legalDocumentPrintDate a samm:Property ;
+    samm:preferredName "Legal Document Print Date"@en ;
+    samm:description "Print date"@en ;
+    samm:characteristic :DateCharacteristic .
+
+:legalDocumentSignature a samm:Property ;
+    samm:preferredName "Legal Document Signature"@en ;
+    samm:description "Digital signature: Digital signature to verify the document."@en ;
+    samm:characteristic samm-c:Text .
+
+:limit8H a samm:Property ;
+    samm:preferredName "Limit8H"@en ;
+    samm:description "If two occurences, one must be ppm and the other a matching mg/m3 value."@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierList .
+
+:limitShortTerm a samm:Property ;
+    samm:preferredName "Limit Short Term"@en ;
+    samm:description "If two occurences, one must be ppm and the other a matching mg/m3 value."@en ;
+    samm:characteristic :StelList .
+
+:limitValueTypeWithCountryOrOrganisation a samm:Property ;
+    samm:preferredName "Limit Value Type With Country Or Organisation"@en ;
+    samm:characteristic :ExposureLimitValueTypeEnumCharacteristic .
+
+:limitedQty a samm:Property ;
+    samm:preferredName "Limited Qty"@en ;
+    samm:characteristic samm-c:Text .
+
+:listItemNo a samm:Property ;
+    samm:preferredName "List Item No"@en ;
+    samm:characteristic :IntegerCharacteristic .
+
+:lowMolecularWeightContentOfPolymers a samm:Property ;
+    samm:preferredName "Low Molecular Weight Content Of Polymers"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:lowerExplosionLimit a samm:Property ;
+    samm:preferredName "Lower Explosion Limit"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:lowerTierQuantity a samm:Property ;
+    samm:preferredName "Lower Tier Quantity"@en ;
+    samm:characteristic :LowerTierQuantityInlineCharacteristic .
+
+:lowerValue a samm:Property ;
+    samm:preferredName "Lower Value"@en ;
+    samm:characteristic :FloatCharacteristic .
+
+:lowerValueSymbol a samm:Property ;
+    samm:preferredName "Lower Value Symbol"@en ;
+    samm:characteristic :LowerQualifierEnumCharacteristic .
+
+:mainGroup a samm:Property ;
+    samm:preferredName "Main Group"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:mainIntendedUse a samm:Property ;
+    samm:preferredName "Main Intended Use"@en ;
+    samm:characteristic :EupcsCategoryCharacteristic .
+
+:majorAccidentsOrdinance a samm:Property ;
+    samm:preferredName "Major Accidents Ordinance"@en ;
+    samm:description "Störfallverordnung of Switzerland"@en ;
+    samm:characteristic :MajorAccidentsOrdinanceCharacteristic .
+
+:malCodeDeliveryState a samm:Property ;
+    samm:preferredName "Mal Code Delivery State"@en ;
+    samm:characteristic samm-c:Text .
+
+:malCodeReadyToUse a samm:Property ;
+    samm:preferredName "Mal Code Ready To Use"@en ;
+    samm:description "If the application requires mixing or thinning, Mal codes should be determined also for the ready to use product. Omit if this is not the case."@en ;
+    samm:characteristic samm-c:Text .
+
+:manufacturer a samm:Property ;
+    samm:preferredName "Manufacturer"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:marinePollutant a samm:Property ;
+    samm:preferredName "Marine Pollutant"@en ;
+    samm:description "Marine pollutant: To state if the chemical is classified as a marine pollutant."@en ;
+    samm:characteristic samm-c:Boolean .
+
+:maskType a samm:Property ;
+    samm:preferredName "Mask Type"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:materialType a samm:Property ;
+    samm:preferredName "Material Type"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:materialsToAvoid a samm:Property ;
+    samm:preferredName "Materials To Avoid"@en ;
+    samm:description "Materials to avoid – incompatible materials: Families of substances or mixtures or specific substances, such as water, air, acids, bases, oxidising agents, with which the substance or mixture could react to produce a hazardous situation shall be listed. If appropriate, give a brief description of measures to be taken."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:maxDuration a samm:Property ;
+    samm:preferredName "Max Duration"@en ;
+    samm:description "Maximum duration of the use/application."@en ;
+    samm:characteristic :NumericValueWithUnitCharacteristic .
+
+:maxPercentage a samm:Property ;
+    samm:preferredName "Max Percentage"@en ;
+    samm:description "always interpreted as less than (not equal) to the value. If omitted, max percentage is 100."@en ;
+    samm:characteristic :FloatCharacteristic .
+
+:maxTemperatureReached a samm:Property ;
+    samm:preferredName "Max Temperature Reached"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:maxVocConcInMixture a samm:Property ;
+    samm:preferredName "Max Voc Conc In Mixture"@en ;
+    samm:description "Actual max. concentration in the mixture: The concentration of VOC in the mixture. To be given in grams per litre."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericValueWithUnitAndQualifierCharacteristic .
+
+:maxWearDurationOccasionalContact a samm:Property ;
+    samm:preferredName "Max Wear Duration Occasional Contact"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:maxWearDurationPermanentContact a samm:Property ;
+    samm:preferredName "Max Wear Duration Permanent Contact"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:maximumStoragePeriod a samm:Property ;
+    samm:preferredName "Maximum Storage Period"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:meanPhotoEffect a samm:Property ;
+    samm:preferredName "Mean Photo Effect"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:measuresOnConsumerUseOfTheChemical a samm:Property ;
+    samm:preferredName "Measures On Consumer Use Of The Chemical"@en ;
+    samm:characteristic :PhraseList .
+
+:measuresOnServiceLifeInArticles a samm:Property ;
+    samm:preferredName "Measures On Service Life In Articles"@en ;
+    samm:characteristic :PhraseList .
+
+:measuresToPreventAerosolAndDust a samm:Property ;
+    samm:preferredName "Measures To Prevent Aerosol And Dust"@en ;
+    samm:characteristic :PhraseList .
+
+:measuresToPreventFire a samm:Property ;
+    samm:preferredName "Measures To Prevent Fire"@en ;
+    samm:characteristic :PhraseList .
+
+:measuresToProtectEnvironment a samm:Property ;
+    samm:preferredName "Measures To Protect Environment"@en ;
+    samm:characteristic :PhraseList .
+
+:mediaNotBeUsed a samm:Property ;
+    samm:preferredName "Media Not Be Used"@en ;
+    samm:description "Unsuitable media: Media that must not be applied in case of a fire."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:mediaToBeUsed a samm:Property ;
+    samm:preferredName "Media To Be Used"@en ;
+    samm:description "Suitable extinguishing media: Extinguishing media that can be used."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:medicalAttentionAndSpecialTreatmentNeeded a samm:Property ;
+    samm:preferredName "Medical Attention And Special Treatment Needed"@en ;
+    samm:description "Medical attention and special treatment needed: Information if immediate medical attention or special medical treatment is needed after exposure to the chemical."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :MedicalAttentionAndSpecialTreatmentNeededCharacteristic .
+
+:medicalTreatment a samm:Property ;
+    samm:preferredName "Medical Treatment"@en ;
+    samm:description "Medical treatment: Information on"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:medium a samm:Property ;
+    samm:preferredName "Medium"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SolubilityMediumEnumCharacteristic .
+
+:mediumDescription a samm:Property ;
+    samm:preferredName "Medium Description"@en ;
+    samm:description "Specify solubility medium if Medium above is Other, or full text of the medium in printable form."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:meltingPoint a samm:Property ;
+    samm:preferredName "Melting Point"@en ;
+    samm:description "Melting point: The exact temperature or temperature range when a solid becomes liquid"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:meltingPointRelated a samm:Property ;
+    samm:preferredName "Melting Point Related"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :MeltingPointRelatedCharacteristic .
+
+:mergePhrase a samm:Property ;
+    samm:preferredName "Merge Phrase"@en ;
+    samm:characteristic :MergePhraseList .
+
+:mergePhraseNo a samm:Property ;
+    samm:preferredName "Merge Phrase No"@en ;
+    samm:characteristic :IntegerCharacteristic .
+
+:mergeText a samm:Property ;
+    samm:preferredName "Merge Text"@en ;
+    samm:characteristic samm-c:Text .
+
+:methodFulltext a samm:Property ;
+    samm:preferredName "Method Fulltext"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:methodInvestigationMethodEnum a samm:Property ;
+    samm:preferredName "Method"@en ;
+    samm:characteristic :InvestigationMethodEnumCharacteristic .
+
+:methodPhrase a samm:Property ;
+    samm:preferredName "Method"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:microorganismToxicity a samm:Property ;
+    samm:preferredName "Microorganism Toxicity"@en ;
+    samm:characteristic :EcotoxicityAquaticList .
+
+:minPercentage a samm:Property ;
+    samm:preferredName "Min Percentage"@en ;
+    samm:description "always interpreted as greater than or equal to the value"@en ;
+    samm:characteristic :FloatCharacteristic .
+
+:miscibility a samm:Property ;
+    samm:preferredName "Miscibility"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:mixtureExposureScenarioInAnnex a samm:Property ;
+    samm:preferredName "Mixture Exposure Scenario In Annex"@en ;
+    samm:description "Exposure scenarios for the mixture: To state if information on the actual use of the mixture, similar to information in an exposure scenario for a substance, is enclosed the SDS."@en ;
+    samm:characteristic samm-c:Boolean .
+
+:mobility a samm:Property ;
+    samm:preferredName "Mobility"@en ;
+    samm:characteristic :MobilityList .
+
+:mobilityEvaluation a samm:Property ;
+    samm:preferredName "Mobility Evaluation"@en ;
+    samm:characteristic :PhraseList .
+
+:molecularWeightDistribution a samm:Property ;
+    samm:preferredName "Molecular Weight Distribution"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:multiplyingFactor a samm:Property ;
+    samm:preferredName "Multiplying Factor"@en ;
+    samm:description "Multiplying factor for substances highly toxic to the environment. Part of the classification of pure substances. The M factors are used in application of summation method for classification of mixtures containing substances that are classified as very toxic. The concept of M factors has been established to give an increased weight to very toxic substances when classifying mixtures."@en ;
+    samm:characteristic :MultiplyingFactorCharacteristic .
+
+:name a samm:Property ;
+    samm:preferredName "Name"@en ;
+    samm:characteristic samm-c:Text .
+
+:nameDetergentsRegulation a samm:Property ;
+    samm:preferredName "Name Detergents Regulation"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:narcoticEffects a samm:Property ;
+    samm:preferredName "Narcotic Effects"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ToxInfoStotSe3Characteristic .
+
+:nationalContact a samm:Property ;
+    samm:preferredName "National Contact"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislation a samm:Property ;
+    samm:preferredName "National Legislation"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NationalLegislationCharacteristic .
+
+:nationalLegislationAlbania a samm:Property ;
+    samm:preferredName "National Legislation Albania"@en ;
+    samm:description "EU candidate"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationAndorra a samm:Property ;
+    samm:preferredName "National Legislation Andorra"@en ;
+    samm:description "not part of the EU, but closely connected and currently without relevant national regulations. This element is a placeholder."@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationAustria a samm:Property ;
+    samm:preferredName "National Legislation Austria"@en ;
+    samm:characteristic :RegulationsAtCharacteristic .
+
+:nationalLegislationBelarus a samm:Property ;
+    samm:preferredName "National Legislation Belarus"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationBelgium a samm:Property ;
+    samm:preferredName "National Legislation Belgium"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationBosniaAndHerzegovina a samm:Property ;
+    samm:preferredName "National Legislation Bosnia And Herzegovina"@en ;
+    samm:description "not a EU member and witout chemicals law - except for the Srpska province, which aligns its safety data sheet to the EU."@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationBulgaria a samm:Property ;
+    samm:preferredName "National Legislation Bulgaria"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationCroatia a samm:Property ;
+    samm:preferredName "National Legislation Croatia"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationCyprus a samm:Property ;
+    samm:preferredName "National Legislation Cyprus"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationCzechRepublic a samm:Property ;
+    samm:preferredName "National Legislation Czech Republic"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationDenmark a samm:Property ;
+    samm:preferredName "National Legislation Denmark"@en ;
+    samm:characteristic :RegulationsDkCharacteristic .
+
+:nationalLegislationEstonia a samm:Property ;
+    samm:preferredName "National Legislation Estonia"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationFinland a samm:Property ;
+    samm:preferredName "National Legislation Finland"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationFrance a samm:Property ;
+    samm:preferredName "National Legislation France"@en ;
+    samm:description "includes French Guayana, Guadeloupe, Martinique, Réunion, Mayotte and Saint Martin, which are not part of the European Customs Union."@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationGermany a samm:Property ;
+    samm:preferredName "National Legislation Germany"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :RegulationsDeCharacteristic .
+
+:nationalLegislationGreece a samm:Property ;
+    samm:preferredName "National Legislation Greece"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationHungary a samm:Property ;
+    samm:preferredName "National Legislation Hungary"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationIceland a samm:Property ;
+    samm:preferredName "National Legislation Iceland"@en ;
+    samm:description "not part of the EU, but chemical legislation aligned with EU legislation."@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationIreland a samm:Property ;
+    samm:preferredName "National Legislation Ireland"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationItaly a samm:Property ;
+    samm:preferredName "National Legislation Italy"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationKazakhstan a samm:Property ;
+    samm:preferredName "National Legislation Kazakhstan"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationLatvia a samm:Property ;
+    samm:preferredName "National Legislation Latvia"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationLiechtenstein a samm:Property ;
+    samm:preferredName "National Legislation Liechtenstein"@en ;
+    samm:description "not part of the EU, but closely connected."@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationLithuania a samm:Property ;
+    samm:preferredName "National Legislation Lithuania"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationLuxembourg a samm:Property ;
+    samm:preferredName "National Legislation Luxembourg"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationMalta a samm:Property ;
+    samm:preferredName "National Legislation Malta"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationMonaco a samm:Property ;
+    samm:preferredName "National Legislation Monaco"@en ;
+    samm:description "not part of the EU, but closely connected."@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationMontenegro a samm:Property ;
+    samm:preferredName "National Legislation Montenegro"@en ;
+    samm:description "EU candidate"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationNetherlands a samm:Property ;
+    samm:preferredName "National Legislation Netherlands"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationNorthMacedonia a samm:Property ;
+    samm:preferredName "National Legislation North Macedonia"@en ;
+    samm:description "EU candidate"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationNorway a samm:Property ;
+    samm:preferredName "National Legislation Norway"@en ;
+    samm:description "not part of the EU, but closely connected."@en ;
+    samm:characteristic :RegulationsNoCharacteristic .
+
+:nationalLegislationPoland a samm:Property ;
+    samm:preferredName "National Legislation Poland"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationPortugal a samm:Property ;
+    samm:preferredName "National Legislation Portugal"@en ;
+    samm:description "includes the Azores and Madeira"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationRomania a samm:Property ;
+    samm:preferredName "National Legislation Romania"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationRussianFederation a samm:Property ;
+    samm:preferredName "National Legislation Russian Federation"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationSanMarino a samm:Property ;
+    samm:preferredName "National Legislation San Marino"@en ;
+    samm:description "not part of the EU, but closely connected and currently without relevant national regulations. This element is a placeholder."@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationSerbia a samm:Property ;
+    samm:preferredName "National Legislation Serbia"@en ;
+    samm:description "EU candidate"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationSlovakia a samm:Property ;
+    samm:preferredName "National Legislation Slovakia"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationSlovenia a samm:Property ;
+    samm:preferredName "National Legislation Slovenia"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationSpain a samm:Property ;
+    samm:preferredName "National Legislation Spain"@en ;
+    samm:description "Includes the Canaries. Includes Ceuta and Melilla which are not part of the European Customs Union."@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationSweden a samm:Property ;
+    samm:preferredName "National Legislation Sweden"@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationSwitzerland a samm:Property ;
+    samm:preferredName "National Legislation Switzerland"@en ;
+    samm:description "no EU member, but has its legislation widely aligned to EU law, thus accepts safety data sheets in EU format."@en ;
+    samm:characteristic :RegulationsChCharacteristic .
+
+:nationalLegislationUkraine a samm:Property ;
+    samm:preferredName "National Legislation Ukraine"@en ;
+    samm:description "not part of the EU, but legislation allows SDS according to EU standards."@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationUnitedKingdom a samm:Property ;
+    samm:preferredName "National Legislation United Kingdom"@en ;
+    samm:description "No EU member anymore after March 29, 2019. Until deviating legislation is established, the UK will be covered with a EU safety data sheet. Includes Gibraltar, which is not part of the European Customs Union."@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationVaticanCityState a samm:Property ;
+    samm:preferredName "National Legislation Vatican City State"@en ;
+    samm:description "not part of the EU, but closely connected and currently without relevant national regulations. This element is a placeholder."@en ;
+    samm:characteristic samm-c:Text .
+
+:nationalLegislationsDescription a samm:Property ;
+    samm:preferredName "National Legislations Description"@en ;
+    samm:characteristic :PhraseList .
+
+:nationalRegulations a samm:Property ;
+    samm:preferredName "National Regulations"@en ;
+    samm:characteristic :PhraseList .
+
+:nationalWasteCode a samm:Property ;
+    samm:preferredName "National Waste Code"@en ;
+    samm:characteristic :PhraseList .
+
+:nationalWasteLegislation a samm:Property ;
+    samm:preferredName "National Waste Legislation"@en ;
+    samm:characteristic :NationalWasteLegislationNoList .
+
+:nationalWasteLegislationCh a samm:Property ;
+    samm:preferredName "National Waste Legislation Ch"@en ;
+    samm:characteristic :NationalWasteLegislationChCharacteristic .
+
+:nationalWasteLegislationDe a samm:Property ;
+    samm:preferredName "National Waste Legislation De"@en ;
+    samm:description "National legislation: National requirements related to waste that applies to the product or its packaging."@en ;
+    samm:characteristic :NationalWasteLegislationDeList .
+
+:noInt20 a samm:Property ;
+    samm:preferredName "No"@en ;
+    samm:description "GTIN No:"@en ;
+    samm:characteristic samm-c:Text .
+
+:noPhrase a samm:Property ;
+    samm:preferredName "No"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:noString256 a samm:Property ;
+    samm:preferredName "No"@en ;
+    samm:description "Telephone number:"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:nom2015HazardClassification a samm:Property ;
+    samm:preferredName "Nom2015Hazard Classification"@en ;
+    samm:description "according to GHS revision 5"@en ;
+    samm:characteristic :Nom2015HazardClassificationCharacteristic .
+
+:nom2015HazardLabelling a samm:Property ;
+    samm:preferredName "Nom2015Hazard Labelling"@en ;
+    samm:description "according to GHS revision 5"@en ;
+    samm:characteristic :Nom2015HazardLabellingCharacteristic .
+
+:nonHumanToxicologicalData a samm:Property ;
+    samm:preferredName "Non Human Toxicological Data"@en ;
+    samm:characteristic :NonHumanToxicologicalDataList .
+
+:norwegianPrFunctionCode a samm:Property ;
+    samm:preferredName "Norwegian Pr Function Code"@en ;
+    samm:characteristic :PhraseList .
+
+:notApplicableReason a samm:Property ;
+    samm:preferredName "Not Applicable Reason"@en ;
+    samm:characteristic :PhraseList .
+
+:numberAverageMolecularWeight a samm:Property ;
+    samm:preferredName "Number Average Molecular Weight"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:oarGroup a samm:Property ;
+    samm:preferredName "Oar Group"@en ;
+    samm:characteristic samm-c:Text .
+
+:oarValue a samm:Property ;
+    samm:preferredName "Oar Value"@en ;
+    samm:characteristic samm-c:Text .
+
+:occupationalAirRequirement a samm:Property ;
+    samm:preferredName "Occupational Air Requirement"@en ;
+    samm:characteristic :OccupationalAirRequirementNoCharacteristic .
+
+:occupationalExposureLimit a samm:Property ;
+    samm:preferredName "Occupational Exposure Limit"@en ;
+    samm:description "aims at the product in delivery state"@en ;
+    samm:characteristic :OccupationalExposureLimitList .
+
+:occupationalExposureLimits a samm:Property ;
+    samm:preferredName "Occupational Exposure Limits"@en ;
+    samm:description "Occupational exposure limit: Values shall be given for the country where the substance or preparation is placed on the market. Give information on currently recommended monitoring procedures. For mixtures, it is useful to provide values for those constituent substances which are required to be listed in the Safety Data Sheet."@en ;
+    samm:characteristic :OccupationalExposureLimitsCharacteristic .
+
+:odour a samm:Property ;
+    samm:preferredName "Odour"@en ;
+    samm:description "Product odour: Description of the smell of the product."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:odourThreshold a samm:Property ;
+    samm:preferredName "Odour Threshold"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+
+:operationalConditions a samm:Property ;
+    samm:preferredName "Operational Conditions"@en ;
+    samm:characteristic :OperationalConditionsCharacteristic .
+
+:oral a samm:Property ;
+    samm:preferredName "Oral"@en ;
+    samm:characteristic :PercentageCharacteristic .
+
+:organ a samm:Property ;
+    samm:preferredName "Organ"@en ;
+    samm:description "For Sepcific Target Organ Toxicity (STOT), one or more affected organs should be listed if known."@en ;
+    samm:characteristic :PhraseList .
+
+:organAffected a samm:Property ;
+    samm:preferredName "Organ Affected"@en ;
+    samm:characteristic :PhraseList .
+
+:organicPeroxides a samm:Property ;
+    samm:preferredName "Organic Peroxides"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :OrganicPeroxidesCharacteristic .
+
+:organisationalMeasures a samm:Property ;
+    samm:preferredName "Organisational Measures"@en ;
+    samm:characteristic :PhraseList .
+
+:organisationalSigns a samm:Property ;
+    samm:preferredName "Organisational Signs"@en ;
+    samm:characteristic samm-c:Text .
+
+:other a samm:Property ;
+    samm:preferredName "Other"@en ;
+    samm:characteristic :PhraseList .
+
+:otherAdverseEffects a samm:Property ;
+    samm:preferredName "Other Adverse Effects"@en ;
+    samm:characteristic :OtherAdverseEffectsCharacteristic .
+
+:otherEuLabellingRequirements a samm:Property ;
+    samm:preferredName "Other Eu Labelling Requirements"@en ;
+    samm:description "Other labelling requirenments in accordance with EU legislation: Labelling requirements imposed to the chemical in accordance with EU legislation not stated above."@en ;
+    samm:characteristic :PhraseList .
+
+:otherEuLegislation a samm:Property ;
+    samm:preferredName "Other Eu Legislation"@en ;
+    samm:description "Other EU legislations: Miscellaneous restrictions etc. that apply to the chemical based on EU legislations – e.g. regulation on construction products."@en ;
+    samm:characteristic :PhraseList .
+
+:otherHazardThreshold a samm:Property ;
+    samm:preferredName "Other Hazard Threshold"@en ;
+    samm:description "in kg. Includes results from tables 4 and 5"@en ;
+    samm:characteristic :IntegerCharacteristic .
+
+:otherHazardsInfo a samm:Property ;
+    samm:preferredName "Other Hazards Info"@en ;
+    samm:description "Other hazards: Hazards which do not result in classification but which may contribute to the overall hazards of the substance or mixture, such as formation of air contaminants during hardening or processing, dustiness, dust explosion hazards, cross-sensitisation, suffocation, freezing, high potency for odour or taste, or environmental effects like hazards to soil-dwelling organisms, or photochemical ozone creation potential."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :OtherHazardsInfoCharacteristic .
+
+:otherHazardsPhrase a samm:Property ;
+    samm:preferredName "Other Hazards"@en ;
+    samm:description "Ohter hazards: Other hazards necessary to mention which do not result in classification, but which contribute to overall hazards."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:otherHazardsSevesoEntryDe a samm:Property ;
+    samm:preferredName "Other Hazards"@en ;
+    samm:characteristic :SevesoEntryDeCharacteristic .
+
+:otherHazardsSevesoEntryEu a samm:Property ;
+    samm:preferredName "Other Hazards"@en ;
+    samm:characteristic :SevesoEntryEuCharacteristic .
+
+:otherInformation a samm:Property ;
+    samm:preferredName "Other Information"@en ;
+    samm:characteristic :OtherInformationCharacteristic .
+
+:otherLegislation a samm:Property ;
+    samm:preferredName "Other Legislation"@en ;
+    samm:characteristic :PhraseList .
+
+:otherName a samm:Property ;
+    samm:preferredName "Other Name"@en ;
+    samm:description "Includes trade name(s) of the chemical that appear on the packages / hazard label."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:otherPhysicalChemicalProperty a samm:Property ;
+    samm:preferredName "Other Physical Chemical Property"@en ;
+    samm:characteristic :PhraseList .
+
+:otherRestrictionsAndProhibitionRegulations a samm:Property ;
+    samm:preferredName "Other Restrictions And Prohibition Regulations"@en ;
+    samm:description "Other German legislation:"@en ;
+    samm:characteristic :PhraseList .
+
+:otherSafetyInformation a samm:Property ;
+    samm:preferredName "Other Safety Information"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :OtherSafetyInformationCharacteristic .
+
+:overallAssessmentOnCmrProperties a samm:Property ;
+    samm:preferredName "Overall Assessment On Cmr Properties"@en ;
+    samm:characteristic :PhraseList .
+
+:oxidisingGases a samm:Property ;
+    samm:preferredName "Oxidising Gases"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :OxidisingGasesCharacteristic .
+
+:oxidisingLiquids a samm:Property ;
+    samm:preferredName "Oxidising Liquids"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :OxidisingLiquidsCharacteristic .
+
+:oxidisingProperties a samm:Property ;
+    samm:preferredName "Oxidising Properties"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:oxidisingSolids a samm:Property ;
+    samm:preferredName "Oxidising Solids"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :OxidisingSolidsCharacteristic .
+
+:ozoneDepletionPotential a samm:Property ;
+    samm:preferredName "Ozone Depletion Potential"@en ;
+    samm:description "a.k.a. ODP"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:pH a samm:Property ;
+    samm:preferredName "PH"@en ;
+    samm:characteristic :NumericRangeWithQualifierCharacteristic .
+
+:packaging a samm:Property ;
+    samm:preferredName "Packaging"@en ;
+    samm:description "This node and enclosed information are not required for the SDS, but helpful to identfy the packaged product and required for poison center notification according to CLP article 45."@en ;
+    samm:characteristic :PackagingCharacteristic .
+
+:packagingContainer a samm:Property ;
+    samm:preferredName "Packaging Container"@en ;
+    samm:description "Packaging materials: Material and type of container to be used and packaging compabilities."@en ;
+    samm:characteristic :PhraseList .
+
+:packagingMaterial a samm:Property ;
+    samm:preferredName "Packaging Material"@en ;
+    samm:characteristic :PackagingMaterialEnumCharacteristic .
+
+:packagingMaterialDescription a samm:Property ;
+    samm:preferredName "Packaging Material Description"@en ;
+    samm:description "Further specifies the material and type of packaging."@en ;
+    samm:characteristic :PhraseList .
+
+:packagingSize a samm:Property ;
+    samm:preferredName "Packaging Size"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:packagingType a samm:Property ;
+    samm:preferredName "Packaging Type"@en ;
+    samm:characteristic :PackagingTypeEnumCharacteristic .
+
+:packagingTypeDescription a samm:Property ;
+    samm:preferredName "Packaging Type Description"@en ;
+    samm:description "Further specifies the material and type of packaging."@en ;
+    samm:characteristic :PhraseList .
+
+:packagingWaste a samm:Property ;
+    samm:preferredName "Packaging Waste"@en ;
+    samm:characteristic :PhraseList .
+
+:packingGroup a samm:Property ;
+    samm:preferredName "Packing Group"@en ;
+    samm:characteristic :PackingGroupEnumCharacteristic .
+
+:parameterTested a samm:Property ;
+    samm:preferredName "Parameter Tested"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:particleFraction a samm:Property ;
+    samm:preferredName "Particle Fraction"@en ;
+    samm:characteristic :ExposureLimitFractionEnumCharacteristic .
+
+:particleFractionFulltext a samm:Property ;
+    samm:preferredName "Particle Fraction Fulltext"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:particleSize a samm:Property ;
+    samm:preferredName "Particle Size"@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+
+:partitionCoefficient a samm:Property ;
+    samm:preferredName "Partition Coefficient"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PartitionCoefficientList .
+
+:pcCode a samm:Property ;
+    samm:preferredName "Pc Code"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ProductCategoryCodeEnumCharacteristic .
+
+:pcFulltext a samm:Property ;
+    samm:preferredName "Pc Fulltext"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:pdscl a samm:Property ;
+    samm:preferredName "Pdscl"@en ;
+    samm:characteristic :PdsclCharacteristic .
+
+:peakLimitation a samm:Property ;
+    samm:preferredName "Peak Limitation"@en ;
+    samm:description "Also known as ceiling value. If two occurences, one must be ppm and the other a matching mg/m3 value. One of Value and PeakLimitationOverflowFactor is sufficient. If both are given, Value must be the short-term Value multiplied with the overflow factor."@en ;
+    samm:characteristic :PeakLimitationList .
+
+:peakLimitationOverflowFactor a samm:Property ;
+    samm:preferredName "Peak Limitation Overflow Factor"@en ;
+    samm:characteristic :NumericRangeWithQualifierCharacteristic .
+
+:penetrationNo a samm:Property ;
+    samm:preferredName "Penetration No"@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+
+:persistenceDegradability a samm:Property ;
+    samm:preferredName "Persistence Degradability"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PersistenceDegradabilityCharacteristic .
+
+:persistenceDegradabilityEvaluation a samm:Property ;
+    samm:preferredName "Persistence Degradability Evaluation"@en ;
+    samm:characteristic :PhraseList .
+
+:personalPrecautions a samm:Property ;
+    samm:preferredName "Personal Precautions"@en ;
+    samm:description "Personal precautions for non-emergency personnel: Advice on protective equipment etc."@en ;
+    samm:characteristic :PhraseList .
+
+:personalProtectionEquipment a samm:Property ;
+    samm:preferredName "Personal Protection Equipment"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PersonalProtectionEquipmentCharacteristic .
+
+:personalProtectionFirstAider a samm:Property ;
+    samm:preferredName "Personal Protection First Aider"@en ;
+    samm:description "Personal protection for first aider: Information on personal protective equipment to be used by rescuers."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:ph a samm:Property ;
+    samm:preferredName "Ph"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericRangeWithQualifierCharacteristic .
+
+:phNotRelevant a samm:Property ;
+    samm:preferredName "Ph Not Relevant"@en ;
+    samm:characteristic :PhNotRelevantEnumCharacteristic .
+
+:phValue a samm:Property ;
+    samm:preferredName "Ph Value"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhValueList .
+
+:phone a samm:Property ;
+    samm:preferredName "Phone"@en ;
+    samm:description "Telephone number:"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:photoIrritationFactor a samm:Property ;
+    samm:preferredName "Photo Irritation Factor"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:photocatalyticProperties a samm:Property ;
+    samm:preferredName "Photocatalytic Properties"@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+
+:photochemicalOzoneCreationPotential a samm:Property ;
+    samm:preferredName "Photochemical Ozone Creation Potential"@en ;
+    samm:description "a.k.a. POCP"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:phototoxicity a samm:Property ;
+    samm:preferredName "Phototoxicity"@en ;
+    samm:characteristic :PhototoxicityCharacteristic .
+
+:phototoxicityTestResults a samm:Property ;
+    samm:preferredName "Phototoxicity Test Results"@en ;
+    samm:characteristic :PhototoxicityTestResultsList .
+
+:phraseCatalogue a samm:Property ;
+    samm:preferredName "Phrase Catalogue"@en ;
+    samm:description "Phrase catalogue: The phrase library(ies) applied in the preparation of the information. The optional attribute PhraseCatalogueId allows multiple catalogues to be used. Phrase must then have an attribute specifying the PhraseCatalogueId."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCatalogueList .
+
+:phraseCatalogueDate a samm:Property ;
+    samm:preferredName "Phrase Catalogue Date"@en ;
+    samm:description "Date of release of the catalogue version: The version timestamp of the phrase catalogue the information is based on"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DateCharacteristic .
+
+:phraseCatalogueId a samm:Property ;
+    samm:preferredName "Phrase Catalogue Id"@en ;
+    samm:characteristic :EsdscomPhraseCatalogueIdCharacteristic .
+
+:phraseCatalogueIssuer a samm:Property ;
+    samm:preferredName "Phrase Catalogue Issuer"@en ;
+    samm:description "Phrase catalogue issuer: Identification of the suppler of the phrase catalogue to the exporting system, eg. EuPhraC-Workinggroup."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:phraseCatalogueName a samm:Property ;
+    samm:preferredName "Phrase Catalogue Name"@en ;
+    samm:description "Phrase catalogue Name, eg. EuPhraC"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:phraseCatalogueVersion a samm:Property ;
+    samm:preferredName "Phrase Catalogue Version"@en ;
+    samm:description "Catalogue version: The version no of the phrase catalog the information is based on to identify the actual version of the phrase catalogue applied. Phrase catalogues are updated more or less regularly, and different versions may show some differences."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:phraseCodeAtp12SpecialSupplementalLabelInfoEnum a samm:Property ;
+    samm:preferredName "Phrase Code"@en ;
+    samm:characteristic :Atp12SpecialSupplementalLabelInfoEnumCharacteristic .
+
+:phraseCodeAtp12SupplementalHazardInformationEnum a samm:Property ;
+    samm:preferredName "Phrase Code"@en ;
+    samm:characteristic :Atp12SupplementalHazardInformationEnumCharacteristic .
+
+:phraseCodeGhs03HazardEnum a samm:Property ;
+    samm:preferredName "Phrase Code"@en ;
+    samm:description "Should be present for GHS hazard statements, and omitted only for additional US hazard statements."@en ;
+    samm:characteristic samm-c:Text .
+
+:phraseCodeGhs03PrecautionEnum a samm:Property ;
+    samm:preferredName "Phrase Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:phraseCodeGhs05HazardEnum a samm:Property ;
+    samm:preferredName "Phrase Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:phraseCodeGhs05PrecautionEnum a samm:Property ;
+    samm:preferredName "Phrase Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:phraseCodeGhs07HazardEnum a samm:Property ;
+    samm:preferredName "Phrase Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:phraseCodeGhs07PrecautionEnum a samm:Property ;
+    samm:preferredName "Phrase Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:phraseCodeGhsSignalWordEnum a samm:Property ;
+    samm:preferredName "Phrase Code"@en ;
+    samm:characteristic :GhsSignalWordEnumCharacteristic .
+
+:phraseId a samm:Property ;
+    samm:preferredName "Phrase Id"@en ;
+    samm:description "Phrase ID in the catalogue referenced by PhraseCatalogueId - which is not eSDScom, because eSDScom phrase IDs are represented as a field in the phrase types."@en ;
+    samm:characteristic samm-c:Text .
+
+:physicalChemicalPropertiesPhysicalChemicalProperties a samm:Property ;
+    samm:preferredName "Physical Chemical Properties"@en ;
+    samm:description "Physical and chemical properties: This section of the safety data sheet shall describe the empirical data relating to the substance or mixture, if relevant. In the case of a mixture, the entries shall clearly indicate to which substance in the mixture the data apply, unless it is valid for the whole mixture. The following properties shall be clearly identified including, where appropriate, a reference to the test methods used and specification of appropriate units of measurement and/or reference conditions. If relevant for the interpretation of the numerical value, the method of determination shall also be provided."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysicalChemicalPropertiesCharacteristic .
+
+:physicalHazardThreshold a samm:Property ;
+    samm:preferredName "Physical Hazard Threshold"@en ;
+    samm:description "in kg"@en ;
+    samm:characteristic :IntegerCharacteristic .
+
+:physicalHazards a samm:Property ;
+    samm:preferredName "Physical Hazards"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysicalHazardsCharacteristic .
+
+:physicalHazardsSevesoEntryDe a samm:Property ;
+    samm:preferredName "Physical Hazards"@en ;
+    samm:characteristic :SevesoEntryDeCharacteristic .
+
+:physicalHazardsSevesoEntryEu a samm:Property ;
+    samm:preferredName "Physical Hazards"@en ;
+    samm:characteristic :SevesoEntryEuCharacteristic .
+
+:physicochemicalEffect a samm:Property ;
+    samm:preferredName "Physicochemical Effect"@en ;
+    samm:description "Physicochemical effects: The most important adverse physicochemical effects and symptoms."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:plantToxicity a samm:Property ;
+    samm:preferredName "Plant Toxicity"@en ;
+    samm:characteristic :EcotoxicityAquaticList .
+
+:pnecValue a samm:Property ;
+    samm:preferredName "Pnec Value"@en ;
+    samm:characteristic :NumericValueWithUnitCharacteristic .
+
+:pollutionCategory a samm:Property ;
+    samm:preferredName "Pollution Category"@en ;
+    samm:characteristic :PhraseList .
+
+:postAddressLine1 a samm:Property ;
+    samm:preferredName "Post Address Line1"@en ;
+    samm:description "Postal address: P.O.Box or street address"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:postAddressLine2 a samm:Property ;
+    samm:preferredName "Post Address Line2"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:postAddressLine3 a samm:Property ;
+    samm:preferredName "Post Address Line3"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:postCity a samm:Property ;
+    samm:preferredName "Post City"@en ;
+    samm:description "Postal city:"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:postCode a samm:Property ;
+    samm:preferredName "Post Code"@en ;
+    samm:description "Postal code: Two-letter ISO3166 country code followed by a hyphen and the national postal code."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:pourPoint a samm:Property ;
+    samm:preferredName "Pour Point"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:poxPurgeableOrganohalogens a samm:Property ;
+    samm:preferredName "Pox Purgeable Organohalogens"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:prProductCode a samm:Property ;
+    samm:preferredName "Pr Product Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:prProductNo a samm:Property ;
+    samm:preferredName "Pr Product No"@en ;
+    samm:characteristic samm-c:Text .
+
+:prProductRegistration a samm:Property ;
+    samm:preferredName "Pr Product Registration"@en ;
+    samm:characteristic :PrProductRegistrationNoList .
+
+:precautionaryMeasures a samm:Property ;
+    samm:preferredName "Precautionary Measures"@en ;
+    samm:characteristic :PrecautionaryMeasuresCharacteristic .
+
+:precautionaryStatement a samm:Property ;
+    samm:preferredName "Precautionary Statement"@en ;
+    samm:description "Precautionary statement: A phrase that describes recommended measure(s) to minimise or prevent adverse effects resulting from exposure to a hazardous substance or mixture due to its use or disposal."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :Ghs05PrecautionaryStatementList .
+
+:predictedNoEffectConcentration a samm:Property ;
+    samm:preferredName "Predicted No Effect Concentration"@en ;
+    samm:description "Predicted no effect concentration (PNEC): Where a Chemical Safety Report is required, the relevant PNECs for the substance shall be given. For preparations, it is useful to provide values for those constituent substances which are required to be listed."@en ;
+    samm:characteristic :PnecList .
+
+:pressure a samm:Property ;
+    samm:preferredName "Pressure"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:preventiveIndustrialMedicalExaminationRequired a samm:Property ;
+    samm:preferredName "Preventive Industrial Medical Examination Required"@en ;
+    samm:characteristic :PhraseList .
+
+:printAsAttachment a samm:Property ;
+    samm:preferredName "Print As Attachment"@en ;
+    samm:characteristic samm-c:Boolean .
+
+:procCode a samm:Property ;
+    samm:preferredName "Proc Code"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ProcessCategoryCodeEnumCharacteristic .
+
+:procFulltext a samm:Property ;
+    samm:preferredName "Proc Fulltext"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:processCategory a samm:Property ;
+    samm:preferredName "Process Category"@en ;
+    samm:description "Process category: PROC"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ProcessCategoryList .
+
+:productCategory a samm:Property ;
+    samm:preferredName "Product Category"@en ;
+    samm:description "Product category (PC):"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ProductCategoryList .
+
+:productDefinition a samm:Property ;
+    samm:preferredName "Product Definition"@en ;
+    samm:description "This is the place to describe kits. If the data describes a product P which is part of kit K, create two instances of ProductIdentity: One for P, and one for K with an entry in ProductDefinition that describes \"This Product is a kit. The data describes one part of the kit.\""@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:productFunctionCode a samm:Property ;
+    samm:preferredName "Product Function Code"@en ;
+    samm:characteristic :PhraseList .
+
+:productFunctionDescription a samm:Property ;
+    samm:preferredName "Product Function Description"@en ;
+    samm:description "Function desription: This field can be used for product function description in free text."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:productGtin a samm:Property ;
+    samm:preferredName "Product Gtin"@en ;
+    samm:description "GTIN No, in Europe also known as EAN. Has max. 1 instance in an ideal world."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ProductGtinList .
+
+:productIdentifiers a samm:Property ;
+    samm:preferredName "Product Identifiers"@en ;
+    samm:description "Substances as well as mixtures can have trade names, thus the ProductIdentifiers should be applied to both."@en ;
+    samm:characteristic :ProductIdentifiersCharacteristic .
+
+:productName a samm:Property ;
+    samm:preferredName "Product Name"@en ;
+    samm:characteristic samm-c:Text .
+
+:productNoUser a samm:Property ;
+    samm:preferredName "Product No User"@en ;
+    samm:description "The user's item number: The item number(s) used internally by the customer (user). Usually just 1 instance per TradeProductIdentity."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:productRelatedMeasures a samm:Property ;
+    samm:preferredName "Product Related Measures"@en ;
+    samm:characteristic :PhraseList .
+
+:productSubcategory a samm:Property ;
+    samm:preferredName "Product Subcategory"@en ;
+    samm:description "Product Subcategory: The type of paint or varnish"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:productType a samm:Property ;
+    samm:preferredName "Product Type"@en ;
+    samm:description "Product type: For trade product, e.g. detergent, paint, lubricant, glue"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:productWaste a samm:Property ;
+    samm:preferredName "Product Waste"@en ;
+    samm:characteristic :PhraseList .
+
+:professionalUse a samm:Property ;
+    samm:preferredName "Professional Use"@en ;
+    samm:characteristic samm-c:Boolean .
+
+:propellantContent a samm:Property ;
+    samm:preferredName "Propellant Content"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:properShippingName a samm:Property ;
+    samm:preferredName "Proper Shipping Name"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:properShippingNameEnglish a samm:Property ;
+    samm:preferredName "Proper Shipping Name English"@en ;
+    samm:description "Content should be in English language - see issue #13. For additions to this name, see issue #76."@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:properShippingNameNational a samm:Property ;
+    samm:preferredName "Proper Shipping Name National"@en ;
+    samm:description "Content should be in the language of the SDS - see issue #13. For additions to this name, see issue #76."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:properties a samm:Property ;
+    samm:preferredName "Properties"@en ;
+    samm:characteristic :PropertiesCharacteristic .
+
+:protectiveClothingNecessaryProperties a samm:Property ;
+    samm:preferredName "Protective Clothing Necessary Properties"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:protectiveClothingRecommendedMaterial a samm:Property ;
+    samm:preferredName "Protective Clothing Recommended Material"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:protectiveEquipment a samm:Property ;
+    samm:preferredName "Protective Equipment"@en ;
+    samm:characteristic :PhraseList .
+
+:protectiveMeasures a samm:Property ;
+    samm:preferredName "Protective Measures"@en ;
+    samm:characteristic :PhraseList .
+
+:pyrophoricLiquids a samm:Property ;
+    samm:preferredName "Pyrophoric Liquids"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PyrophoricLiquidsCharacteristic .
+
+:pyrophoricSolids a samm:Property ;
+    samm:preferredName "Pyrophoric Solids"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PyrophoricSolidsCharacteristic .
+
+:radicalFormationPotential a samm:Property ;
+    samm:preferredName "Radical Formation Potential"@en ;
+    samm:characteristic :PhysChemValueWithTemperatureList .
+
+:rangeOfApplication a samm:Property ;
+    samm:preferredName "Range Of Application"@en ;
+    samm:characteristic :PhraseList .
+
+:rcraBasisForListing a samm:Property ;
+    samm:preferredName "Rcra Basis For Listing"@en ;
+    samm:characteristic :PhraseList .
+
+:rcraWasteCode a samm:Property ;
+    samm:preferredName "Rcra Waste Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:reachRegNo a samm:Property ;
+    samm:preferredName "Reach Reg No"@en ;
+    samm:characteristic samm-c:Text .
+
+:reactivityDescription a samm:Property ;
+    samm:preferredName "Reactivity Description"@en ;
+    samm:description "Reactivity description: The reactivity hazards of the chemical shall be described. Specific test data shall be provided where available. Information may also be based on general data for the class or family of substance or mixture if such data adequately represent the anticipated hazard.If data for mixtures are not available, data on substances in the mixture shall be provided."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:reasonForWaiving a samm:Property ;
+    samm:preferredName "Reason For Waiving"@en ;
+    samm:characteristic :ReasonForWaivingCharacteristic .
+
+:recommendations a samm:Property ;
+    samm:preferredName "Recommendations"@en ;
+    samm:characteristic :PhraseList .
+
+:recommendedMonitoringProcedure a samm:Property ;
+    samm:preferredName "Recommended Monitoring Procedure"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:recommendedProtectiveClothingArticles a samm:Property ;
+    samm:preferredName "Recommended Protective Clothing Articles"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ProtectionArticleList .
+
+:recommendedRespiratoryProtectionArticles a samm:Property ;
+    samm:preferredName "Recommended Respiratory Protection Articles"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :RespiratoryProtectionArticleList .
+
+:redoxPotential a samm:Property ;
+    samm:preferredName "Redox Potential"@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+
+:reference a samm:Property ;
+    samm:preferredName "Reference"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:referenceGas a samm:Property ;
+    samm:preferredName "Reference Gas"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:referenceRelevantStandard a samm:Property ;
+    samm:preferredName "Reference Relevant Standard"@en ;
+    samm:description "Reference relevant standard: Only to be used for referencing old standards for compatibility"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:referenceToOtherSections a samm:Property ;
+    samm:preferredName "Reference To Other Sections"@en ;
+    samm:description "If appropriate, reference should be made to information in for instance section 8 and 13."@en ;
+    samm:characteristic :PhraseList .
+
+:refractionIndex a samm:Property ;
+    samm:preferredName "Refraction Index"@en ;
+    samm:characteristic :PhysChemValueWithTemperatureList .
+
+:regionAr a samm:Property ;
+    samm:preferredName "Region Ar"@en ;
+    samm:characteristic :RegionArCharacteristic .
+
+:regionBr a samm:Property ;
+    samm:preferredName "Region Br"@en ;
+    samm:characteristic :RegionBrCharacteristic .
+
+:regionBrRegulationsBr a samm:Property ;
+    samm:preferredName "Region Br"@en ;
+    samm:characteristic :RegulationsBrCharacteristic .
+
+:regionBrTransportBr a samm:Property ;
+    samm:preferredName "Region Br"@en ;
+    samm:characteristic :TransportBrCharacteristic .
+
+:regionCa a samm:Property ;
+    samm:preferredName "Region Ca"@en ;
+    samm:characteristic :RegionCaCharacteristic .
+
+:regionCaRegulationsCa a samm:Property ;
+    samm:preferredName "Region Ca"@en ;
+    samm:characteristic :RegulationsCaCharacteristic .
+
+:regionCaSdsSupplierInfo a samm:Property ;
+    samm:preferredName "Region Ca"@en ;
+    samm:characteristic :SdsSupplierInfoCharacteristic .
+
+:regionCaTransportCa a samm:Property ;
+    samm:preferredName "Region Ca"@en ;
+    samm:characteristic :TransportCaCharacteristic .
+
+:regionEu a samm:Property ;
+    samm:preferredName "Region Eu"@en ;
+    samm:characteristic :RegionEuCharacteristic .
+
+:regionEuAnnexesEu a samm:Property ;
+    samm:preferredName "Region Eu"@en ;
+    samm:characteristic :AnnexesEuCharacteristic .
+
+:regionEuControlParametersEu a samm:Property ;
+    samm:preferredName "Region Eu"@en ;
+    samm:characteristic :ControlParametersEuCharacteristic .
+
+:regionEuDisposalConsiderationsEu a samm:Property ;
+    samm:preferredName "Region Eu"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DisposalConsiderationsEuCharacteristic .
+
+:regionEuRegulationsEu a samm:Property ;
+    samm:preferredName "Region Eu"@en ;
+    samm:description "This element refers to all countries an regulations that will be covered by a safety data sheet in EU REACH format. Including a country here is no political statement, i.e. it does not mean the country is, will be or should be(come) part of the European Union."@en ;
+    samm:characteristic :RegulationsEuCharacteristic .
+
+:regionEuSdsSupplierInfoEu a samm:Property ;
+    samm:preferredName "Region Eu"@en ;
+    samm:characteristic :SdsSupplierInfoEuCharacteristic .
+
+:regionEuSubstanceIdentityEu a samm:Property ;
+    samm:preferredName "Region Eu"@en ;
+    samm:characteristic :SubstanceIdentityEuCharacteristic .
+
+:regionEuTransportEu a samm:Property ;
+    samm:preferredName "Region Eu"@en ;
+    samm:characteristic :TransportEuCharacteristic .
+
+:regionGb a samm:Property ;
+    samm:preferredName "Region Gb"@en ;
+    samm:characteristic :RegionGbCharacteristic .
+
+:regionJp a samm:Property ;
+    samm:preferredName "Region Jp"@en ;
+    samm:characteristic :RegulationsJpCharacteristic .
+
+:regionMx a samm:Property ;
+    samm:preferredName "Region Mx"@en ;
+    samm:characteristic :RegionMxCharacteristic .
+
+:regionMxRegulationsMx a samm:Property ;
+    samm:preferredName "Region Mx"@en ;
+    samm:characteristic :RegulationsMxCharacteristic .
+
+:regionMxTransportMx a samm:Property ;
+    samm:preferredName "Region Mx"@en ;
+    samm:characteristic :TransportMxCharacteristic .
+
+:regionRu a samm:Property ;
+    samm:preferredName "Region Ru"@en ;
+    samm:description "This region is formed by countries having a customs union, as this gives the strongest indication of future alignment of (existing and new) legislation."@en ;
+    samm:characteristic :RegulationsRuCharacteristic .
+
+:regionTr a samm:Property ;
+    samm:preferredName "Region Tr"@en ;
+    samm:characteristic :RegionTrCharacteristic .
+
+:regionUs a samm:Property ;
+    samm:preferredName "Region Us"@en ;
+    samm:characteristic :RegionUsCharacteristic .
+
+:regionUsDisposalConsiderationsUs a samm:Property ;
+    samm:preferredName "Region Us"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DisposalConsiderationsUsCharacteristic .
+
+:regionUsRegulationsUs a samm:Property ;
+    samm:preferredName "Region Us"@en ;
+    samm:characteristic :RegulationsUsCharacteristic .
+
+:regionUsSdsSupplierInfo a samm:Property ;
+    samm:preferredName "Region Us"@en ;
+    samm:characteristic :SdsSupplierInfoCharacteristic .
+
+:regionUsTransportUs a samm:Property ;
+    samm:preferredName "Region Us"@en ;
+    samm:characteristic :TransportUsCharacteristic .
+
+:registrationNoAccordingToBiozidMeldeverordnung a samm:Property ;
+    samm:preferredName "Registration No According To Biozid Meldeverordnung"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:regulationsRelatedToCountryOrRegion a samm:Property ;
+    samm:preferredName "Regulations Related To Country Or Region"@en ;
+    samm:description "Regulatory information related to country or region: What country the information applies to, stated as a code in accordance to ISO 3166 (two letters). This defines which SDSs can be derived from this file. (A SDS may be written in English, and the information given may be in accordance to Norwegian regulations)."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :RegulationsRelatedToCountryOrRegionList .
+
+:regulationsRelatedToCountryOrRegionCode a samm:Property ;
+    samm:preferredName "Regulations Related To Country Or Region Code"@en ;
+    samm:description "Enumeration with defined code set."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :CountryCodeEnumCharacteristic .
+
+:regulationsRelatedToCountryOrRegionName a samm:Property ;
+    samm:preferredName "Regulations Related To Country Or Region Name"@en ;
+    samm:description "String with actual country name. Possible to print. Automatic translation possible if a PhraseId is also given."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:regulatoryInformation a samm:Property ;
+    samm:preferredName "Regulatory Information"@en ;
+    samm:description "Regulatory information: This section shall describe regulatory information on the chemical that is not already provided in the safety data sheet (such as whether the substance or mixture is subject to Regulation (EC) No 2037/2000 of the European Parliament and of the Council of 29 June 2000 on substances that deplete the ozone layer, Regulation (EC) No 850/2004 of the European Parliament and of the Council of 29 April 2004 on persistent organic pollutants and amending Directive 79/117/EEC or Regulation (EC) No 689/2008 of the European Parliament and of the Council of 17 June 2008 concerning the export and import of dangerous chemicals)."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :RegulatoryInformationCharacteristic .
+
+:relatedDocuments a samm:Property ;
+    samm:preferredName "Related Documents"@en ;
+    samm:description "Reference to further documents related to the SDS e.g. technical bulletin or manual."@en ;
+    samm:characteristic :RelatedDocumentsList .
+
+:relativeDensity a samm:Property ;
+    samm:preferredName "Relative Density"@en ;
+    samm:characteristic :PhysChemValueWithTemperatureList .
+
+:relativeVapourDensity a samm:Property ;
+    samm:preferredName "Relative Vapour Density"@en ;
+    samm:characteristic :RelativeVapourDensityList .
+
+:relevantIdentifiedUse a samm:Property ;
+    samm:preferredName "Relevant Identified Use"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :RelevantIdentifiedUseCharacteristic .
+
+:remark a samm:Property ;
+    samm:preferredName "Remark"@en ;
+    samm:characteristic :PhraseList .
+
+:reproductiveToxicity a samm:Property ;
+    samm:preferredName "Reproductive Toxicity"@en ;
+    samm:description "Can have one instance for each ReproductiveToxicityType"@en ;
+    samm:characteristic :ReproductiveToxicityList .
+
+:reproductiveToxicityHumanExperience a samm:Property ;
+    samm:preferredName "Reproductive Toxicity Human Experience"@en ;
+    samm:characteristic :PhraseList .
+
+:reproductiveToxicityTestResults a samm:Property ;
+    samm:preferredName "Reproductive Toxicity Test Results"@en ;
+    samm:characteristic :CmrDataList .
+
+:reproductiveToxicityType a samm:Property ;
+    samm:preferredName "Reproductive Toxicity Type"@en ;
+    samm:characteristic :ReproductiveToxicityTypeCharacteristic .
+
+:requiredClinicalTesting a samm:Property ;
+    samm:preferredName "Required Clinical Testing"@en ;
+    samm:description "Required clinical testing: Information on the need of clinical testing."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:requiredMedicalMonitoring a samm:Property ;
+    samm:preferredName "Required Medical Monitoring"@en ;
+    samm:description "Required medical monitoring: Information on"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:requiredProperties a samm:Property ;
+    samm:preferredName "Required Properties"@en ;
+    samm:characteristic :PhraseList .
+
+:requirementsForStorageRoomsAndVessels a samm:Property ;
+    samm:preferredName "Requirements For Storage Rooms And Vessels"@en ;
+    samm:description "Requirements for storage rooms and vessels: Specific design for storage rooms or vessels (including retention walls and ventilation), incompatible materials, conditions of storage (temperature and humidity limit/range, light, inert gas, etc.) special electrical equipment and prevention of static electricity."@en ;
+    samm:characteristic :PhraseList .
+
+:respiratoryOrSkinSensitisation a samm:Property ;
+    samm:preferredName "Respiratory Or Skin Sensitisation"@en ;
+    samm:characteristic :RespiratoryOrSkinSensitisationCharacteristic .
+
+:respiratoryOrSkinSensitisationTestResults a samm:Property ;
+    samm:preferredName "Respiratory Or Skin Sensitisation Test Results"@en ;
+    samm:characteristic :RespiratoryOrSkinSensitisationTestResultsList .
+
+:respiratoryProtection a samm:Property ;
+    samm:preferredName "Respiratory Protection"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :RespiratoryProtectionCharacteristic .
+
+:respiratoryProtectionGeneral a samm:Property ;
+    samm:preferredName "Respiratory Protection General"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:respiratoryProtectionNecessaryAt a samm:Property ;
+    samm:preferredName "Respiratory Protection Necessary At"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:respiratorySensitisationHumanExperience a samm:Property ;
+    samm:preferredName "Respiratory Sensitisation Human Experience"@en ;
+    samm:characteristic :PhraseList .
+
+:restriction a samm:Property ;
+    samm:preferredName "Restriction"@en ;
+    samm:description "e.g. \"dust or mist\""@en ;
+    samm:characteristic :PhraseList .
+
+:restrictionsAccordingReach a samm:Property ;
+    samm:preferredName "Restrictions According Reach"@en ;
+    samm:description "Restricted in use according REACH: Restrictions on the chemical according to Annex XVII of REACH"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:restrictionsOfOccupation a samm:Property ;
+    samm:preferredName "Restrictions Of Occupation"@en ;
+    samm:characteristic :PhraseList .
+
+:result a samm:Property ;
+    samm:preferredName "Result"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:resultEvaluation a samm:Property ;
+    samm:preferredName "Result Evaluation"@en ;
+    samm:characteristic :PhraseList .
+
+:resultEvaluationScore a samm:Property ;
+    samm:preferredName "Result Evaluation Score"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:results a samm:Property ;
+    samm:preferredName "Results"@en ;
+    samm:characteristic :PhraseList .
+
+:revisionDate a samm:Property ;
+    samm:preferredName "Revision Date"@en ;
+    samm:description "Date of revision: The date of the last revision of the SDS document. See also EditingDate."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :DateCharacteristic .
+
+:riskManagementMeasures a samm:Property ;
+    samm:preferredName "Risk Management Measures"@en ;
+    samm:characteristic :RiskManagementMeasuresCharacteristic .
+
+:rmmControlBandingApproach a samm:Property ;
+    samm:preferredName "Rmm Control Banding Approach"@en ;
+    samm:characteristic :RmmControlBandingApproachList .
+
+:rmmEnvironment a samm:Property ;
+    samm:preferredName "Rmm Environment"@en ;
+    samm:characteristic :PhraseList .
+
+:rmmPictogram a samm:Property ;
+    samm:preferredName "Rmm Pictogram"@en ;
+    samm:characteristic samm-c:Text .
+
+:rmmWorker a samm:Property ;
+    samm:preferredName "Rmm Worker"@en ;
+    samm:characteristic :PhraseList .
+
+:role a samm:Property ;
+    samm:preferredName "Role"@en ;
+    samm:description "Description of role: To describe an actor’s role."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :RoleCharacteristic .
+
+:roleCode a samm:Property ;
+    samm:preferredName "Role Code"@en ;
+    samm:description "Description of role: To describe an actor’s role. Accepted values: Responsible company, National responsible, Manufacturer, Importer, Only representative, Reimporter, Formulator, Distributor, Downstream user, Foreign manufacturer"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :RoleDescriptionEnumCharacteristic .
+
+:roleDescription a samm:Property ;
+    samm:preferredName "Role Description"@en ;
+    samm:description "Role description: Textual description of the role code. To allow language independent description in addition to English based role codes."@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:route a samm:Property ;
+    samm:preferredName "Route"@en ;
+    samm:characteristic :ExposureRouteEnumCharacteristic .
+
+:routeFulltext a samm:Property ;
+    samm:preferredName "Route Fulltext"@en ;
+    samm:characteristic :PhraseList .
+
+:safeHandling a samm:Property ;
+    samm:preferredName "Safe Handling"@en ;
+    samm:characteristic :SafeHandlingCharacteristic .
+
+:safeHandlingOfGasContainers a samm:Property ;
+    samm:preferredName "Safe Handling Of Gas Containers"@en ;
+    samm:description "Safe handling of gas containers: Recommendations and instructions on handling of gas botles and containers to prevent acidents and damages."@en ;
+    samm:characteristic :PhraseList .
+
+:safeUseInfoForMixtures a samm:Property ;
+    samm:preferredName "Safe Use Info For Mixtures"@en ;
+    samm:description "Safe Use Information for Mixture (SUMI)"@en ;
+    samm:characteristic :SumiList .
+
+:safetyCharacteristics a samm:Property ;
+    samm:preferredName "Safety Characteristics"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysicalHazardsSafetyCharacteristicsList .
+
+:safetyParameter a samm:Property ;
+    samm:preferredName "Safety Parameter"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:safetyRelevantInformation a samm:Property ;
+    samm:preferredName "Safety Relevant Information"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SafetyRelevantInformationCharacteristic .
+
+:safetyResult a samm:Property ;
+    samm:preferredName "Safety Result"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueCharacteristic .
+
+:safetySigns a samm:Property ;
+    samm:preferredName "Safety Signs"@en ;
+    samm:description "Normally to be displayed or printed at the top of section 8. In case of using information from components, duplicates should be removed."@en ;
+    samm:characteristic samm-c:Text .
+
+:scaleOfUse a samm:Property ;
+    samm:preferredName "Scale Of Use"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:screeningProcedures a samm:Property ;
+    samm:preferredName "Screening Procedures"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysicalHazardsScreeningProceduresList .
+
+:screeningResult a samm:Property ;
+    samm:preferredName "Screening Result"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueCharacteristic .
+
+:screeningType a samm:Property ;
+    samm:preferredName "Screening Type"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:sdsName a samm:Property ;
+    samm:preferredName "Sds Name"@en ;
+    samm:description "Name of the SDS. Shall be identical with the name on the hazard label and package unless the SDS is a group SDS, in which case the hazard label name must match one of the instances of TradeProductIdentity."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:sdsNotLegallyRequired a samm:Property ;
+    samm:preferredName "Sds Not Legally Required"@en ;
+    samm:description "SDS not legally required: The formal requirements to SDSs do not apply to chemicals that legally do not require such documents. In this field, the reason for no legal requirement for an SDS can be stated."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:sdscomSubset a samm:Property ;
+    samm:preferredName "Sdscom Subset"@en ;
+    samm:description "Reference to the SDScomXML subsets SDScomBau and SDScomChem containing SDSComXML fields. More informaion to SDScomBau and SDScomChem are available at www.sdbtransfer.de"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SdscomSubsetEnumCharacteristic .
+
+:sdscomVersionNo a samm:Property ;
+    samm:preferredName "Sdscom Version No"@en ;
+    samm:description "The version of the eSDScom standard which is applied in the transmission of information. This version number also denotes the minimum version number for eSDScom phrase IDs referenced in the XML file. For backward compatibility, the tag name is still SDScom, although the standard now includes ESCom exposure scenarios and is thus named eSDScom."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SdscomVersionEnumCharacteristic .
+
+:seaHazardClassification2021 a samm:Property ;
+    samm:preferredName "Sea Hazard Classification2021"@en ;
+    samm:description "The chemical’s individual hazard classifications according to SEA (2021), which adopted EU regulation 1272/2008 as modified by ATP 12."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SeaHazardClassification2021Characteristic .
+
+:seaHazardLabelling2021 a samm:Property ;
+    samm:preferredName "Sea Hazard Labelling2021"@en ;
+    samm:description "Labelling according to EU regulation 1272/2008, revised until and including EU regulation 2019/521, based on GHS revision 7. THE TRANSITION PERIOD OF ATP 14 ENDED 09 SEPTEMBER 2021, SO ATP 12 IS NO LONGER APPLICABLE. ALL PRODUCTS MUST NOW BE CLASSIFIED (OR THEIR CLASSIFICATION CONFIRMED) ACCORDING TO THIS OR A NEWER REGULATION."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SeaHazardLabelling2021Characteristic .
+
+:secondaryUses a samm:Property ;
+    samm:preferredName "Secondary Uses"@en ;
+    samm:characteristic :EupcsCategoryList .
+
+:sectorOfUse a samm:Property ;
+    samm:preferredName "Sector Of Use"@en ;
+    samm:description "Sector of use (SU):"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SectorOfUseList .
+
+:sectorSumiCode a samm:Property ;
+    samm:preferredName "Sector Sumi Code"@en ;
+    samm:description "Leave empty if the Sumi is not published by a chemical sector association and part of Use Map activities (no company specific SUMI codes here!). First word should be the sector name, e.g. AISE or FEICA, followed by the sector's SUMI code."@en ;
+    samm:characteristic samm-c:Text .
+
+:sedimentToxicity a samm:Property ;
+    samm:preferredName "Sediment Toxicity"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :EcotoxicityList .
+
+:selfheatingSubstancesAndMixtures a samm:Property ;
+    samm:preferredName "Selfheating Substances And Mixtures"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SelfheatingSubstancesAndMixturesCharacteristic .
+
+:selfreactiveSubstancesAndMixtures a samm:Property ;
+    samm:preferredName "Selfreactive Substances And Mixtures"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SelfreactiveSubstancesAndMixturesCharacteristic .
+
+:seveso a samm:Property ;
+    samm:preferredName "Seveso"@en ;
+    samm:characteristic :SevesoEuCharacteristic .
+
+:shipType a samm:Property ;
+    samm:preferredName "Ship Type"@en ;
+    samm:characteristic :PhraseList .
+
+:sicCode a samm:Property ;
+    samm:preferredName "Sic Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:signalWord a samm:Property ;
+    samm:preferredName "Signal Word"@en ;
+    samm:description "Signal word: A word that indicates the relative level of severity of hazards to alert the reader to a potential hazard."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :GhsSignalWordCharacteristic .
+
+:sinterTemperature a samm:Property ;
+    samm:preferredName "Sinter Temperature"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:skinBodyOtherProtection a samm:Property ;
+    samm:preferredName "Skin Body Other Protection"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:skinCorrosionAcidicOrAlkalineReserve a samm:Property ;
+    samm:preferredName "Skin Corrosion Acidic Or Alkaline Reserve"@en ;
+    samm:characteristic :SkinCorrosionAcidicOrAlkalineReserveCharacteristic .
+
+:skinCorrosionAcidicReserve a samm:Property ;
+    samm:preferredName "Skin Corrosion Acidic Reserve"@en ;
+    samm:description "Acidic reserve: Buffer capacity for mixtures with extreme pH values - expressed for instance as g NaOH/100 g product"@en ;
+    samm:characteristic :PhraseList .
+
+:skinCorrosionAlkalineReserve a samm:Property ;
+    samm:preferredName "Skin Corrosion Alkaline Reserve"@en ;
+    samm:description "Alkaline reserve: Buffer capacity for mixtures with extreme pH values - expressed for instance as g H2SO4/100 g product"@en ;
+    samm:characteristic :PhraseList .
+
+:skinCorrosionIrritation a samm:Property ;
+    samm:preferredName "Skin Corrosion Irritation"@en ;
+    samm:characteristic :SkinCorrosionIrritationCharacteristic .
+
+:skinCorrosionIrritationHumanExperience a samm:Property ;
+    samm:preferredName "Skin Corrosion Irritation Human Experience"@en ;
+    samm:characteristic :PhraseList .
+
+:skinCorrosionIrritationTestResults a samm:Property ;
+    samm:preferredName "Skin Corrosion Irritation Test Results"@en ;
+    samm:characteristic :CorrosionIrritationDataList .
+
+:skinHandProtectionLongTermContact a samm:Property ;
+    samm:preferredName "Skin Hand Protection Long Term Contact"@en ;
+    samm:characteristic :PhraseList .
+
+:skinHandProtectionShortTermContact a samm:Property ;
+    samm:preferredName "Skin Hand Protection Short Term Contact"@en ;
+    samm:characteristic :PhraseList .
+
+:skinProtection a samm:Property ;
+    samm:preferredName "Skin Protection"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SkinProtectionCharacteristic .
+
+:skinSensitisationHumanExperience a samm:Property ;
+    samm:preferredName "Skin Sensitisation Human Experience"@en ;
+    samm:characteristic :PhraseList .
+
+:softeningPoint a samm:Property ;
+    samm:preferredName "Softening Point"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:soilMicroorganismsToxicity a samm:Property ;
+    samm:preferredName "Soil Microorganisms Toxicity"@en ;
+    samm:characteristic :EcotoxicityList .
+
+:solidContent a samm:Property ;
+    samm:preferredName "Solid Content"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:solidificationPoint a samm:Property ;
+    samm:preferredName "Solidification Point"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:solubilities a samm:Property ;
+    samm:preferredName "Solubilities"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SolubilitiesList .
+
+:solubility a samm:Property ;
+    samm:preferredName "Solubility"@en ;
+    samm:description "should be 0..1 only (unbounded is deprecated / on the list for refactoring)."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SolubilityList .
+
+:solubilityDescription a samm:Property ;
+    samm:preferredName "Solubility Description"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:solutionExtractionBehaviourOfPolymersInWater a samm:Property ;
+    samm:preferredName "Solution Extraction Behaviour Of Polymers In Water"@en ;
+    samm:characteristic :SolutionExtractionBehaviourOfPolymersInWaterList .
+
+:solventSeparationTest a samm:Property ;
+    samm:preferredName "Solvent Separation Test"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:source a samm:Property ;
+    samm:preferredName "Source"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:sourcesOfSupply a samm:Property ;
+    samm:preferredName "Sources Of Supply"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:specialPrecautionUser a samm:Property ;
+    samm:preferredName "Special Precaution User"@en ;
+    samm:characteristic :PhraseList .
+
+:specialProtectiveEquipmentForFirefighters a samm:Property ;
+    samm:preferredName "Special Protective Equipment For Firefighters"@en ;
+    samm:characteristic :PhraseList .
+
+:specialProvisions a samm:Property ;
+    samm:preferredName "Special Provisions"@en ;
+    samm:characteristic samm-c:Text .
+
+:specialRulesOnPackaging a samm:Property ;
+    samm:preferredName "Special Rules On Packaging"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:specialSupplementalLabelInfoMixtures a samm:Property ;
+    samm:preferredName "Special Supplemental Label Info Mixtures"@en ;
+    samm:description "Special supplemental labelling information: Labelling requirements according to REACH Annex XVII."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :Atp12SpecialSupplementalLabelInfoList .
+
+:speciesPhrase a samm:Property ;
+    samm:preferredName "Species"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:speciesSpecies a samm:Property ;
+    samm:preferredName "Species"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SpeciesCharacteristic .
+
+:specificAntidotes a samm:Property ;
+    samm:preferredName "Specific Antidotes"@en ;
+    samm:description "Specific antidotes: Information on"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:specificConcLimit a samm:Property ;
+    samm:preferredName "Specific Conc Limit"@en ;
+    samm:description "As provided by a harmonized classification or the supplier for dilutions of the substance/product. There is not just one SCL per hazard class, so this cannot be bound to such classes."@en ;
+    samm:characteristic :SpecificConcLimitList .
+
+:specificEffect a samm:Property ;
+    samm:preferredName "Specific Effect"@en ;
+    samm:characteristic :PhraseList .
+
+:specificEndUses a samm:Property ;
+    samm:preferredName "Specific End Uses"@en ;
+    samm:description "For substances and mixtures designed for specific end use(s), recommendations shall relate to the identified use(s) and be detailed and operational. If industry or sector specific guidance is available, detailed reference to it (including source and issuing date) may be made."@en ;
+    samm:characteristic :SpecificEndUsesCharacteristic .
+
+:specificEnvironmentalReleaseCategory a samm:Property ;
+    samm:preferredName "Specific Environmental Release Category"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SpecificEnvironmentalReleaseCategoryList .
+
+:specificFirstAidEquipment a samm:Property ;
+    samm:preferredName "Specific First Aid Equipment"@en ;
+    samm:description "Specific first aid equipment: Information about specific equipment that must be available at the work place for instantaneous specific treatment in case of an accident."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:specificHygieneMeasures a samm:Property ;
+    samm:preferredName "Specific Hygiene Measures"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:specificTargetOrganRe a samm:Property ;
+    samm:preferredName "Specific Target Organ Re"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SpecificTargetOrganReCharacteristic .
+
+:specificTargetOrganReHumanExperience a samm:Property ;
+    samm:preferredName "Specific Target Organ Re Human Experience"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:specificTargetOrganReTestResults a samm:Property ;
+    samm:preferredName "Specific Target Organ Re Test Results"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :StotDataList .
+
+:specificTargetOrganSe a samm:Property ;
+    samm:preferredName "Specific Target Organ Se"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SpecificTargetOrganSeCharacteristic .
+
+:specificTargetOrganSe3 a samm:Property ;
+    samm:preferredName "Specific Target Organ Se3"@en ;
+    samm:description "separate from SpecificTargetOrganSE3 because classified independently STOT SE data in section 11 does not cover the data on narcotic effects (H336) and irritation to the respriratory tract (H335) which is correctly represented in the classification structure. STOT-SE Category 3 includes only respiratory tract irritation (sore throat, cough) and narcotic effects (dizziness, drowsiness)."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SpecificTargetOrganSe3Characteristic .
+
+:specificTargetOrganSeHumanExperience a samm:Property ;
+    samm:preferredName "Specific Target Organ Se Human Experience"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:specificTargetOrganSeTestResults a samm:Property ;
+    samm:preferredName "Specific Target Organ Se Test Results"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :StotDataList .
+
+:specificationNo a samm:Property ;
+    samm:preferredName "Specification No"@en ;
+    samm:description "Sender-defined identification of a specification the chemical is in accordance with, e.g. a formulation number. This is not meant for compliance statements like international or vendor-internal standards!"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:spercCode a samm:Property ;
+    samm:preferredName "Sperc Code"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:spercFulltext a samm:Property ;
+    samm:preferredName "Sperc Fulltext"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:srt2015HazardClassification a samm:Property ;
+    samm:preferredName "Srt2015Hazard Classification"@en ;
+    samm:description "according to GHS revision 5"@en ;
+    samm:characteristic :Srt2015HazardClassificationCharacteristic .
+
+:srt2015HazardLabelling a samm:Property ;
+    samm:preferredName "Srt2015Hazard Labelling"@en ;
+    samm:description "according to GHS revision 5"@en ;
+    samm:characteristic :Srt2015HazardLabellingCharacteristic .
+
+:stabilityDescription a samm:Property ;
+    samm:preferredName "Stability Description"@en ;
+    samm:description "Stability description: The stability of the substance or preparation and the possibility of hazardous reactions occurring. Specify the need of stabilizer, the possibility of hazardous reaction (e.g. exothermic reaction), safety significance of a possible change in physical characteristics of the chemical, etc."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:stabilityReactivity a samm:Property ;
+    samm:preferredName "Stability Reactivity"@en ;
+    samm:description "Stability and reactivity: The section shall describe the stability of the chemical and the possibility of hazardous reactions occurring under certain conditions of use, also if released into the environment. Where appropriate, include a reference to the test methods used. If a particular property does not apply or if information is not available, the reasons shall be given."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :StabilityReactivityCharacteristic .
+
+:state a samm:Property ;
+    samm:preferredName "State"@en ;
+    samm:description "Physical state (only solid/liquid/gaseous) under standard conditions (20°C, 1013 hpa)"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :StateUnderStandardConditionsEnumCharacteristic .
+
+:stateFulltext a samm:Property ;
+    samm:preferredName "State Fulltext"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:stateUnderStandardConditions a samm:Property ;
+    samm:preferredName "State Under Standard Conditions"@en ;
+    samm:characteristic :StateUnderStandardConditionsCharacteristic .
+
+:stoerfallverordnung a samm:Property ;
+    samm:preferredName "Stoerfallverordnung"@en ;
+    samm:characteristic :SevesoDeCharacteristic .
+
+:storageAirHumidity a samm:Property ;
+    samm:preferredName "Storage Air Humidity"@en ;
+    samm:characteristic :PhysChemUnitValueCharacteristic .
+
+:storageClassCh a samm:Property ;
+    samm:preferredName "Storage Class Ch"@en ;
+    samm:description "Classification of the chemical in accordance with Swiss guidance on storage. See https://www.kvu.ch/de/arbeitsgruppen?id=151"@en ;
+    samm:characteristic :StorageClassEnumChCharacteristic .
+
+:storageClassDe a samm:Property ;
+    samm:preferredName "Storage Class De"@en ;
+    samm:description "German storage class: Classification of the chemical in accordance with German regulation."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :StorageClassEnumDeCharacteristic .
+
+:storagePrecautions a samm:Property ;
+    samm:preferredName "Storage Precautions"@en ;
+    samm:description "Storage precautions: Advice on specific storage requirements. How to manage possible risks associated with explosive atmospheres, corrosive conditions, flammability hazards, incompatible chemicals, evaporative conditions, and potential ignition sources. Advices may, if relevant, include ventilation requirements, specific designs for storage rooms or vessels, and quantity limits under storage conditions."@en ;
+    samm:characteristic :PhraseList .
+
+:storagePressure a samm:Property ;
+    samm:preferredName "Storage Pressure"@en ;
+    samm:characteristic :PhysChemUnitValueCharacteristic .
+
+:storageStability a samm:Property ;
+    samm:preferredName "Storage Stability"@en ;
+    samm:description "Information on the use of stabilisers or antioxidants that are required to maintain the integrity of the chemical"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :StorageStabilityList .
+
+:storageTemperature a samm:Property ;
+    samm:preferredName "Storage Temperature"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueCharacteristic .
+
+:suCode a samm:Property ;
+    samm:preferredName "Su Code"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SectorOfUseCodeEnumCharacteristic .
+
+:suFulltext a samm:Property ;
+    samm:preferredName "Su Fulltext"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:sublimationPoint a samm:Property ;
+    samm:preferredName "Sublimation Point"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:subrisk a samm:Property ;
+    samm:preferredName "Subrisk"@en ;
+    samm:characteristic :TransportClassEnumCharacteristic .
+
+:subsidiaryRisk a samm:Property ;
+    samm:preferredName "Subsidiary Risk"@en ;
+    samm:characteristic :TransportClassEnumCharacteristic .
+
+:substanceIdentifiers a samm:Property ;
+    samm:preferredName "Substance Identifiers"@en ;
+    samm:description "for single-constituent (chemically pure) Substances."@en ;
+    samm:characteristic :SubstanceIdentifiersCharacteristic .
+
+:substancesWhichInContactWithWaterEmitFlammableGases a samm:Property ;
+    samm:preferredName "Substances Which In Contact With Water Emit Flammable Gases"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SubstancesWhichInContactWithWaterEmitFlammableGasesCharacteristic .
+
+:suitableEyeProtection a samm:Property ;
+    samm:preferredName "Suitable Eye Protection"@en ;
+    samm:characteristic :PhraseList .
+
+:suitableGlovesType a samm:Property ;
+    samm:preferredName "Suitable Gloves Type"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:suitableMaterial a samm:Property ;
+    samm:preferredName "Suitable Material"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:suitableProtectiveClothing a samm:Property ;
+    samm:preferredName "Suitable Protective Clothing"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:suitableRespiratoryProtectionEquipment a samm:Property ;
+    samm:preferredName "Suitable Respiratory Protection Equipment"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:sumiReference a samm:Property ;
+    samm:preferredName "Sumi Reference"@en ;
+    samm:characteristic :SumiReferenceCharacteristic .
+
+:summaryRmMeasures a samm:Property ;
+    samm:preferredName "Summary Rm Measures"@en ;
+    samm:characteristic :SummaryRmMeasuresCharacteristic .
+
+:summaryRmMeasuresEnvironm a samm:Property ;
+    samm:preferredName "Summary Rm Measures Environm"@en ;
+    samm:characteristic :PhraseList .
+
+:summaryRmMeasuresMan a samm:Property ;
+    samm:preferredName "Summary Rm Measures Man"@en ;
+    samm:characteristic :PhraseList .
+
+:supplementalHazard a samm:Property ;
+    samm:preferredName "Supplemental Hazard"@en ;
+    samm:characteristic :Atp12SupplementalHazardInformationEnumCharacteristic .
+
+:supplementalHazardInformation a samm:Property ;
+    samm:preferredName "Supplemental Hazard Information"@en ;
+    samm:description "Supplemental Hazards are treated in CLP as labelling elements, but in fact are assessed like other classifications. For mixtures, supplemental hazards of ingredients need to be known to determine supplemental hazards of the mixture. Thus, systems can duplicate the information available as labelling here. See also https://github.com/esdscom/sdscom-xml/issues/229"@en ;
+    samm:characteristic :SupplementalHazardInformationList .
+
+:supplierInformation a samm:Property ;
+    samm:preferredName "Supplier Information"@en ;
+    samm:description "Supplier information: Contact information etc. on relevant actors in the supply chain."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :SupplierInformationList .
+
+:surfaceTension a samm:Property ;
+    samm:preferredName "Surface Tension"@en ;
+    samm:characteristic :SurfaceTensionList .
+
+:swedReference a samm:Property ;
+    samm:preferredName "Swed Reference"@en ;
+    samm:description "Reference to the Sector-specific Worker Exposure Description as named in the sector's Use Map."@en ;
+    samm:characteristic :PhraseList .
+
+:symptomsAndEffectsGeneral a samm:Property ;
+    samm:preferredName "Symptoms And Effects General"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:symptomsOfExposure a samm:Property ;
+    samm:preferredName "Symptoms Of Exposure"@en ;
+    samm:characteristic :SymptomsOfExposureCharacteristic .
+
+:systemUsedInPreparation a samm:Property ;
+    samm:preferredName "System Used In Preparation"@en ;
+    samm:description "Software applied in preparation of information: State which system the information has been exported from. The actual version number of the system applied or any other identifier that helps to understand the export scope or method should also be stated."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:taLuft a samm:Property ;
+    samm:preferredName "Ta Luft"@en ;
+    samm:characteristic :TaLuftList .
+
+:tactileWarning a samm:Property ;
+    samm:preferredName "Tactile Warning"@en ;
+    samm:description "Tactile Warning: To inform if packaging must be supplied with tactile warning if the chemical is supplied to the gerneral public"@en ;
+    samm:characteristic samm-c:Boolean .
+
+:targetGroup a samm:Property ;
+    samm:preferredName "Target Group"@en ;
+    samm:description "Describes any combination of industrial/professional/consumer in a way compatible e.g. to CLP article 45 poison center notification format."@en ;
+    samm:characteristic :TargetGroupCharacteristic .
+
+:task a samm:Property ;
+    samm:preferredName "Task"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:tasksNeedingRespiratoryProtection a samm:Property ;
+    samm:preferredName "Tasks Needing Respiratory Protection"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:technicalMeasures a samm:Property ;
+    samm:preferredName "Technical Measures"@en ;
+    samm:characteristic :PhraseList .
+
+:technicalMeasuresAndStorageConditions a samm:Property ;
+    samm:preferredName "Technical Measures And Storage Conditions"@en ;
+    samm:description "Technical measures and storage conditions: Conditions required for safe storage of the chemical."@en ;
+    samm:characteristic :PhraseList .
+
+:technicalSigns a samm:Property ;
+    samm:preferredName "Technical Signs"@en ;
+    samm:characteristic samm-c:Text .
+
+:terrestrialToxicity a samm:Property ;
+    samm:preferredName "Terrestrial Toxicity"@en ;
+    samm:characteristic :TerrestrialToxicityCharacteristic .
+
+:testDate a samm:Property ;
+    samm:preferredName "Test Date"@en ;
+    samm:characteristic :DateCharacteristic .
+
+:testDuration a samm:Property ;
+    samm:preferredName "Test Duration"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:testMaterial a samm:Property ;
+    samm:preferredName "Test Material"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:testMethod a samm:Property ;
+    samm:preferredName "Test Method"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:testPerformed a samm:Property ;
+    samm:preferredName "Test Performed"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :TestPerformedList .
+
+:testReference a samm:Property ;
+    samm:preferredName "Test Reference"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:testResult a samm:Property ;
+    samm:preferredName "Test Result"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueCharacteristic .
+
+:testResults a samm:Property ;
+    samm:preferredName "Test Results"@en ;
+    samm:characteristic :PhraseList .
+
+:text a samm:Property ;
+    samm:preferredName "Text"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:theoreticalCarbonDioxideAmount a samm:Property ;
+    samm:preferredName "Theoretical Carbon Dioxide Amount"@en ;
+    samm:description "a.k.a. ThCO2"@en ;
+    samm:characteristic :FurtherEcologicalDataList .
+
+:theoreticalOxygenDemand a samm:Property ;
+    samm:preferredName "Theoretical Oxygen Demand"@en ;
+    samm:description "a.k.a. ThOD"@en ;
+    samm:characteristic :FurtherEcologicalDataList .
+
+:thermalHazardsProtection a samm:Property ;
+    samm:preferredName "Thermal Hazards Protection"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:thicknessOfGloveMaterial a samm:Property ;
+    samm:preferredName "Thickness Of Glove Material"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:title a samm:Property ;
+    samm:preferredName "Title"@en ;
+    samm:characteristic :PhraseList .
+
+:totalOrganicCarbon a samm:Property ;
+    samm:preferredName "Total Organic Carbon"@en ;
+    samm:description "a.k.a. TOC"@en ;
+    samm:characteristic :FurtherEcologicalDataList .
+
+:toxicokineticInfo a samm:Property ;
+    samm:preferredName "Toxicokinetic Info"@en ;
+    samm:characteristic :ToxicokineticInfoCharacteristic .
+
+:toxicologicalInformationToxicologicalInformation a samm:Property ;
+    samm:preferredName "Toxicological Information"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ToxicologicalInformationCharacteristic .
+
+:tradeName a samm:Property ;
+    samm:preferredName "Trade Name"@en ;
+    samm:description "for Mixtures"@en ;
+    samm:characteristic samm-c:Text .
+
+:tradeProductIdentity a samm:Property ;
+    samm:preferredName "Trade Product Identity"@en ;
+    samm:description "At least one instance (with empty UserId) for the identification as delivered by the supplier. Use more instances for various package sizes, various products in a group SDS, or (with filled UserId) for reference to relabelled products of the SDS recipient. Also for group safety data sheets, each instance of TradeProductIdentity covers one substance or product. When importing, make sure that SDScom documents are not automatically replaced if the product identity is the same! GTINs are not necessarily unique (they should, but aren't in practice!), and product identities may refer to kits with multiple products and SDSs. Unique IDs that allow automatic overriding of data require a bilateral agreement between customer and supplier and should be placed in ProductNo."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :TradeProductIdentityList .
+
+:transportInBulk a samm:Property ;
+    samm:preferredName "Transport In Bulk"@en ;
+    samm:characteristic :TransportInBulkCharacteristic .
+
+:transportInformation a samm:Property ;
+    samm:preferredName "Transport Information"@en ;
+    samm:description "Transport information: This section shall provide basic classification information for transporting/shipment of chemicals mentioned under Section 1 by road, rail, sea, inland waterways or air. Where information is not available or relevant this shall be stated."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :TransportInformationCharacteristic .
+
+:transportType a samm:Property ;
+    samm:preferredName "Transport Type"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:type a samm:Property ;
+    samm:preferredName "Type"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :TypeList .
+
+:typeDescription a samm:Property ;
+    samm:preferredName "Type Description"@en ;
+    samm:description "Specify viscosity type if type above is Other, or full text of the type in printable form."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:typeDoseEnum a samm:Property ;
+    samm:preferredName "Type"@en ;
+    samm:characteristic :DoseEnumCharacteristic .
+
+:typeEffectLevelTypeEnum a samm:Property ;
+    samm:preferredName "Type"@en ;
+    samm:characteristic :EffectLevelTypeEnumCharacteristic .
+
+:typeFulltext a samm:Property ;
+    samm:preferredName "Type Fulltext"@en ;
+    samm:characteristic :PhraseList .
+
+:typePnecTypeEnum a samm:Property ;
+    samm:preferredName "Type"@en ;
+    samm:characteristic :PnecTypeEnumCharacteristic .
+
+:typeReproductiveToxicityTypeEnum a samm:Property ;
+    samm:preferredName "Type"@en ;
+    samm:characteristic :ReproductiveToxicityTypeEnumCharacteristic .
+
+:typeViscosityTypeEnum a samm:Property ;
+    samm:preferredName "Type"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ViscosityTypeEnumCharacteristic .
+
+:ucnCode a samm:Property ;
+    samm:preferredName "Ucn Code"@en ;
+    samm:characteristic samm-c:Text .
+
+:ufi a samm:Property ;
+    samm:preferredName "Ufi"@en ;
+    samm:description "Companies are allowed to define multiple UFIs for the same composition, even for the same product. As group safety data sheets are allowed, it should be possible to transmit multiple UFIs although the main intention for multiple UFIs might be to hide the identity of differently named products."@en ;
+    samm:characteristic samm-c:Text .
+
+:unNo a samm:Property ;
+    samm:preferredName "Un No"@en ;
+    samm:description "UN number IMDG:"@en ;
+    samm:characteristic samm-c:Text .
+
+:unit a samm:Property ;
+    samm:preferredName "Unit"@en ;
+    samm:characteristic :UnitEnumCharacteristic .
+
+:unitFulltext a samm:Property ;
+    samm:preferredName "Unit Fulltext"@en ;
+    samm:characteristic :PhraseList .
+
+:unitValue a samm:Property ;
+    samm:preferredName "Unit Value"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:unknownToxicity a samm:Property ;
+    samm:preferredName "Unknown Toxicity"@en ;
+    samm:characteristic :UnknownToxicityCharacteristic .
+
+:unsuitableEyeProtection a samm:Property ;
+    samm:preferredName "Unsuitable Eye Protection"@en ;
+    samm:characteristic :PhraseList .
+
+:unsuitableMaterials a samm:Property ;
+    samm:preferredName "Unsuitable Materials"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:unsuitableProtectiveClothing a samm:Property ;
+    samm:preferredName "Unsuitable Protective Clothing"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:upperExplosionLimit a samm:Property ;
+    samm:preferredName "Upper Explosion Limit"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:upperTierQuantity a samm:Property ;
+    samm:preferredName "Upper Tier Quantity"@en ;
+    samm:characteristic :UpperTierQuantityInlineCharacteristic .
+
+:upperValue a samm:Property ;
+    samm:preferredName "Upper Value"@en ;
+    samm:characteristic :FloatCharacteristic .
+
+:upperValueSymbol a samm:Property ;
+    samm:preferredName "Upper Value Symbol"@en ;
+    samm:characteristic :UpperQualifierEnumCharacteristic .
+
+:url a samm:Property ;
+    samm:preferredName "Url"@en ;
+    samm:description "URL: Web addressof the company contact"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:ResourcePath .
+
+:use a samm:Property ;
+    samm:preferredName "Use"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:useAdvisedAgainst a samm:Property ;
+    samm:preferredName "Use Advised Against"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseList .
+
+:useDescriptors a samm:Property ;
+    samm:preferredName "Use Descriptors"@en ;
+    samm:characteristic :UseDescriptorsCharacteristic .
+
+:userId a samm:Property ;
+    samm:preferredName "User Id"@en ;
+    samm:description "The user (direct or indirect customer of the supplier, recipient of the SDS) that the information in this instance of TradeIdentity is meant for. Leave empty if this instance of TradeProductIdentity refers to the supplier."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:valueFloat a samm:Property ;
+    samm:preferredName "Value"@en ;
+    samm:characteristic :FloatCharacteristic .
+
+:valueNumericRangeWithQualifier a samm:Property ;
+    samm:preferredName "Value"@en ;
+    samm:characteristic :NumericRangeWithQualifierCharacteristic .
+
+:valueNumericRangeWithUnitAndQualifier a samm:Property ;
+    samm:preferredName "Value"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:valuePhrase a samm:Property ;
+    samm:preferredName "Value"@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:valuePhysChemUnitValue a samm:Property ;
+    samm:preferredName "Value"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueCharacteristic .
+
+:valuePhysChemUnitValueWithTemperature a samm:Property ;
+    samm:preferredName "Value"@en ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureCharacteristic .
+
+:valuePhysChemValueWithTemperature a samm:Property ;
+    samm:preferredName "Value"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemValueWithTemperatureCharacteristic .
+
+:vapourPressure a samm:Property ;
+    samm:preferredName "Vapour Pressure"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhysChemUnitValueWithTemperatureList .
+
+:vbfClass a samm:Property ;
+    samm:preferredName "Vbf Class"@en ;
+    samm:characteristic :VbfClassCharacteristic .
+
+:versionNo a samm:Property ;
+    samm:preferredName "Version No"@en ;
+    samm:description "Version No: The current version of the SDS document."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:versionNumber a samm:Property ;
+    samm:preferredName "Version Number"@en ;
+    samm:description "Version number is optional here because SUMI info is part of the eSDS which is versioned, so the version date is expected to be the same and is sufficient to determine a sector SUMI version."@en ;
+    samm:characteristic samm-c:Text .
+
+:viscosity a samm:Property ;
+    samm:preferredName "Viscosity"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :ViscosityList .
+
+:visitingAddressCity a samm:Property ;
+    samm:preferredName "Visiting Address City"@en ;
+    samm:characteristic samm-c:Text .
+
+:visitingAddressLine1 a samm:Property ;
+    samm:preferredName "Visiting Address Line1"@en ;
+    samm:characteristic samm-c:Text .
+
+:visitingAddressLine2 a samm:Property ;
+    samm:preferredName "Visiting Address Line2"@en ;
+    samm:characteristic samm-c:Text .
+
+:visitingAddressLine3 a samm:Property ;
+    samm:preferredName "Visiting Address Line3"@en ;
+    samm:characteristic samm-c:Text .
+
+:visitingAddressPostCode a samm:Property ;
+    samm:preferredName "Visiting Address Post Code"@en ;
+    samm:description "Postal code: Two-letter ISO3166 country code followed by a hyphen and the national postal code."@en ;
+    samm:characteristic samm-c:Text .
+
+:voc a samm:Property ;
+    samm:preferredName "Voc"@en ;
+    samm:description "Restrictions related to the use of volatile organic compounds: Directive 2004/42/EC amending 1999/13/EC. This should be an exact value, not a range. But for reasons of ingredient nondisclosure, some companies decide to provide a range here."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :VocCharacteristic .
+
+:vocInPercentByWeight a samm:Property ;
+    samm:preferredName "Voc In Percent By Weight"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PercentageRangeCharacteristic .
+
+:vocLabelling a samm:Property ;
+    samm:preferredName "Voc Labelling"@en ;
+    samm:description "VOC Labelling: Labelling requirements according to directive 2004/42/EC (amending 1999/13/EC)"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :VocLabellingList .
+
+:vocLimitForSubcategory a samm:Property ;
+    samm:preferredName "Voc Limit For Subcategory"@en ;
+    samm:description "Maximum VOC content limit for the mixture: The maximum concentration of VOC in the actual product. To be given in grams per litre."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericValueWithUnitAndQualifierCharacteristic .
+
+:vocValue a samm:Property ;
+    samm:preferredName "Voc Value"@en ;
+    samm:description "Voc contents: To be usually measured in g/L"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:wasteCodePhrase a samm:Property ;
+    samm:preferredName "Waste Code"@en ;
+    samm:description "National waste code: National identification number for the chemical and or its packaging as waste, with a corresponding description of the waste covered by the actual number."@en ;
+    samm:characteristic :PhraseCharacteristic .
+
+:wasteCodeWasteCode a samm:Property ;
+    samm:preferredName "Waste Code"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic samm-c:Text .
+
+:wasteDescription a samm:Property ;
+    samm:preferredName "Waste Description"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:characteristic :PhraseCharacteristic .
+
+:wasteRegulations a samm:Property ;
+    samm:preferredName "Waste Regulations"@en ;
+    samm:description "National waste regulations: National regulations related to waste that applies to the product or its packing."@en ;
+    samm:characteristic :PhraseList .
+
+:wasteTreatment a samm:Property ;
+    samm:preferredName "Waste Treatment"@en ;
+    samm:description "Waste treatment: Specify the appropriate methods of disposal of both the chemical and any contaminated packaging. The actual use of the chemical will often influence the classification of the waste. Waste treatment containers and methods shall be specified including the appropriate methods of waste treatment of both the chemical and any contaminated packaging (e.g. incineration, recycling, landfilling). Physical or chemical properties that may affect waste treatment options shall be specified. Sewage disposal shall be discouraged. Where appropriate, any special precautions for any recommended waste treatment option shall be identified."@en ;
+    samm:characteristic :WasteTreatmentCharacteristic .
+
+:waterHazardClass a samm:Property ;
+    samm:preferredName "Water Hazard Class"@en ;
+    samm:characteristic :WaterHazardClassCharacteristic .
+
+:waterReactive a samm:Property ;
+    samm:preferredName "Water Reactive"@en ;
+    samm:characteristic :PhraseList .
+
+:weightAverageMolecularWeight a samm:Property ;
+    samm:preferredName "Weight Average Molecular Weight"@en ;
+    samm:characteristic :PhysChemUnitValueList .
+
+:weightFraction a samm:Property ;
+    samm:preferredName "Weight Fraction"@en ;
+    samm:characteristic :NumericRangeWithUnitAndQualifierCharacteristic .
+
+:whmis2015HazardClassification a samm:Property ;
+    samm:preferredName "Whmis2015Hazard Classification"@en ;
+    samm:characteristic :Whmis2015HazardClassificationCharacteristic .
+
+# ──────────────────────────────────────────────────────────────────────────
+# Characteristics
+# ──────────────────────────────────────────────────────────────────────────
+
+:AbntNrb2015HazardClassificationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Abnt Nrb2015Hazard Classification Characteristic"@en ;
+    samm:dataType :AbntNrb2015HazardClassification .
+
+:AbntNrb2017HazardLabellingCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Abnt Nrb2017Hazard Labelling Characteristic"@en ;
+    samm:dataType :AbntNrb2017HazardLabelling .
+
+:AbntNrb2019HazardClassificationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Abnt Nrb2019Hazard Classification Characteristic"@en ;
+    samm:dataType :AbntNrb2019HazardClassification .
+
+:AccidentalReleaseMeasuresCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Accidental Release Measures Characteristic"@en ;
+    samm:dataType :AccidentalReleaseMeasures .
+
+:AcuteToxicityCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Acute Toxicity Characteristic"@en ;
+    samm:dataType :AcuteToxicity .
+
+:AdditionalEcotoxInformationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Additional Ecotox Information Characteristic"@en ;
+    samm:dataType :AdditionalEcotoxInformation .
+
+:AddressCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Address Characteristic"@en ;
+    samm:dataType :Address .
+
+:AdnCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Adn Characteristic"@en ;
+    samm:dataType :Adn .
+
+:AdrRidCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Adr Rid Characteristic"@en ;
+    samm:dataType :AdrRid .
+
+:AnnexesEuCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Annexes Eu Characteristic"@en ;
+    samm:dataType :AnnexesEu .
+
+:AppearanceCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Appearance Characteristic"@en ;
+    samm:dataType :Appearance .
+
+:AppropriateEnvionmentalExposureControlCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Appropriate Envionmental Exposure Control Characteristic"@en ;
+    samm:dataType :AppropriateEnvionmentalExposureControl .
+
+:AquaticToxicityCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Aquatic Toxicity Characteristic"@en ;
+    samm:dataType :AquaticToxicity .
+
+:ArticleCategoryCodeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Article Category Code Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "AC1" "AC2" "AC3" "AC4" "AC5" "AC6" "AC7" "AC8" "AC10" "AC11" "AC13" "AC30" "AC31" "AC32" "AC33" "AC34" "AC35" "AC36" "AC38" "AC0" ) .
+
+:ArticleCategoryList a samm-c:List ;
+    samm:preferredName "Article Category List"@en ;
+    samm:dataType :ArticleCategory .
+
+:AspirationHazardCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Aspiration Hazard Characteristic"@en ;
+    samm:dataType :AspirationHazard .
+
+:AssessmentCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Assessment Characteristic"@en ;
+    samm:dataType :Assessment .
+
+:AssessmentEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Assessment Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "Yes" "No" "Not assessed" ) .
+
+:AteCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Ate Characteristic"@en ;
+    samm:dataType :Ate .
+
+:AteValueCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Ate Value Characteristic"@en ;
+    samm:dataType :AteValue .
+
+:Atp12SpecialSupplementalLabelInfoEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Atp12Special Supplemental Label Info Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "201" "201A" "202" "203" "204" "205" "206" "207" "208" "209" "209A" "210" "401" ) .
+
+:Atp12SpecialSupplementalLabelInfoList a samm-c:List ;
+    samm:preferredName "Atp12Special Supplemental Label Info List"@en ;
+    samm:dataType :Atp12SpecialSupplementalLabelInfo .
+
+:Atp12SupplementalHazardInformationEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Atp12Supplemental Hazard Information Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "006" "014" "018" "019" "044" "029" "031" "032" "066" "070" "071" "059" ) .
+
+:BioaccumulationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Bioaccumulation Characteristic"@en ;
+    samm:dataType :Bioaccumulation .
+
+:BiocidesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Biocides Characteristic"@en ;
+    samm:dataType :Biocides .
+
+:BioconcentrationFactorList a samm-c:List ;
+    samm:preferredName "Bioconcentration Factor List"@en ;
+    samm:dataType :BioconcentrationFactor .
+
+:BiologicalDegradationList a samm-c:List ;
+    samm:preferredName "Biological Degradation List"@en ;
+    samm:dataType :BiologicalDegradation .
+
+:BiologicalLimitValueList a samm-c:List ;
+    samm:preferredName "Biological Limit Value List"@en ;
+    samm:dataType :BiologicalLimitValue .
+
+:BiologicalLimitValuesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Biological Limit Values Characteristic"@en ;
+    samm:dataType :BiologicalLimitValues .
+
+:BoilingPointRelatedCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Boiling Point Related Characteristic"@en ;
+    samm:dataType :BoilingPointRelated .
+
+:CaliforniaCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "California Characteristic"@en ;
+    samm:dataType :California .
+
+:CarcinogenicityCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Carcinogenicity Characteristic"@en ;
+    samm:dataType :Carcinogenicity .
+
+:CertainFluorinatedGreenhouseGasesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Certain Fluorinated Greenhouse Gases Characteristic"@en ;
+    samm:dataType :CertainFluorinatedGreenhouseGases .
+
+:ChemicalSafetyAssessmentInfoCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Chemical Safety Assessment Info Characteristic"@en ;
+    samm:dataType :ChemicalSafetyAssessmentInfo .
+
+:ChemicalSafetyReportCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Chemical Safety Report Characteristic"@en ;
+    samm:dataType :ChemicalSafetyReport .
+
+:ClassificationArCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Classification Ar Characteristic"@en ;
+    samm:dataType :ClassificationAr .
+
+:ClassificationAssessmentCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Classification Assessment Characteristic"@en ;
+    samm:dataType :ClassificationAssessment .
+
+:ClassificationBrCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Classification Br Characteristic"@en ;
+    samm:dataType :ClassificationBr .
+
+:ClassificationCaCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Classification Ca Characteristic"@en ;
+    samm:dataType :ClassificationCa .
+
+:ClassificationGbCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Classification Gb Characteristic"@en ;
+    samm:dataType :ClassificationGb .
+
+:ClassificationList a samm-c:List ;
+    samm:preferredName "Classification List"@en ;
+    samm:dataType :Classification .
+
+:ClassificationMxCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Classification Mx Characteristic"@en ;
+    samm:dataType :ClassificationMx .
+
+:ClassificationTrCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Classification Tr Characteristic"@en ;
+    samm:dataType :ClassificationTr .
+
+:ClassificationUsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Classification Us Characteristic"@en ;
+    samm:dataType :ClassificationUs .
+
+:CmrDataList a samm-c:List ;
+    samm:preferredName "Cmr Data List"@en ;
+    samm:dataType :CmrData .
+
+:ColourEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Colour Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "colourless" "black" "blue" "brown" "gold" "green" "grey" "orange" "pink" "purple" "red" "silver" "violet" "white" "yellow" "multicolour" "colouring agent" ) .
+
+:ColourIntensityEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Colour Intensity Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "translucent" "light" "dark" "fluorescent" ) .
+
+:CompanyContactList a samm-c:List ;
+    samm:preferredName "Company Contact List"@en ;
+    samm:dataType :CompanyContact .
+
+:CompleteSdsWithEsIncorporatedCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Complete Sds With Es Incorporated Characteristic"@en ;
+    samm:dataType :CompleteSdsWithEsIncorporated .
+
+:CompositionCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Composition Characteristic"@en ;
+    samm:dataType :Composition .
+
+:ConditionsForSafeStorageCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Conditions For Safe Storage Characteristic"@en ;
+    samm:dataType :ConditionsForSafeStorage .
+
+:ConsumerExposureControlCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Consumer Exposure Control Characteristic"@en ;
+    samm:dataType :ConsumerExposureControl .
+
+:ContainmentAndCleaningUpCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Containment And Cleaning Up Characteristic"@en ;
+    samm:dataType :ContainmentAndCleaningUp .
+
+:ControlParametersCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Control Parameters Characteristic"@en ;
+    samm:dataType :ControlParameters .
+
+:ControlParametersEuCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Control Parameters Eu Characteristic"@en ;
+    samm:dataType :ControlParametersEu .
+
+:CorrespondingExposureScenarioList a samm-c:List ;
+    samm:preferredName "Corresponding Exposure Scenario List"@en ;
+    samm:dataType :CorrespondingExposureScenario .
+
+:CorrosionIrritationDataList a samm-c:List ;
+    samm:preferredName "Corrosion Irritation Data List"@en ;
+    samm:dataType :CorrosionIrritationData .
+
+:CorrosiveToMetalsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Corrosive To Metals Characteristic"@en ;
+    samm:dataType :CorrosiveToMetals .
+
+:CountryCodeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Country Code Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "AD" "AE" "AF" "AG" "AI" "AL" "AM" "AO" "AQ" "AR" "AS" "AT" "AU" "AW" "AX" "AZ" "BA" "BB" "BD" "BE" "BF" "BG" "BH" "BI" "BJ" "BL" "BM" "BN" "BO" "BQ" "BR" "BS" "BT" "BV" "BW" "BY" "BZ" "CA" "CC" "CD" "CF" "CG" "CH" "CI" "CK" "CL" "CM" "CN" "CO" "CR" "CU" "CV" "CW" "CX" "CY" "CZ" "DE" "DJ" "DK" "DM" "DO" "DZ" "EC" "EE" "EG" "EH" "ER" "ES" "ET" "FI" "FJ" "FK" "FM" "FO" "FR" "GA" "GB" "GD" "GE" "GF" "GG" "GH" "GI" "GL" "GM" "GN" "GP" "GQ" "GR" "GS" "GT" "GU" "GW" "GY" "HK" "HM" "HN" "HR" "HT" "HU" "ID" "IE" "IL" "IM" "IN" "IO" "IQ" "IR" "IS" "IT" "JE" "JM" "JO" "JP" "KE" "KG" "KH" "KI" "KM" "KN" "KP" "KR" "KW" "KY" "KZ" "LA" "LB" "LC" "LI" "LK" "LR" "LS" "LT" "LU" "LV" "LY" "MA" "MC" "MD" "ME" "MF" "MG" "MH" "MK" "ML" "MM" "MN" "MO" "MP" "MQ" "MR" "MS" "MT" "MU" "MV" "MW" "MX" "MY" "MZ" "NA" "NC" "NE" "NF" "NG" "NI" "NL" "NO" "NP" "NR" "NU" "NZ" "OM" "PA" "PE" "PF" "PG" "PH" "PK" "PL" "PM" "PN" "PR" "PS" "PT" "PW" "PY" "QA" "RE" "RO" "RS" "RU" "RW" "SA" "SB" "SC" "SD" "SE" "SG" "SH" "SI" "SJ" "SK" "SL" "SM" "SN" "SO" "SR" "SS" "ST" "SV" "SX" "SY" "SZ" "TC" "TD" "TF" "TG" "TH" "TJ" "TK" "TL" "TM" "TN" "TO" "TR" "TT" "TV" "TW" "TZ" "UA" "UG" "UM" "US" "UY" "UZ" "VA" "VC" "VE" "VG" "VI" "VN" "VU" "WF" "WS" "YE" "YT" "ZA" "ZM" "ZW" ) .
+
+:DatasheetList a samm-c:List ;
+    samm:preferredName "Datasheet List"@en ;
+    samm:dataType :Datasheet .
+
+:DateCharacteristic a samm:Characteristic ;
+    samm:preferredName "Date Characteristic"@en ;
+    samm:dataType xsd:date .
+
+:DegradationEliminationList a samm-c:List ;
+    samm:preferredName "Degradation Elimination List"@en ;
+    samm:dataType :DegradationElimination .
+
+:DensitiesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Densities Characteristic"@en ;
+    samm:dataType :Densities .
+
+:DescriptionOfFirstAidMeasuresCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Description Of First Aid Measures Characteristic"@en ;
+    samm:dataType :DescriptionOfFirstAidMeasures .
+
+:DetergentsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Detergents Characteristic"@en ;
+    samm:dataType :Detergents .
+
+:DisposalConsiderationsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Disposal Considerations Characteristic"@en ;
+    samm:dataType :DisposalConsiderations .
+
+:DisposalConsiderationsEuCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Disposal Considerations Eu Characteristic"@en ;
+    samm:dataType :DisposalConsiderationsEu .
+
+:DisposalConsiderationsUsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Disposal Considerations Us Characteristic"@en ;
+    samm:dataType :DisposalConsiderationsUs .
+
+:DissociationConstantList a samm-c:List ;
+    samm:preferredName "Dissociation Constant List"@en ;
+    samm:dataType :DissociationConstant .
+
+:DmelList a samm-c:List ;
+    samm:preferredName "Dmel List"@en ;
+    samm:dataType :Dmel .
+
+:DnelList a samm-c:List ;
+    samm:preferredName "Dnel List"@en ;
+    samm:dataType :Dnel .
+
+:DoseCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Dose Characteristic"@en ;
+    samm:dataType :Dose .
+
+:DoseEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Dose Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "NOEC" "LOEC" "NOEL" "LOEL" "NOAEL" "LOAEL" "LC0" "LCLo" "LC50" "LC100" "LD0" "LDLo" "LD50" "LD100" "EC0" "EC3" "EC10" "EC20" "EC25" "EC50" "EC50 (+ UVA)" "EC50 (- UVA)" "EC80" "ATEmix" "cATpE" "ERC50" "ERCLo" "IC50" "other" ) .
+
+:EcologicalInformationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Ecological Information Characteristic"@en ;
+    samm:dataType :EcologicalInformation .
+
+:EcotoxicityAquaticList a samm-c:List ;
+    samm:preferredName "Ecotoxicity Aquatic List"@en ;
+    samm:dataType :EcotoxicityAquatic .
+
+:EcotoxicityList a samm-c:List ;
+    samm:preferredName "Ecotoxicity List"@en ;
+    samm:dataType :Ecotoxicity .
+
+:EcotoxicologicalInformationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Ecotoxicological Information Characteristic"@en ;
+    samm:dataType :EcotoxicologicalInformation .
+
+:EffectLevelGroupEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Effect Level Group Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "Worker" "Consumer" ) .
+
+:EffectLevelTypeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Effect Level Type Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "Acute oral (systemic)" "Long-term oral (systemic)" "Acute dermal (local)" "Acute dermal (systemic)" "Long-term dermal (local)" "Long-term dermal (systemic)" "Acute inhalation (local)" "Acute inhalation (systemic)" "Long-term inhalation (local)" "Long-term inhalation (systemic)" ) .
+
+:EmergencyPhoneList a samm-c:List ;
+    samm:preferredName "Emergency Phone List"@en ;
+    samm:dataType :EmergencyPhone .
+
+:EnvironmentalExposureControlsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Environmental Exposure Controls Characteristic"@en ;
+    samm:dataType :EnvironmentalExposureControls .
+
+:EnvironmentalReleaseCategoryCodeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Environmental Release Category Code Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "ERC1" "ERC2" "ERC3" "ERC4" "ERC5" "ERC6a" "ERC6b" "ERC6c" "ERC6d" "ERC7" "ERC8a" "ERC8b" "ERC8c" "ERC8d" "ERC8e" "ERC8f" "ERC9a" "ERC9b" "ERC10a" "ERC10b" "ERC11a" "ERC11b" "ERC12a" "ERC12b" ) .
+
+:EnvironmentalReleaseCategoryList a samm-c:List ;
+    samm:preferredName "Environmental Release Category List"@en ;
+    samm:dataType :EnvironmentalReleaseCategory .
+
+:EquipmentList a samm-c:List ;
+    samm:preferredName "Equipment List"@en ;
+    samm:dataType :Equipment .
+
+:EsdscomPhraseCatalogueIdCharacteristic a samm:Characteristic ;
+    samm:preferredName "Esdscom Phrase Catalogue Id Characteristic"@en ;
+    samm:dataType xsd:integer .
+
+:EsdscomPhraseIdCharacteristic a samm:Characteristic ;
+    samm:preferredName "Esdscom Phrase Id Characteristic"@en ;
+    samm:dataType xsd:integer .
+
+:EuLegislationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Eu Legislation Characteristic"@en ;
+    samm:dataType :EuLegislation .
+
+:EupcsCategoryCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Eupcs Category Characteristic"@en ;
+    samm:dataType :EupcsCategory .
+
+:EupcsCategoryCodeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Eupcs Category Code Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "F" "PC-ADH-1" "PC-ADH-2" "PC-ADH-3" "PC-ADH-4" "PC-ADH-5" "PC-ADH-6" "PC-ADH-7" "PC-ADH-8" "PC-ADH-OTH" "PC-AIR-1" "PC-AIR-2" "PC-AIR-3" "PC-AIR-4" "PC-AIR-5" "PC-AIR-6" "PC-AIR-7" "PC-AIR-8" "PC-AIR-OTH" "PC-ANI-1" "PC-ANI-2" "PC-ANI-OTH" "PC-ART-1" "PC-ART-2" "PC-ART-3" "PC-ART-4" "PC-ART-5" "PC-ART-6" "PC-ART-OTH" "PC-CLN-1" "PC-CLN-2" "PC-CLN-3" "PC-CLN-4" "PC-CLN-5" "PC-CLN-6" "PC-CLN-7" "PC-CLN-8" "PC-CLN-9" "PC-CLN-10.1" "PC-CLN-10.2" "PC-CLN-10.3" "PC-CLN-10.4" "PC-CLN-10.OTH" "PC-CLN-11.1" "PC-CLN-11.2" "PC-CLN-11.3" "PC-CLN-11.OTH" "PC-CLN-12.1" "PC-CLN-12.2" "PC-CLN-12.3" "PC-CLN-12.OTH" "PC-CLN-13.2" "PC-CLN-13.3" "PC-CLN-13.4" "PC-CLN-13.OTH" "PC-CLN-14.1" "PC-CLN-14.2" "PC-CLN-14.OTH" "PC-CLN-15.1" "PC-CLN-15.2" "PC-CLN-15.3" "PC-CLN-15.4" "PC-CLN-15.OTH" "PC-CLN-16.1" "PC-CLN-16.2" "PC-CLN-16.3" "PC-CLN-16.4" "PC-CLN-16.5" "PC-CLN-16.6" "PC-CLN-16.OTH" "PC-CLN-17.1" "PC-CLN-17.2" "PC-CLN-17.3" "PC-CLN-17.4" "PC-CLN-17.5" "PC-CLN-17.6" "PC-CLN-17.7" "PC-CLN-17.8" "PC-CLN-17.OTH" "PC-CLN-OTH" "PC-COL-1" "PC-COL-2" "PC-CON-1" "PC-CON-2" "PC-CON-3" "PC-CON-4" "PC-CON-5" "PC-CON-OTH" "PC-DET-1.1" "PC-DET-1.2" "PC-DET-1.3" "PC-DET-1.OTH" "PC-DET-2.1" "PC-DET-2.2" "PC-DET-2.3" "PC-DET-2.4" "PC-DET-2.5" "PC-DET-2.6" "PC-DET-2.7" "PC-DET-2.8" "PC-DET-2.OTH" "PC-DET-3.1" "PC-DET-3.2" "PC-DET-3.3" "PC-DET-3.OTH" "PC-DET-4.1" "PC-DET-4.2" "PC-DET-4.3" "PC-DET-4.4" "PC-DET-4.OTH" "PC-ELQ" "PC-FER-1" "PC-FER-2" "PC-FER-3" "PC-FER-4" "PC-FER-5" "PC-FER-6" "PC-FER-7" "PC-FUE-1" "PC-FUE-2" "PC-FUE-3" "PC-FUE-4" "PC-FUE-5" "PC-FUE-OTH" "PC-INK-1" "PC-INK-2" "PC-INK-3" "PC-INK-4" "PC-INK-5" "PC-INK-OTH" "PC-PNT-1" "PC-PNT-2" "PC-PNT-3" "PC-PNT-4" "PC-PNT-5" "PC-PNT-6" "PC-PNT-7" "PC-PNT-OTH" "PC-PYR-1" "PC-PYR-2" "PC-PYR-3" "PC-PYR-4" "PC-PYR-OTH" "PC-TAT" "PC-TEC-1" "PC-TEC-2" "PC-TEC-3" "PC-TEC-4" "PC-TEC-5" "PC-TEC-6" "PC-TEC-7" "PC-TEC-8" "PC-TEC-9" "PC-TEC-10" "PC-TEC-11" "PC-TEC-12" "PC-TEC-13" "PC-TEC-14" "PC-TEC-15" "PC-TEC-16" "PC-TEC-17" "PC-TEC-18" "PC-TEC-19" "PC-TEC-20" "PC-TEC-21" "PC-TEC-22" "PC-TEC-23" "PC-TEC-24" "PC-TEC-OTH" "PC-UNC" "PP-BIO-1" "PP-BIO-2" "PP-BIO-3" "PP-BIO-4" "PP-BIO-5" "PP-BIO-6" "PP-BIO-7" "PP-BIO-8" "PP-BIO-9" "PP-BIO-10" "PP-BIO-11" "PP-BIO-12" "PP-BIO-13" "PP-BIO-14" "PP-BIO-15" "PP-BIO-16" "PP-BIO-17" "PP-BIO-18" "PP-BIO-19" "PP-BIO-20" "PP-BIO-21" "PP-BIO-22" "PP-PRD-1" "PP-PRD-2" "PP-PRD-3" "PP-PRD-4" "PP-PRD-5" "PP-PRD-6" "PP-PRD-7" "PP-PRD-8" "PP-PRD-9" "PP-PRD-10" "PP-PRD-11" "PP-PRD-12" "PP-PRD-13" "PP-PRD-14" "PP-PRD-15" "PP-PRD-16" "PP-PRD-OTH" ) .
+
+:EupcsCategoryList a samm-c:List ;
+    samm:preferredName "Eupcs Category List"@en ;
+    samm:dataType :EupcsCategory .
+
+:EuropeanWasteListCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "European Waste List Characteristic"@en ;
+    samm:dataType :EuropeanWasteList .
+
+:ExactQualifierEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Exact Qualifier Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "eq" "ca" ) .
+
+:ExplosionLimitCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Explosion Limit Characteristic"@en ;
+    samm:dataType :ExplosionLimit .
+
+:ExplosivesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Explosives Characteristic"@en ;
+    samm:dataType :Explosives .
+
+:ExposureControlAppropriateMeasuresCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Exposure Control Appropriate Measures Characteristic"@en ;
+    samm:dataType :ExposureControlAppropriateMeasures .
+
+:ExposureControlPersonalProtectionCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Exposure Control Personal Protection Characteristic"@en ;
+    samm:dataType :ExposureControlPersonalProtection .
+
+:ExposureGroupCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Exposure Group Characteristic"@en ;
+    samm:dataType :ExposureGroup .
+
+:ExposureLimitFractionEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Exposure Limit Fraction Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "inhalable" "respirable" ) .
+
+:ExposureLimitValueTypeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Exposure Limit Value Type Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "AGW" "VLA" "MAC" "WEL" "OEL" "TWA" "STEL" "VLE" "AK" "PK" "MK" "PEL" "MAK" "NDS" "NDSCH" "NDSP" "GV" "NGV" "TGV" "KTV" "AN" "ADN" "HTP" ) .
+
+:ExposureRouteCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Exposure Route Characteristic"@en ;
+    samm:dataType :ExposureRoute .
+
+:ExposureRouteEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Exposure Route Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "Inhalation" "Oral" "Dermal" "Inhalation(Gas)" "Inhalation(Vapour)" "Inhalation(Dust/Mist)" "Subcutane" "Intraperitonial" "Intravenal" "Intraarterial" "Unreported" ) .
+
+:ExposureRouteFrequencyAndEffectCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Exposure Route Frequency And Effect Characteristic"@en ;
+    samm:dataType :ExposureRouteFrequencyAndEffect .
+
+:ExposureScenarioCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Exposure Scenario Characteristic"@en ;
+    samm:dataType :ExposureScenario .
+
+:ExtinguishingMediaCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Extinguishing Media Characteristic"@en ;
+    samm:dataType :ExtinguishingMedia .
+
+:EyeDamageOrIrritationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Eye Damage Or Irritation Characteristic"@en ;
+    samm:dataType :EyeDamageOrIrritation .
+
+:EyeProtectionCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Eye Protection Characteristic"@en ;
+    samm:dataType :EyeProtection .
+
+:FederalCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Federal Characteristic"@en ;
+    samm:dataType :Federal .
+
+:FireFightingMeasuresCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Fire Fighting Measures Characteristic"@en ;
+    samm:dataType :FireFightingMeasures .
+
+:FirstAidMeasuresCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "First Aid Measures Characteristic"@en ;
+    samm:dataType :FirstAidMeasures .
+
+:FlammableAerosolsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Flammable Aerosols Characteristic"@en ;
+    samm:dataType :FlammableAerosols .
+
+:FlammableGasesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Flammable Gases Characteristic"@en ;
+    samm:dataType :FlammableGases .
+
+:FlammableLiquidsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Flammable Liquids Characteristic"@en ;
+    samm:dataType :FlammableLiquids .
+
+:FlammableSolidsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Flammable Solids Characteristic"@en ;
+    samm:dataType :FlammableSolids .
+
+:FlashPointList a samm-c:List ;
+    samm:preferredName "Flash Point List"@en ;
+    samm:dataType :FlashPoint .
+
+:FloatCharacteristic a samm:Characteristic ;
+    samm:preferredName "Float Characteristic"@en ;
+    samm:dataType xsd:float .
+
+:ForNonEmergencyPersonnelCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "For Non Emergency Personnel Characteristic"@en ;
+    samm:dataType :ForNonEmergencyPersonnel .
+
+:FormEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Form Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "aerosol dispenser: not specified" "aerosol dispenser: foam aerosol" "aerosol dispenser: spray aerosol" "gas" "gas: vapour" "gas under pressure: compressed gas" "gas under pressure: dissolved gas" "gas under pressure: liquefied gas" "gas under pressure: refrigerated liquefied gas" "cream / paste" "foam" "gel" "liquid" "liquid: viscous" "liquid: volatile" "liquid - liquid: emulsion" "liquid - solid: mixture of" "semi-solid (amorphous): gel" "solid" "solid: bulk" "solid: compact" "solid: crystalline" "solid: fibres" "solid: filaments" "solid: flakes" "solid: granular" "solid: particulate/powder" "solid: pellets" "solid: pressed powder" "solid: nanomaterial, surface-treated" "solid: nanomaterial, no surface treatment" "solid: nanomaterial" "solid: tabs / tablets" "solid - liquid: aqueous solution" "solid - liquid: suspension" "solid - solid: alloy" "other" ) .
+
+:FurtherEcologicalDataList a samm-c:List ;
+    samm:preferredName "Further Ecological Data List"@en ;
+    samm:dataType :FurtherEcologicalData .
+
+:GasGroupEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Gas Group Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "IIA" "IIB" "IIC" ) .
+
+:GasGroupList a samm-c:List ;
+    samm:preferredName "Gas Group List"@en ;
+    samm:dataType :GasGroup .
+
+:GasesUnderPressureCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Gases Under Pressure Characteristic"@en ;
+    samm:dataType :GasesUnderPressure .
+
+:GbClpHazardClassification2020Characteristic a samm-c:SingleEntity ;
+    samm:preferredName "Gb Clp Hazard Classification2020Characteristic"@en ;
+    samm:dataType :GbClpHazardClassification2020 .
+
+:GbClpHazardLabelling2020Characteristic a samm-c:SingleEntity ;
+    samm:preferredName "Gb Clp Hazard Labelling2020Characteristic"@en ;
+    samm:dataType :GbClpHazardLabelling2020 .
+
+:GeneralDescriptionCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "General Description Characteristic"@en ;
+    samm:dataType :GeneralDescription .
+
+:GermCellMutagenicityCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Germ Cell Mutagenicity Characteristic"@en ;
+    samm:dataType :GermCellMutagenicity .
+
+:Ghs03HazardStatementUsList a samm-c:List ;
+    samm:preferredName "Ghs03Hazard Statement Us List"@en ;
+    samm:dataType :Ghs03HazardStatementUs .
+
+:Ghs03PrecautionaryStatementList a samm-c:List ;
+    samm:preferredName "Ghs03Precautionary Statement List"@en ;
+    samm:dataType :Ghs03PrecautionaryStatement .
+
+:Ghs05HazardStatementList a samm-c:List ;
+    samm:preferredName "Ghs05Hazard Statement List"@en ;
+    samm:dataType :Ghs05HazardStatement .
+
+:Ghs05PrecautionaryStatementList a samm-c:List ;
+    samm:preferredName "Ghs05Precautionary Statement List"@en ;
+    samm:dataType :Ghs05PrecautionaryStatement .
+
+:Ghs07HazardStatementList a samm-c:List ;
+    samm:preferredName "Ghs07Hazard Statement List"@en ;
+    samm:dataType :Ghs07HazardStatement .
+
+:Ghs07PrecautionaryStatementList a samm-c:List ;
+    samm:preferredName "Ghs07Precautionary Statement List"@en ;
+    samm:dataType :Ghs07PrecautionaryStatement .
+
+:GhsPictogramCodeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Ghs Pictogram Code Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "GHS01" "GHS02" "GHS03" "GHS04" "GHS05" "GHS06" "GHS07" "GHS08" "GHS09" ) .
+
+:GhsSignalWordCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Ghs Signal Word Characteristic"@en ;
+    samm:dataType :GhsSignalWord .
+
+:GhsSignalWordEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Ghs Signal Word Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "DGR" "WNG" ) .
+
+:GoodPracticeAdviceCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Good Practice Advice Characteristic"@en ;
+    samm:dataType :GoodPracticeAdvice .
+
+:HandProtectionCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Hand Protection Characteristic"@en ;
+    samm:dataType :HandProtection .
+
+:HandlingAndStorageCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Handling And Storage Characteristic"@en ;
+    samm:dataType :HandlingAndStorage .
+
+:HazardIdentificationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Hazard Identification Characteristic"@en ;
+    samm:dataType :HazardIdentification .
+
+:HazardLabellingArCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Hazard Labelling Ar Characteristic"@en ;
+    samm:dataType :HazardLabellingAr .
+
+:HazardLabellingBrCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Hazard Labelling Br Characteristic"@en ;
+    samm:dataType :HazardLabellingBr .
+
+:HazardLabellingCaCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Hazard Labelling Ca Characteristic"@en ;
+    samm:dataType :HazardLabellingCa .
+
+:HazardLabellingGbCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Hazard Labelling Gb Characteristic"@en ;
+    samm:dataType :HazardLabellingGb .
+
+:HazardLabellingMxCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Hazard Labelling Mx Characteristic"@en ;
+    samm:dataType :HazardLabellingMx .
+
+:HazardLabellingTrCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Hazard Labelling Tr Characteristic"@en ;
+    samm:dataType :HazardLabellingTr .
+
+:HazardLabellingUsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Hazard Labelling Us Characteristic"@en ;
+    samm:dataType :HazardLabellingUs .
+
+:Hazcom2012HazardClassificationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Hazcom2012Hazard Classification Characteristic"@en ;
+    samm:dataType :Hazcom2012HazardClassification .
+
+:Hazcom2012HazardLabellingCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Hazcom2012Hazard Labelling Characteristic"@en ;
+    samm:dataType :Hazcom2012HazardLabelling .
+
+:HumanExperienceCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Human Experience Characteristic"@en ;
+    samm:dataType :HumanExperience .
+
+:HydrolysisRateList a samm-c:List ;
+    samm:preferredName "Hydrolysis Rate List"@en ;
+    samm:dataType :HydrolysisRate .
+
+:IataDgrCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Iata Dgr Characteristic"@en ;
+    samm:dataType :IataDgr .
+
+:IdentificationSubstPrepCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Identification Subst Prep Characteristic"@en ;
+    samm:dataType :IdentificationSubstPrep .
+
+:IdentifiedUseList a samm-c:List ;
+    samm:preferredName "Identified Use List"@en ;
+    samm:dataType :IdentifiedUse .
+
+:ImdgCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Imdg Characteristic"@en ;
+    samm:dataType :Imdg .
+
+:IndustrialEmissionsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Industrial Emissions Characteristic"@en ;
+    samm:dataType :IndustrialEmissions .
+
+:InformationFromExportingSystemCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Information From Exporting System Characteristic"@en ;
+    samm:dataType :InformationFromExportingSystem .
+
+:InformationToHealthProfessionalsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Information To Health Professionals Characteristic"@en ;
+    samm:dataType :InformationToHealthProfessionals .
+
+:IntegerCharacteristic a samm:Characteristic ;
+    samm:preferredName "Integer Characteristic"@en ;
+    samm:dataType xsd:integer .
+
+:InvestigationMethodCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Investigation Method Characteristic"@en ;
+    samm:dataType :InvestigationMethod .
+
+:InvestigationMethodEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Investigation Method Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "in-vivo" "in-vitro" ) .
+
+:LabellingAccordingToOtherLegislationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Labelling According To Other Legislation Characteristic"@en ;
+    samm:dataType :LabellingAccordingToOtherLegislation .
+
+:LanguageCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Language Characteristic"@en ;
+    samm:dataType :Language .
+
+:LanguageCodeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Language Code Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "aa" "ab" "ae" "af" "ak" "am" "an" "ar" "as" "av" "ay" "az" "ba" "be" "bg" "bh" "bi" "bm" "bn" "bo" "br" "bs" "ca" "ce" "ch" "co" "cr" "cs" "cu" "cv" "cy" "da" "de" "dv" "dz" "ee" "el" "en" "eo" "es" "et" "eu" "fa" "ff" "fi" "fj" "fo" "fr" "fy" "ga" "gd" "gl" "gn" "gu" "gv" "ha" "he" "hi" "ho" "hr" "ht" "hu" "hy" "hz" "ia" "id" "ie" "ig" "ii" "ik" "io" "is" "it" "iu" "ja" "jv" "ka" "kg" "ki" "kj" "kk" "kl" "km" "kn" "ko" "kr" "ks" "ku" "kv" "kw" "ky" "la" "lb" "lg" "li" "ln" "lo" "lt" "lu" "lv" "mg" "mh" "mi" "mk" "ml" "mn" "mr" "ms" "mt" "my" "na" "nb" "nd" "ne" "ng" "nl" "nn" "no" "nr" "nv" "ny" "oc" "oj" "om" "or" "os" "pa" "pi" "pl" "ps" "pt" "qu" "rm" "rn" "ro" "ru" "rw" "sa" "sc" "sd" "se" "sg" "si" "sk" "sl" "sm" "sn" "so" "sq" "sr" "ss" "st" "su" "sv" "sw" "ta" "te" "tg" "th" "ti" "tk" "tl" "tn" "to" "tr" "ts" "tt" "tw" "ty" "ug" "uk" "ur" "uz" "ve" "vi" "vo" "wa" "wo" "xh" "yi" "yo" "za" "zh" "zu" ) .
+
+:LegalDocumentCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Legal Document Characteristic"@en ;
+    samm:dataType :LegalDocument .
+
+:LowerQualifierEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Lower Qualifier Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "gt" "ge" ) .
+
+:LowerTierQuantityInlineCharacteristic a samm:Characteristic ;
+    samm:preferredName "Lower Tier Quantity Inline Characteristic"@en ;
+    samm:dataType xsd:integer .
+
+:MajorAccidentsOrdinanceCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Major Accidents Ordinance Characteristic"@en ;
+    samm:dataType :MajorAccidentsOrdinance .
+
+:MedicalAttentionAndSpecialTreatmentNeededCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Medical Attention And Special Treatment Needed Characteristic"@en ;
+    samm:dataType :MedicalAttentionAndSpecialTreatmentNeeded .
+
+:MeltingPointRelatedCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Melting Point Related Characteristic"@en ;
+    samm:dataType :MeltingPointRelated .
+
+:MergePhraseList a samm-c:List ;
+    samm:preferredName "Merge Phrase List"@en ;
+    samm:dataType :MergePhrase .
+
+:MobilityList a samm-c:List ;
+    samm:preferredName "Mobility List"@en ;
+    samm:dataType :Mobility .
+
+:MultiplyingFactorCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Multiplying Factor Characteristic"@en ;
+    samm:dataType :MultiplyingFactor .
+
+:NationalLegislationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "National Legislation Characteristic"@en ;
+    samm:dataType :NationalLegislation .
+
+:NationalWasteLegislationChCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "National Waste Legislation Ch Characteristic"@en ;
+    samm:dataType :NationalWasteLegislationCh .
+
+:NationalWasteLegislationDeList a samm-c:List ;
+    samm:preferredName "National Waste Legislation De List"@en ;
+    samm:dataType :NationalWasteLegislationDe .
+
+:NationalWasteLegislationNoList a samm-c:List ;
+    samm:preferredName "National Waste Legislation No List"@en ;
+    samm:dataType :NationalWasteLegislationNo .
+
+:Nom2015HazardClassificationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Nom2015Hazard Classification Characteristic"@en ;
+    samm:dataType :Nom2015HazardClassification .
+
+:Nom2015HazardLabellingCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Nom2015Hazard Labelling Characteristic"@en ;
+    samm:dataType :Nom2015HazardLabelling .
+
+:NonHumanToxicologicalDataList a samm-c:List ;
+    samm:preferredName "Non Human Toxicological Data List"@en ;
+    samm:dataType :NonHumanToxicologicalData .
+
+:NumericRangeWithQualifierCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Numeric Range With Qualifier Characteristic"@en ;
+    samm:dataType :NumericRangeWithQualifier .
+
+:NumericRangeWithUnitAndQualifierCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Numeric Range With Unit And Qualifier Characteristic"@en ;
+    samm:dataType :NumericRangeWithUnitAndQualifier .
+
+:NumericRangeWithUnitAndQualifierList a samm-c:List ;
+    samm:preferredName "Numeric Range With Unit And Qualifier List"@en ;
+    samm:dataType :NumericRangeWithUnitAndQualifier .
+
+:NumericValueCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Numeric Value Characteristic"@en ;
+    samm:dataType :NumericValue .
+
+:NumericValueWithUnitAndQualifierCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Numeric Value With Unit And Qualifier Characteristic"@en ;
+    samm:dataType :NumericValueWithUnitAndQualifier .
+
+:NumericValueWithUnitCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Numeric Value With Unit Characteristic"@en ;
+    samm:dataType :NumericValueWithUnit .
+
+:OccupationalAirRequirementNoCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Occupational Air Requirement No Characteristic"@en ;
+    samm:dataType :OccupationalAirRequirementNo .
+
+:OccupationalExposureLimitList a samm-c:List ;
+    samm:preferredName "Occupational Exposure Limit List"@en ;
+    samm:dataType :OccupationalExposureLimit .
+
+:OccupationalExposureLimitsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Occupational Exposure Limits Characteristic"@en ;
+    samm:dataType :OccupationalExposureLimits .
+
+:OperationalConditionsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Operational Conditions Characteristic"@en ;
+    samm:dataType :OperationalConditions .
+
+:OrganicPeroxidesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Organic Peroxides Characteristic"@en ;
+    samm:dataType :OrganicPeroxides .
+
+:OtherAdverseEffectsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Other Adverse Effects Characteristic"@en ;
+    samm:dataType :OtherAdverseEffects .
+
+:OtherHazardsInfoCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Other Hazards Info Characteristic"@en ;
+    samm:dataType :OtherHazardsInfo .
+
+:OtherInformationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Other Information Characteristic"@en ;
+    samm:dataType :OtherInformation .
+
+:OtherSafetyInformationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Other Safety Information Characteristic"@en ;
+    samm:dataType :OtherSafetyInformation .
+
+:OxidisingGasesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Oxidising Gases Characteristic"@en ;
+    samm:dataType :OxidisingGases .
+
+:OxidisingLiquidsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Oxidising Liquids Characteristic"@en ;
+    samm:dataType :OxidisingLiquids .
+
+:OxidisingSolidsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Oxidising Solids Characteristic"@en ;
+    samm:dataType :OxidisingSolids .
+
+:PackagingCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Packaging Characteristic"@en ;
+    samm:dataType :Packaging .
+
+:PackagingMaterialEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Packaging Material Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "glass" "plastic: HDPE" "plastic: LDPE" "plastic: PET" "plastic: composite" "metal" "paper, cardboard" "other" ) .
+
+:PackagingTypeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Packaging Type Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "aerosol can" "airspray" "atomizer" "bag / sack" "baitbox" "blister" "bottle" "box" "brick" "bucket" "can / tin" "carboy" "case" "dispenser" "dropper" "drum" "envelope" "IBC (intermediate bulk container)" "jar" "jerry can" "jug" "packet" "sachet" "phial" "stick" "syringe" "talcum powder container" "tank" "tea bag (product disperses through the container when added to water)" "tube" "water soluble bag" "other" ) .
+
+:PackingGroupEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Packing Group Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "I" "II" "III" ) .
+
+:ParticleFractionCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Particle Fraction Characteristic"@en ;
+    samm:dataType :ParticleFraction .
+
+:PartitionCoefficientList a samm-c:List ;
+    samm:preferredName "Partition Coefficient List"@en ;
+    samm:dataType :PartitionCoefficient .
+
+:PdsclCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Pdscl Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "deleterious" "poisonous" "special" ) .
+
+:PeakLimitationList a samm-c:List ;
+    samm:preferredName "Peak Limitation List"@en ;
+    samm:dataType :PeakLimitation .
+
+:PercentageCharacteristic a samm:Characteristic ;
+    samm:preferredName "Percentage Characteristic"@en ;
+    samm:dataType xsd:float .
+
+:PercentageRangeCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Percentage Range Characteristic"@en ;
+    samm:dataType :PercentageRange .
+
+:PersistenceDegradabilityCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Persistence Degradability Characteristic"@en ;
+    samm:dataType :PersistenceDegradability .
+
+:PersonalProtectionEquipmentCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Personal Protection Equipment Characteristic"@en ;
+    samm:dataType :PersonalProtectionEquipment .
+
+:PhNotRelevantEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Ph Not Relevant Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "pH is below -3" "pH is above 15" "substance/mixture is a gas" "substance/mixture is non-polar/aprotic" "substance/mixture is non-soluble (in water)" "substance/mixture not stable" "substance/mixture reacts with water" ) .
+
+:PhValueList a samm-c:List ;
+    samm:preferredName "Ph Value List"@en ;
+    samm:dataType :PhValue .
+
+:PhValueStateEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Ph Value State Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "In delivery state" "In aqueous solution" ) .
+
+:PhototoxicityCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Phototoxicity Characteristic"@en ;
+    samm:dataType :Phototoxicity .
+
+:PhototoxicityTestResultsList a samm-c:List ;
+    samm:preferredName "Phototoxicity Test Results List"@en ;
+    samm:dataType :PhototoxicityTestResults .
+
+:PhraseCatalogueList a samm-c:List ;
+    samm:preferredName "Phrase Catalogue List"@en ;
+    samm:dataType :PhraseCatalogue .
+
+:PhraseCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Phrase Characteristic"@en ;
+    samm:dataType :Phrase .
+
+:PhraseList a samm-c:List ;
+    samm:preferredName "Phrase List"@en ;
+    samm:dataType :Phrase .
+
+:PhysChemUnitValueCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Phys Chem Unit Value Characteristic"@en ;
+    samm:dataType :PhysChemUnitValue .
+
+:PhysChemUnitValueList a samm-c:List ;
+    samm:preferredName "Phys Chem Unit Value List"@en ;
+    samm:dataType :PhysChemUnitValue .
+
+:PhysChemUnitValueWithTemperatureCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Phys Chem Unit Value With Temperature Characteristic"@en ;
+    samm:dataType :PhysChemUnitValueWithTemperature .
+
+:PhysChemUnitValueWithTemperatureList a samm-c:List ;
+    samm:preferredName "Phys Chem Unit Value With Temperature List"@en ;
+    samm:dataType :PhysChemUnitValueWithTemperature .
+
+:PhysChemValueList a samm-c:List ;
+    samm:preferredName "Phys Chem Value List"@en ;
+    samm:dataType :PhysChemValue .
+
+:PhysChemValueWithTemperatureCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Phys Chem Value With Temperature Characteristic"@en ;
+    samm:dataType :PhysChemValueWithTemperature .
+
+:PhysChemValueWithTemperatureList a samm-c:List ;
+    samm:preferredName "Phys Chem Value With Temperature List"@en ;
+    samm:dataType :PhysChemValueWithTemperature .
+
+:PhysicalChemicalPropertiesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Physical Chemical Properties Characteristic"@en ;
+    samm:dataType :PhysicalChemicalProperties .
+
+:PhysicalHazardsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Physical Hazards Characteristic"@en ;
+    samm:dataType :PhysicalHazards .
+
+:PhysicalHazardsGeneralInformationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Physical Hazards General Information Characteristic"@en ;
+    samm:dataType :PhysicalHazardsGeneralInformation .
+
+:PhysicalHazardsSafetyCharacteristicsList a samm-c:List ;
+    samm:preferredName "Physical Hazards Safety Characteristics List"@en ;
+    samm:dataType :PhysicalHazardsSafetyCharacteristics .
+
+:PhysicalHazardsScreeningProceduresList a samm-c:List ;
+    samm:preferredName "Physical Hazards Screening Procedures List"@en ;
+    samm:dataType :PhysicalHazardsScreeningProcedures .
+
+:PnecList a samm-c:List ;
+    samm:preferredName "Pnec List"@en ;
+    samm:dataType :Pnec .
+
+:PnecTypeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Pnec Type Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "Soil" "Sediment, marine water" "Sediment, freshwater" "Aquatic, intermittent release" "Aquatic, marine water" "Aquatic, freshwater" "Sewage treatment plant (STP)" "Secondary poisoning" "Air" ) .
+
+:PrProductRegistrationNoList a samm-c:List ;
+    samm:preferredName "Pr Product Registration No List"@en ;
+    samm:dataType :PrProductRegistrationNo .
+
+:PrecautionaryMeasuresCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Precautionary Measures Characteristic"@en ;
+    samm:dataType :PrecautionaryMeasures .
+
+:ProcessCategoryCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Process Category Characteristic"@en ;
+    samm:dataType :ProcessCategory .
+
+:ProcessCategoryCodeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Process Category Code Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "PROC1" "PROC2" "PROC3" "PROC4" "PROC5" "PROC6" "PROC7" "PROC8a" "PROC8b" "PROC9" "PROC10" "PROC11" "PROC12" "PROC13" "PROC14" "PROC15" "PROC16" "PROC17" "PROC18" "PROC19" "PROC20" "PROC21" "PROC22" "PROC23" "PROC24" "PROC25" "PROC26" "PROC27a" "PROC27b" ) .
+
+:ProcessCategoryList a samm-c:List ;
+    samm:preferredName "Process Category List"@en ;
+    samm:dataType :ProcessCategory .
+
+:ProductCategoryCodeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Product Category Code Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "PC1" "PC2" "PC3" "PC4" "PC7" "PC8" "PC9a" "PC9b" "PC9c" "PC11" "PC12" "PC13" "PC14" "PC15" "PC16" "PC17" "PC18" "PC19" "PC20" "PC21" "PC22" "PC23" "PC24" "PC25" "PC26" "PC27" "PC28" "PC29" "PC30" "PC31" "PC32" "PC33" "PC34" "PC35" "PC36" "PC37" "PC38" "PC39" "PC40" "PC0" ) .
+
+:ProductCategoryList a samm-c:List ;
+    samm:preferredName "Product Category List"@en ;
+    samm:dataType :ProductCategory .
+
+:ProductGtinList a samm-c:List ;
+    samm:preferredName "Product Gtin List"@en ;
+    samm:dataType :ProductGtin .
+
+:ProductIdentifiersCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Product Identifiers Characteristic"@en ;
+    samm:dataType :ProductIdentifiers .
+
+:PropertiesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Properties Characteristic"@en ;
+    samm:dataType :Properties .
+
+:ProtectionArticleList a samm-c:List ;
+    samm:preferredName "Protection Article List"@en ;
+    samm:dataType :ProtectionArticle .
+
+:PyrophoricLiquidsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Pyrophoric Liquids Characteristic"@en ;
+    samm:dataType :PyrophoricLiquids .
+
+:PyrophoricSolidsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Pyrophoric Solids Characteristic"@en ;
+    samm:dataType :PyrophoricSolids .
+
+:ReasonForWaivingCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Reason For Waiving Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "cannot be determined" "not applicable" "no data" ) .
+
+:RegionArCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Region Ar Characteristic"@en ;
+    samm:dataType :RegionAr .
+
+:RegionBrCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Region Br Characteristic"@en ;
+    samm:dataType :RegionBr .
+
+:RegionCaCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Region Ca Characteristic"@en ;
+    samm:dataType :RegionCa .
+
+:RegionEuCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Region Eu Characteristic"@en ;
+    samm:dataType :RegionEu .
+
+:RegionGbCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Region Gb Characteristic"@en ;
+    samm:dataType :RegionGb .
+
+:RegionMxCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Region Mx Characteristic"@en ;
+    samm:dataType :RegionMx .
+
+:RegionTrCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Region Tr Characteristic"@en ;
+    samm:dataType :RegionTr .
+
+:RegionUsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Region Us Characteristic"@en ;
+    samm:dataType :RegionUs .
+
+:RegulationsArCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Ar Characteristic"@en ;
+    samm:dataType :RegulationsAr .
+
+:RegulationsAtCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations At Characteristic"@en ;
+    samm:dataType :RegulationsAt .
+
+:RegulationsBrCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Br Characteristic"@en ;
+    samm:dataType :RegulationsBr .
+
+:RegulationsCaCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Ca Characteristic"@en ;
+    samm:dataType :RegulationsCa .
+
+:RegulationsChCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Ch Characteristic"@en ;
+    samm:dataType :RegulationsCh .
+
+:RegulationsDeCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations De Characteristic"@en ;
+    samm:dataType :RegulationsDe .
+
+:RegulationsDkCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Dk Characteristic"@en ;
+    samm:dataType :RegulationsDk .
+
+:RegulationsEuCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Eu Characteristic"@en ;
+    samm:dataType :RegulationsEu .
+
+:RegulationsGbCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Gb Characteristic"@en ;
+    samm:dataType :RegulationsGb .
+
+:RegulationsJpCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Jp Characteristic"@en ;
+    samm:dataType :RegulationsJp .
+
+:RegulationsMxCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Mx Characteristic"@en ;
+    samm:dataType :RegulationsMx .
+
+:RegulationsNoCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations No Characteristic"@en ;
+    samm:dataType :RegulationsNo .
+
+:RegulationsRelatedToCountryOrRegionList a samm-c:List ;
+    samm:preferredName "Regulations Related To Country Or Region List"@en ;
+    samm:dataType :RegulationsRelatedToCountryOrRegion .
+
+:RegulationsRuCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Ru Characteristic"@en ;
+    samm:dataType :RegulationsRu .
+
+:RegulationsTrCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Tr Characteristic"@en ;
+    samm:dataType :RegulationsTr .
+
+:RegulationsUsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulations Us Characteristic"@en ;
+    samm:dataType :RegulationsUs .
+
+:RegulatoryInformationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Regulatory Information Characteristic"@en ;
+    samm:dataType :RegulatoryInformation .
+
+:RelatedDocumentsList a samm-c:List ;
+    samm:preferredName "Related Documents List"@en ;
+    samm:dataType :RelatedDocuments .
+
+:RelativeVapourDensityList a samm-c:List ;
+    samm:preferredName "Relative Vapour Density List"@en ;
+    samm:dataType :RelativeVapourDensity .
+
+:RelevantIdentifiedUseCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Relevant Identified Use Characteristic"@en ;
+    samm:dataType :RelevantIdentifiedUse .
+
+:ReproductiveToxicityList a samm-c:List ;
+    samm:preferredName "Reproductive Toxicity List"@en ;
+    samm:dataType :ReproductiveToxicity .
+
+:ReproductiveToxicityTypeCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Reproductive Toxicity Type Characteristic"@en ;
+    samm:dataType :ReproductiveToxicityType .
+
+:ReproductiveToxicityTypeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Reproductive Toxicity Type Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "sexual function" "developmental" "lactation" ) .
+
+:RespiratoryOrSkinSensitisationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Respiratory Or Skin Sensitisation Characteristic"@en ;
+    samm:dataType :RespiratoryOrSkinSensitisation .
+
+:RespiratoryOrSkinSensitisationTestResultsList a samm-c:List ;
+    samm:preferredName "Respiratory Or Skin Sensitisation Test Results List"@en ;
+    samm:dataType :RespiratoryOrSkinSensitisationTestResults .
+
+:RespiratoryProtectionArticleList a samm-c:List ;
+    samm:preferredName "Respiratory Protection Article List"@en ;
+    samm:dataType :RespiratoryProtectionArticle .
+
+:RespiratoryProtectionCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Respiratory Protection Characteristic"@en ;
+    samm:dataType :RespiratoryProtection .
+
+:ResultsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Results Characteristic"@en ;
+    samm:dataType :Results .
+
+:RiskManagementMeasuresCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Risk Management Measures Characteristic"@en ;
+    samm:dataType :RiskManagementMeasures .
+
+:RmmControlBandingApproachList a samm-c:List ;
+    samm:preferredName "Rmm Control Banding Approach List"@en ;
+    samm:dataType :RmmControlBandingApproach .
+
+:RoleCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Role Characteristic"@en ;
+    samm:dataType :Role .
+
+:RoleDescriptionEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Role Description Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "Responsible company" "National responsible" "Manufacturer" "Importer" "Only representative" "Reimporter" "Formulator" "Distributor" "Downstream user" "Foreign manufacturer" ) .
+
+:SafeHandlingCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Safe Handling Characteristic"@en ;
+    samm:dataType :SafeHandling .
+
+:SafetyRelevantInformationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Safety Relevant Information Characteristic"@en ;
+    samm:dataType :SafetyRelevantInformation .
+
+:SdsSupplierInfoCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Sds Supplier Info Characteristic"@en ;
+    samm:dataType :SdsSupplierInfo .
+
+:SdsSupplierInfoEuCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Sds Supplier Info Eu Characteristic"@en ;
+    samm:dataType :SdsSupplierInfoEu .
+
+:SdscomSubsetEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Sdscom Subset Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "SdsComXml Light" "SDScomBau" "SDScomChem" "full" "other" ) .
+
+:SdscomVersionEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Sdscom Version Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "5.6" ) .
+
+:SeaHazardClassification2021Characteristic a samm-c:SingleEntity ;
+    samm:preferredName "Sea Hazard Classification2021Characteristic"@en ;
+    samm:dataType :SeaHazardClassification2021 .
+
+:SeaHazardLabelling2021Characteristic a samm-c:SingleEntity ;
+    samm:preferredName "Sea Hazard Labelling2021Characteristic"@en ;
+    samm:dataType :SeaHazardLabelling2021 .
+
+:SectorOfUseCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Sector Of Use Characteristic"@en ;
+    samm:dataType :SectorOfUse .
+
+:SectorOfUseCodeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Sector Of Use Code Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "SU1" "SU2a" "SU2b" "SU3" "SU4" "SU5" "SU6a" "SU6b" "SU7" "SU8" "SU9" "SU10" "SU11" "SU12" "SU13" "SU14" "SU15" "SU16" "SU17" "SU18" "SU19" "SU20" "SU21" "SU22" "SU23" "SU24" "SU0" ) .
+
+:SectorOfUseList a samm-c:List ;
+    samm:preferredName "Sector Of Use List"@en ;
+    samm:dataType :SectorOfUse .
+
+:SelfheatingSubstancesAndMixturesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Selfheating Substances And Mixtures Characteristic"@en ;
+    samm:dataType :SelfheatingSubstancesAndMixtures .
+
+:SelfreactiveSubstancesAndMixturesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Selfreactive Substances And Mixtures Characteristic"@en ;
+    samm:dataType :SelfreactiveSubstancesAndMixtures .
+
+:SevesoDeCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Seveso De Characteristic"@en ;
+    samm:dataType :SevesoDe .
+
+:SevesoEntryDeCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Seveso Entry De Characteristic"@en ;
+    samm:dataType :SevesoEntryDe .
+
+:SevesoEntryEuCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Seveso Entry Eu Characteristic"@en ;
+    samm:dataType :SevesoEntryEu .
+
+:SevesoEuCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Seveso Eu Characteristic"@en ;
+    samm:dataType :SevesoEu .
+
+:SkinCorrosionAcidicOrAlkalineReserveCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Skin Corrosion Acidic Or Alkaline Reserve Characteristic"@en ;
+    samm:dataType :SkinCorrosionAcidicOrAlkalineReserve .
+
+:SkinCorrosionIrritationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Skin Corrosion Irritation Characteristic"@en ;
+    samm:dataType :SkinCorrosionIrritation .
+
+:SkinProtectionCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Skin Protection Characteristic"@en ;
+    samm:dataType :SkinProtection .
+
+:SolubilitiesList a samm-c:List ;
+    samm:preferredName "Solubilities List"@en ;
+    samm:dataType :Solubilities .
+
+:SolubilityList a samm-c:List ;
+    samm:preferredName "Solubility List"@en ;
+    samm:dataType :Solubility .
+
+:SolubilityMediumEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Solubility Medium Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "Water" "Fat" "Undefined" "Other" ) .
+
+:SolutionExtractionBehaviourOfPolymersInWaterList a samm-c:List ;
+    samm:preferredName "Solution Extraction Behaviour Of Polymers In Water List"@en ;
+    samm:dataType :SolutionExtractionBehaviourOfPolymersInWater .
+
+:SpeciesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Species Characteristic"@en ;
+    samm:dataType :Species .
+
+:SpecificConcLimitList a samm-c:List ;
+    samm:preferredName "Specific Conc Limit List"@en ;
+    samm:dataType :SpecificConcLimit .
+
+:SpecificEndUsesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Specific End Uses Characteristic"@en ;
+    samm:dataType :SpecificEndUses .
+
+:SpecificEnvironmentalReleaseCategoryList a samm-c:List ;
+    samm:preferredName "Specific Environmental Release Category List"@en ;
+    samm:dataType :SpecificEnvironmentalReleaseCategory .
+
+:SpecificTargetOrganReCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Specific Target Organ Re Characteristic"@en ;
+    samm:dataType :SpecificTargetOrganRe .
+
+:SpecificTargetOrganSe3Characteristic a samm-c:SingleEntity ;
+    samm:preferredName "Specific Target Organ Se3Characteristic"@en ;
+    samm:dataType :SpecificTargetOrganSe3 .
+
+:SpecificTargetOrganSeCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Specific Target Organ Se Characteristic"@en ;
+    samm:dataType :SpecificTargetOrganSe .
+
+:Srt2015HazardClassificationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Srt2015Hazard Classification Characteristic"@en ;
+    samm:dataType :Srt2015HazardClassification .
+
+:Srt2015HazardLabellingCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Srt2015Hazard Labelling Characteristic"@en ;
+    samm:dataType :Srt2015HazardLabelling .
+
+:StabilityReactivityCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Stability Reactivity Characteristic"@en ;
+    samm:dataType :StabilityReactivity .
+
+:StateCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "State Characteristic"@en ;
+    samm:dataType :State .
+
+:StateUnderStandardConditionsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "State Under Standard Conditions Characteristic"@en ;
+    samm:dataType :StateUnderStandardConditions .
+
+:StateUnderStandardConditionsEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "State Under Standard Conditions Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "solid" "liquid" "gaseous" ) .
+
+:StelList a samm-c:List ;
+    samm:preferredName "Stel List"@en ;
+    samm:dataType :Stel .
+
+:StorageClassEnumChCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Storage Class Enum Ch Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "1" "2" "3" "4.1" "4.2" "4.3" "5" "6.1" "6.2" "7" "8" "9" "10/12" "11/13" "10" "11" "12" "13" "NK" ) .
+
+:StorageClassEnumDeCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Storage Class Enum De Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "1" "2A" "2B" "3" "4.1A" "4.1B" "4.2" "4.3" "5.1A" "5.1B" "5.1C" "5.2" "6.1A" "6.1B" "6.1C" "6.1D" "6.2" "7" "8A" "8B" "9" "10" "11" "12" "13" "10-13" ) .
+
+:StorageStabilityList a samm-c:List ;
+    samm:preferredName "Storage Stability List"@en ;
+    samm:dataType :StorageStability .
+
+:StotDataList a samm-c:List ;
+    samm:preferredName "Stot Data List"@en ;
+    samm:dataType :StotData .
+
+:SubstanceIdentifiersCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Substance Identifiers Characteristic"@en ;
+    samm:dataType :SubstanceIdentifiers .
+
+:SubstanceIdentityEuCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Substance Identity Eu Characteristic"@en ;
+    samm:dataType :SubstanceIdentityEu .
+
+:SubstancesWhichInContactWithWaterEmitFlammableGasesCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Substances Which In Contact With Water Emit Flammable Gases Characteristic"@en ;
+    samm:dataType :SubstancesWhichInContactWithWaterEmitFlammableGases .
+
+:SumiList a samm-c:List ;
+    samm:preferredName "Sumi List"@en ;
+    samm:dataType :Sumi .
+
+:SumiReferenceCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Sumi Reference Characteristic"@en ;
+    samm:dataType :SumiReference .
+
+:SummaryRmMeasuresCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Summary Rm Measures Characteristic"@en ;
+    samm:dataType :SummaryRmMeasures .
+
+:SupplementalHazardInformationList a samm-c:List ;
+    samm:preferredName "Supplemental Hazard Information List"@en ;
+    samm:dataType :SupplementalHazardInformation .
+
+:SupplierInformationList a samm-c:List ;
+    samm:preferredName "Supplier Information List"@en ;
+    samm:dataType :SupplierInformation .
+
+:SurfaceTensionList a samm-c:List ;
+    samm:preferredName "Surface Tension List"@en ;
+    samm:dataType :SurfaceTension .
+
+:SymptomsOfExposureCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Symptoms Of Exposure Characteristic"@en ;
+    samm:dataType :SymptomsOfExposure .
+
+:TaLuftList a samm-c:List ;
+    samm:preferredName "Ta Luft List"@en ;
+    samm:dataType :TaLuft .
+
+:TargetGroupCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Target Group Characteristic"@en ;
+    samm:dataType :TargetGroup .
+
+:TerrestrialToxicityCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Terrestrial Toxicity Characteristic"@en ;
+    samm:dataType :TerrestrialToxicity .
+
+:TestPerformedList a samm-c:List ;
+    samm:preferredName "Test Performed List"@en ;
+    samm:dataType :TestPerformed .
+
+:TestResultsList a samm-c:List ;
+    samm:preferredName "Test Results List"@en ;
+    samm:dataType :TestResults .
+
+:ToxInfoStotSe3Characteristic a samm-c:SingleEntity ;
+    samm:preferredName "Tox Info Stot Se3Characteristic"@en ;
+    samm:dataType :ToxInfoStotSe3 .
+
+:ToxicokineticInfoCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Toxicokinetic Info Characteristic"@en ;
+    samm:dataType :ToxicokineticInfo .
+
+:ToxicologicalInformationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Toxicological Information Characteristic"@en ;
+    samm:dataType :ToxicologicalInformation .
+
+:TradeProductIdentityList a samm-c:List ;
+    samm:preferredName "Trade Product Identity List"@en ;
+    samm:dataType :TradeProductIdentity .
+
+:TransportBrCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Transport Br Characteristic"@en ;
+    samm:dataType :TransportBr .
+
+:TransportCaCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Transport Ca Characteristic"@en ;
+    samm:dataType :TransportCa .
+
+:TransportClassEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Transport Class Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "1" "2" "3" "4.1" "4.2" "4.3" "5.1" "5.2" "6.1" "6.2" "7" "8" "9" ) .
+
+:TransportEuCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Transport Eu Characteristic"@en ;
+    samm:dataType :TransportEu .
+
+:TransportInBulkCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Transport In Bulk Characteristic"@en ;
+    samm:dataType :TransportInBulk .
+
+:TransportInformationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Transport Information Characteristic"@en ;
+    samm:dataType :TransportInformation .
+
+:TransportMxCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Transport Mx Characteristic"@en ;
+    samm:dataType :TransportMx .
+
+:TransportUsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Transport Us Characteristic"@en ;
+    samm:dataType :TransportUs .
+
+:TypeList a samm-c:List ;
+    samm:preferredName "Type List"@en ;
+    samm:dataType :Type .
+
+:UnitEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Unit Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "°C" "°F" "µg/Animal" "µg/cm3" "µg/dL" "µg/g" "µg/kg" "µg/L" "µg/mg" "µg/mL" "µg/mmol" "µg/mol" "µg" "µL/g" "µL/kg" "µL/L" "µL/m3" "µL/mg" "µL/mL" "µL/mmol" "µL/mol" "µm" "µmol/L" "µmol/mol" "µPa.s" "%" "1/K" "1/mol.s" "1/W" "A.h" "A" "a" "atm" "bar.m/s" "bar/s" "bar" "Bq" "C" "cal/kg" "cal/mol.K" "cal/mol" "cal" "cd" "Ci" "cL" "cm/d" "cm/h" "cm/min" "cm/s" "cm2" "cm3/g" "cm3/h" "cm3/min" "cm3/s" "cm3" "cm" "cP" "cSt" "d" "dL" "dm2" "dm3" "dm" "dyn/cm" "F" "fiber/cm3" "fiber/m3" "fiber/mL" "fm" "g O2/g" "g O2/L" "g/cm3" "g/dm3" "g/g" "g/h" "g/kg" "g/L.s" "g/L" "g/m3" "g/m" "g/min" "g/mL" "g/mol" "g/s" "g" "Gbq" "h" "hPa/s" "hPa" "J/kg" "J/mol" "J" "K/min" "K" "kA.h" "kcal/kg" "kcal/mol" "kcal" "kg/dm3" "kg/h" "kg/ha" "kg/L" "kg/m3" "kg/min" "kg/mol" "kg/s.m2" "kg/s" "kg" "kJ/kg" "kJ/mol" "kJ" "km/d" "km/h" "kPa/s" "kPa" "kV" "kW" "L/h" "L/kg.h" "L/kg.min" "L/kg.s" "L/kg" "L/L" "L/m3" "L/min" "L/mol" "L/s" "L" "lm" "lx" "m/d" "m/h" "m/min" "m/s" "m2" "m3/h" "m3/min" "m3/s" "m3" "m" "mA" "mbar" "mCi" "mg C/g" "mg C/L" "mg KOH/g" "mg O2/g" "mg O2/L" "mg/Animal" "mg/cm2" "mg/cm3" "mg/dm2" "mg/dm3" "mg/Eye" "mg/g" "mg/h" "mg/kg bw.d" "mg/kg bw" "mg/kg" "mg/L" "mg/m3" "mg/mg" "mg/min" "mg/mL" "mg/mmol" "mg/mol" "mg/s" "mg" "min" "mJ" "mL/Animal" "mL/Eye" "mL/g" "mL/h" "mL/kg" "mL/L" "mL/m3" "mL/mg" "mL/min" "mL/mL" "mL/mmol" "mL/mol" "mL/s" "mL" "mm H2O" "mm Hg" "mm/a" "mm/d" "mm/h" "mm/min" "mm/s" "mm2/s" "mm2" "mm3" "mm" "mmol/g" "mmol/kg" "mmol/L" "mmol/m3" "mmol/mg" "mmol/mL" "mmol/mmol" "mmol/mol" "mN/m" "mol-%" "mol/g" "mol/kg" "mol/L.s" "mol/L" "mol/m3" "mol/mg" "mol/mL" "mol/mmol" "mol/mol" "mPa.s" "mPa" "ms" "mV" "N/cm2" "N/m2" "N/m" "N/mm2" "ng/cm3" "ng/g" "ng/L" "ng/mg" "ng/mL" "ng/mmol" "ng/mol" "nm" "nmol/L" "P" "Pa.m3/mol" "Pa.s" "Pa/s" "Pa" "pm" "ppb" "ppm" "ppq" "ppt" "S" "s" "St" "t/h" "t/min" "t/s" "t" "Torr" "U/g" "U/kg" "U/L" "U/mg" "U/mL" "U/mmol" "U/mol" "V" "Vol-%" "W.h" "W.m" "W" "Wb" "Weight-%" ) .
+
+:UnknownToxicityCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Unknown Toxicity Characteristic"@en ;
+    samm:dataType :UnknownToxicity .
+
+:UpperQualifierEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Upper Qualifier Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "lt" "le" ) .
+
+:UpperTierQuantityInlineCharacteristic a samm:Characteristic ;
+    samm:preferredName "Upper Tier Quantity Inline Characteristic"@en ;
+    samm:dataType xsd:integer .
+
+:UseDescriptorsCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Use Descriptors Characteristic"@en ;
+    samm:dataType :UseDescriptors .
+
+:VbfClassCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Vbf Class Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "A I" "A II" "A III" "B I" "B II" ) .
+
+:ViscosityList a samm-c:List ;
+    samm:preferredName "Viscosity List"@en ;
+    samm:dataType :Viscosity .
+
+:ViscosityTypeEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Viscosity Type Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "Dynamic" "Kinematic" "Flow time" "Undefined" "Other" ) .
+
+:VocCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Voc Characteristic"@en ;
+    samm:dataType :Voc .
+
+:VocLabellingList a samm-c:List ;
+    samm:preferredName "Voc Labelling List"@en ;
+    samm:dataType :VocLabelling .
+
+:WasteListEntryList a samm-c:List ;
+    samm:preferredName "Waste List Entry List"@en ;
+    samm:dataType :WasteListEntry .
+
+:WasteTreatmentCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Waste Treatment Characteristic"@en ;
+    samm:dataType :WasteTreatment .
+
+:WaterHazardClassCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Water Hazard Class Characteristic"@en ;
+    samm:dataType :WaterHazardClass .
+
+:WaterHazardClassEnumCharacteristic a samm-c:Enumeration ;
+    samm:preferredName "Water Hazard Class Enum Characteristic"@en ;
+    samm:dataType xsd:string ;
+    samm-c:values ( "1" "2" "3" "nwg" "awg" ) .
+
+:Whmis2015HazardClassificationCharacteristic a samm-c:SingleEntity ;
+    samm:preferredName "Whmis2015Hazard Classification Characteristic"@en ;
+    samm:dataType :Whmis2015HazardClassification .
+
+# ──────────────────────────────────────────────────────────────────────────
+# Entities
+# ──────────────────────────────────────────────────────────────────────────
+
+:AbntNrb2015HazardClassification a samm:Entity ;
+    samm:preferredName "Abnt Nrb2015Hazard Classification"@en ;
+    samm:properties (
+        :hazardClassCategory
+        :hazardClassCategoryPrintable
+        [ samm:property :organ ; samm:optional true ]
+        [ samm:property :exposureRoutePhrase ; samm:optional true ]
+        [ samm:property :classificationProcedure ; samm:optional true ]
+        [ samm:property :unknownToxicity ; samm:optional true ]
+        [ samm:property :ate ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+    ) .
+
+:AbntNrb2017HazardLabelling a samm:Entity ;
+    samm:preferredName "Abnt Nrb2017Hazard Labelling"@en ;
+    samm:properties (
+        [ samm:property :hazardPictogram ; samm:optional true ]
+        [ samm:property :signalWord ; samm:optional true ]
+        [ samm:property :hazardStatement ; samm:optional true ]
+        [ samm:property :precautionaryStatement ; samm:optional true ]
+        [ samm:property :additionalLabellingInfo ; samm:optional true ]
+    ) .
+
+:AbntNrb2019HazardClassification a samm:Entity ;
+    samm:preferredName "Abnt Nrb2019Hazard Classification"@en ;
+    samm:properties (
+        :hazardClassCategory
+        :hazardClassCategoryPrintable
+        [ samm:property :organ ; samm:optional true ]
+        [ samm:property :exposureRoutePhrase ; samm:optional true ]
+        [ samm:property :classificationProcedure ; samm:optional true ]
+        [ samm:property :unknownToxicity ; samm:optional true ]
+        [ samm:property :ate ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+    ) .
+
+:AccidentalReleaseMeasures a samm:Entity ;
+    samm:preferredName "Accidental Release Measures"@en ;
+    samm:description "SDS section 6"@en ;
+    samm:properties (
+        [ samm:property :forNonEmergencyPersonnel ; samm:optional true ]
+        [ samm:property :forEmergencyResponders ; samm:optional true ]
+        [ samm:property :environmentalPrecautions ; samm:optional true ]
+        [ samm:property :containmentAndCleaningUp ; samm:optional true ]
+        [ samm:property :referenceToOtherSections ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+    ) .
+
+:AcuteToxicity a samm:Entity ;
+    samm:preferredName "Acute Toxicity"@en ;
+    samm:properties (
+        [ samm:property :testResults ; samm:optional true ]
+        [ samm:property :acuteToxicityHumanExperience ; samm:optional true ]
+        [ samm:property :assessmentAcuteToxicityClassification ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:AdditionalEcotoxInformation a samm:Entity ;
+    samm:preferredName "Additional Ecotox Information"@en ;
+    samm:properties (
+        [ samm:property :dissolvedOrganicCarbon ; samm:optional true ]
+        [ samm:property :theoreticalOxygenDemand ; samm:optional true ]
+        [ samm:property :theoreticalCarbonDioxideAmount ; samm:optional true ]
+        [ samm:property :chemicalOxygenDemand ; samm:optional true ]
+        [ samm:property :biochemicalOxygenDemand ; samm:optional true ]
+        [ samm:property :bod5CodRatio ; samm:optional true ]
+        [ samm:property :totalOrganicCarbon ; samm:optional true ]
+        [ samm:property :inorganicCarbon ; samm:optional true ]
+        [ samm:property :aoxAdsorbableOrganohalogens ; samm:optional true ]
+        [ samm:property :poxPurgeableOrganohalogens ; samm:optional true ]
+        [ samm:property :eoxExtractableOrganohalogens ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+    ) .
+
+:Address a samm:Entity ;
+    samm:preferredName "Address"@en ;
+    samm:properties (
+        [ samm:property :visitingAddressLine1 ; samm:optional true ]
+        [ samm:property :visitingAddressLine2 ; samm:optional true ]
+        [ samm:property :visitingAddressLine3 ; samm:optional true ]
+        [ samm:property :visitingAddressPostCode ; samm:optional true ]
+        [ samm:property :visitingAddressCity ; samm:optional true ]
+        [ samm:property :postAddressLine1 ; samm:optional true ]
+        [ samm:property :postAddressLine2 ; samm:optional true ]
+        [ samm:property :postAddressLine3 ; samm:optional true ]
+        [ samm:property :postCode ; samm:optional true ]
+        [ samm:property :postCity ; samm:optional true ]
+    ) .
+
+:Adn a samm:Entity ;
+    samm:preferredName "Adn"@en ;
+    samm:properties (
+        [ samm:property :unNo ; samm:optional true ]
+        [ samm:property :properShippingNameEnglish ; samm:optional true ]
+        [ samm:property :properShippingNameNational ; samm:optional true ]
+        [ samm:property :dangerReleasingSubstanceEnglish ; samm:optional true ]
+        [ samm:property :dangerReleasingSubstanceNational ; samm:optional true ]
+        [ samm:property :classTransportClassEnum ; samm:optional true ]
+        [ samm:property :classCode ; samm:optional true ]
+        [ samm:property :hazardLabel ; samm:optional true ]
+        [ samm:property :packingGroup ; samm:optional true ]
+        [ samm:property :otherInformation ; samm:optional true ]
+    ) .
+
+:AdrRid a samm:Entity ;
+    samm:preferredName "Adr Rid"@en ;
+    samm:properties (
+        [ samm:property :unNo ; samm:optional true ]
+        [ samm:property :properShippingNameEnglish ; samm:optional true ]
+        [ samm:property :properShippingNameNational ; samm:optional true ]
+        [ samm:property :dangerReleasingSubstanceEnglish ; samm:optional true ]
+        [ samm:property :dangerReleasingSubstanceNational ; samm:optional true ]
+        [ samm:property :classTransportClassEnum ; samm:optional true ]
+        [ samm:property :classCode ; samm:optional true ]
+        [ samm:property :hazardLabelAdr ; samm:optional true ]
+        [ samm:property :hazardLabelRid ; samm:optional true ]
+        [ samm:property :packingGroup ; samm:optional true ]
+        [ samm:property :otherInformation ; samm:optional true ]
+    ) .
+
+:AnnexesEu a samm:Entity ;
+    samm:preferredName "Annexes Eu"@en ;
+    samm:properties ( [ samm:property :safeUseInfoForMixtures ; samm:optional true ] ) .
+
+:Appearance a samm:Entity ;
+    samm:preferredName "Appearance"@en ;
+    samm:properties (
+        [ samm:property :form ; samm:optional true ]
+        [ samm:property :formDescription ; samm:optional true ]
+        [ samm:property :stateUnderStandardConditions ; samm:optional true ]
+        [ samm:property :colour ; samm:optional true ]
+        [ samm:property :colourDescription ; samm:optional true ]
+        [ samm:property :colourIntensity ; samm:optional true ]
+        [ samm:property :colourIntensityDescription ; samm:optional true ]
+        [ samm:property :odour ; samm:optional true ]
+        [ samm:property :odourThreshold ; samm:optional true ]
+    ) .
+
+:AppropriateEnvionmentalExposureControl a samm:Entity ;
+    samm:preferredName "Appropriate Envionmental Exposure Control"@en ;
+    samm:properties (
+        [ samm:property :productRelatedMeasures ; samm:optional true ]
+        [ samm:property :instructionalMeasures ; samm:optional true ]
+        [ samm:property :organisationalMeasures ; samm:optional true ]
+        [ samm:property :technicalMeasures ; samm:optional true ]
+    ) .
+
+:AquaticToxicity a samm:Entity ;
+    samm:preferredName "Aquatic Toxicity"@en ;
+    samm:properties (
+        [ samm:property :acuteFishToxicity ; samm:optional true ]
+        [ samm:property :chronicFishToxicity ; samm:optional true ]
+        [ samm:property :acuteInvertebrateToxicity ; samm:optional true ]
+        [ samm:property :chronicInvertebrateToxicity ; samm:optional true ]
+        [ samm:property :acuteAlgaeToxicity ; samm:optional true ]
+        [ samm:property :chronicAlgaeToxicity ; samm:optional true ]
+        [ samm:property :plantToxicity ; samm:optional true ]
+        [ samm:property :microorganismToxicity ; samm:optional true ]
+    ) .
+
+:ArticleCategory a samm:Entity ;
+    samm:preferredName "Article Category"@en ;
+    samm:description "ArticleCategory, source: Chapter 1, used by: CT \"IdentifiedUse\""@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        :acCode
+        [ samm:property :acFulltext ; samm:optional true ]
+    ) .
+
+:AspirationHazard a samm:Entity ;
+    samm:preferredName "Aspiration Hazard"@en ;
+    samm:properties (
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :aspirationHazardHydrocarbonContent ; samm:optional true ]
+        [ samm:property :aspirationHazardKinematicViscosity40 ; samm:optional true ]
+        [ samm:property :assessmentAspirationHazardClassification ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:Assessment a samm:Entity ;
+    samm:preferredName "Assessment"@en ;
+    samm:properties (
+        :assessmentAssessmentEnum
+        [ samm:property :assessmentFulltext ; samm:optional true ]
+    ) .
+
+:Ate a samm:Entity ;
+    samm:preferredName "Ate"@en ;
+    samm:properties (
+        [ samm:property :inhalation ; samm:optional true ]
+        [ samm:property :dermal ; samm:optional true ]
+        [ samm:property :oral ; samm:optional true ]
+    ) .
+
+:AteValue a samm:Entity ;
+    samm:preferredName "Ate Value"@en ;
+    samm:description "Acute Toxicity Estimates for mixture-in-mixture classification."@en ;
+    samm:properties (
+        :valueFloat
+        :unit
+        [ samm:property :unitFulltext ; samm:optional true ]
+        [ samm:property :restriction ; samm:optional true ]
+    ) .
+
+:Atp12SpecialSupplementalLabelInfo a samm:Entity ;
+    samm:preferredName "Atp12Special Supplemental Label Info"@en ;
+    samm:description "Special Supplemental Label Info for Mixtures CLP"@en ;
+    samm:properties (
+        [ samm:property :phraseId ; samm:optional true ]
+        :phraseCodeAtp12SpecialSupplementalLabelInfoEnum
+        [ samm:property :fullText ; samm:optional true ]
+        [ samm:property :mergePhrase ; samm:optional true ]
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+    ) .
+
+:Bioaccumulation a samm:Entity ;
+    samm:preferredName "Bioaccumulation"@en ;
+    samm:properties (
+        [ samm:property :bioconcentrationFactor ; samm:optional true ]
+        [ samm:property :bioaccumulationEvaluation ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:Biocides a samm:Entity ;
+    samm:preferredName "Biocides"@en ;
+    samm:properties (
+        [ samm:property :isBiocide ; samm:optional true ]
+        [ samm:property :isTreatedArticle ; samm:optional true ]
+        [ samm:property :compositionInformation ; samm:optional true ]
+        [ samm:property :instructionsForUse ; samm:optional true ]
+        [ samm:property :authorizationNo ; samm:optional true ]
+        [ samm:property :mainGroup ; samm:optional true ]
+        [ samm:property :productType ; samm:optional true ]
+    ) .
+
+:BioconcentrationFactor a samm:Entity ;
+    samm:preferredName "Bioconcentration Factor"@en ;
+    samm:properties (
+        [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
+        [ samm:property :speciesSpecies ; samm:optional true ]
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:BiologicalDegradation a samm:Entity ;
+    samm:preferredName "Biological Degradation"@en ;
+    samm:description "BiologicalDegradation, source: Chapter 12"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :inoculum ; samm:optional true ]
+        [ samm:property :degradationRate ; samm:optional true ]
+        [ samm:property :testDuration ; samm:optional true ]
+        [ samm:property :source ; samm:optional true ]
+    ) .
+
+:BiologicalLimitValue a samm:Entity ;
+    samm:preferredName "Biological Limit Value"@en ;
+    samm:description "BiologicalLimitValue, source: Chapter 8"@en ;
+    samm:properties (
+        [ samm:property :limitValueTypeWithCountryOrOrganisation ; samm:optional true ]
+        [ samm:property :investigationParameter ; samm:optional true ]
+        [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
+        [ samm:property :testMaterial ; samm:optional true ]
+        [ samm:property :testDate ; samm:optional true ]
+        [ samm:property :reference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:BiologicalLimitValues a samm:Entity ;
+    samm:preferredName "Biological Limit Values"@en ;
+    samm:properties (
+        [ samm:property :biologicalLimitValue ; samm:optional true ]
+        [ samm:property :intendedUseBiologicalLimitValue ; samm:optional true ]
+    ) .
+
+:BoilingPointRelated a samm:Entity ;
+    samm:preferredName "Boiling Point Related"@en ;
+    samm:properties (
+        [ samm:property :boilingPoint ; samm:optional true ]
+        [ samm:property :sublimationPoint ; samm:optional true ]
+    ) .
+
+:California a samm:Entity ;
+    samm:preferredName "California"@en ;
+    samm:properties (
+        [ samm:property :hazardousWasteCode ; samm:optional true ]
+        [ samm:property :hazardousWasteStatus ; samm:optional true ]
+    ) .
+
+:Carcinogenicity a samm:Entity ;
+    samm:preferredName "Carcinogenicity"@en ;
+    samm:properties (
+        [ samm:property :carcinogenicityTestResults ; samm:optional true ]
+        [ samm:property :carcinogenicityHumanExperience ; samm:optional true ]
+        [ samm:property :assessmentCarcinogenicityClassification ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:CertainFluorinatedGreenhouseGases a samm:Entity ;
+    samm:preferredName "Certain Fluorinated Greenhouse Gases"@en ;
+    samm:properties (
+        [ samm:property :fluorinatedGreenhouseGasesMethod ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:ChemicalSafetyAssessmentInfo a samm:Entity ;
+    samm:preferredName "Chemical Safety Assessment Info"@en ;
+    samm:properties (
+        [ samm:property :chemicalSafetyAssessmentCarriedOut ; samm:optional true ]
+        [ samm:property :chemicalSafetyAssessment ; samm:optional true ]
+    ) .
+
+:ChemicalSafetyReport a samm:Entity ;
+    samm:preferredName "Chemical Safety Report"@en ;
+    samm:properties (
+        [ samm:property :csrRequired ; samm:optional true ]
+        [ samm:property :csrLocation ; samm:optional true ]
+    ) .
+
+:Classification a samm:Entity ;
+    samm:preferredName "Classification"@en ;
+    samm:properties (
+        :hazardClassCategory
+        :hazardClassCategoryPrintable
+        [ samm:property :organ ; samm:optional true ]
+        [ samm:property :exposureRoutePhrase ; samm:optional true ]
+        [ samm:property :classificationProcedure ; samm:optional true ]
+    ) .
+
+:ClassificationAr a samm:Entity ;
+    samm:preferredName "Classification Ar"@en ;
+    samm:properties ( [ samm:property :srt2015HazardClassification ; samm:optional true ] ) .
+
+:ClassificationAssessment a samm:Entity ;
+    samm:preferredName "Classification Assessment"@en ;
+    samm:properties (
+        [ samm:property :assessmentRespiratorySensitisationClassification ; samm:optional true ]
+        [ samm:property :assessmentSkinSensitisationClassification ; samm:optional true ]
+    ) .
+
+:ClassificationBr a samm:Entity ;
+    samm:preferredName "Classification Br"@en ;
+    samm:properties (
+        [ samm:property :abntNrb2015HazardClassification ; samm:optional true ]
+        [ samm:property :abntNrb2019HazardClassification ; samm:optional true ]
+    ) .
+
+:ClassificationCa a samm:Entity ;
+    samm:preferredName "Classification Ca"@en ;
+    samm:properties ( [ samm:property :whmis2015HazardClassification ; samm:optional true ] ) .
+
+:ClassificationGb a samm:Entity ;
+    samm:preferredName "Classification Gb"@en ;
+    samm:properties ( [ samm:property :gbClpHazardClassification2020 ; samm:optional true ] ) .
+
+:ClassificationMx a samm:Entity ;
+    samm:preferredName "Classification Mx"@en ;
+    samm:properties ( [ samm:property :nom2015HazardClassification ; samm:optional true ] ) .
+
+:ClassificationTr a samm:Entity ;
+    samm:preferredName "Classification Tr"@en ;
+    samm:properties ( [ samm:property :seaHazardClassification2021 ; samm:optional true ] ) .
+
+:ClassificationUs a samm:Entity ;
+    samm:preferredName "Classification Us"@en ;
+    samm:properties ( [ samm:property :hazcom2012HazardClassification ; samm:optional true ] ) .
+
+:CmrData a samm:Entity ;
+    samm:preferredName "Cmr Data"@en ;
+    samm:description "CMRData, source: Chapter 11"@en ;
+    samm:properties (
+        :methodPhrase
+        [ samm:property :dose ; samm:optional true ]
+        [ samm:property :exposureRouteExposureRoute ; samm:optional true ]
+        [ samm:property :exposureTime ; samm:optional true ]
+        [ samm:property :effectValue ; samm:optional true ]
+        [ samm:property :testDuration ; samm:optional true ]
+        :speciesSpecies
+        [ samm:property :result ; samm:optional true ]
+        [ samm:property :resultEvaluation ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:CompanyContact a samm:Entity ;
+    samm:preferredName "Company Contact"@en ;
+    samm:properties (
+        [ samm:property :name ; samm:optional true ]
+        [ samm:property :phone ; samm:optional true ]
+        [ samm:property :fax ; samm:optional true ]
+        [ samm:property :url ; samm:optional true ]
+        [ samm:property :email ; samm:optional true ]
+        [ samm:property :nationalContact ; samm:optional true ]
+        [ samm:property :emailCompetentPerson ; samm:optional true ]
+    ) .
+
+:CompleteSdsWithEsIncorporated a samm:Entity ;
+    samm:preferredName "Complete Sds With Es Incorporated"@en ;
+    samm:properties (
+        [ samm:property :extendedSdsWithEsIncorporated ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:Composition a samm:Entity ;
+    samm:preferredName "Composition"@en ;
+    samm:description "SDS section 3"@en ;
+    samm:properties (
+        [ samm:property :chemicalCharacterization ; samm:optional true ]
+        [ samm:property :regionAr ; samm:optional true ]
+        [ samm:property :regionBr ; samm:optional true ]
+        [ samm:property :regionCa ; samm:optional true ]
+        [ samm:property :regionEu ; samm:optional true ]
+        [ samm:property :regionGb ; samm:optional true ]
+        [ samm:property :regionMx ; samm:optional true ]
+        [ samm:property :regionTr ; samm:optional true ]
+        [ samm:property :regionUs ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:ConditionsForSafeStorage a samm:Entity ;
+    samm:preferredName "Conditions For Safe Storage"@en ;
+    samm:properties (
+        [ samm:property :technicalMeasuresAndStorageConditions ; samm:optional true ]
+        [ samm:property :packagingContainer ; samm:optional true ]
+        [ samm:property :requirementsForStorageRoomsAndVessels ; samm:optional true ]
+        [ samm:property :hintsOnStorageAssembly ; samm:optional true ]
+        [ samm:property :storageTemperature ; samm:optional true ]
+        [ samm:property :storagePressure ; samm:optional true ]
+        [ samm:property :storageAirHumidity ; samm:optional true ]
+        [ samm:property :storageStability ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:ConsumerExposureControl a samm:Entity ;
+    samm:preferredName "Consumer Exposure Control"@en ;
+    samm:properties (
+        [ samm:property :measuresOnConsumerUseOfTheChemical ; samm:optional true ]
+        [ samm:property :measuresOnServiceLifeInArticles ; samm:optional true ]
+    ) .
+
+:ContainmentAndCleaningUp a samm:Entity ;
+    samm:preferredName "Containment And Cleaning Up"@en ;
+    samm:properties (
+        [ samm:property :containment ; samm:optional true ]
+        [ samm:property :cleaningUp ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:ControlParameters a samm:Entity ;
+    samm:preferredName "Control Parameters"@en ;
+    samm:properties (
+        [ samm:property :occupationalExposureLimits ; samm:optional true ]
+        [ samm:property :biologicalLimitValues ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+        [ samm:property :regionEuControlParametersEu ; samm:optional true ]
+    ) .
+
+:ControlParametersEu a samm:Entity ;
+    samm:preferredName "Control Parameters Eu"@en ;
+    samm:properties (
+        [ samm:property :derivedNoEffectLevel ; samm:optional true ]
+        [ samm:property :derivedMinimalEffectLevel ; samm:optional true ]
+        [ samm:property :predictedNoEffectConcentration ; samm:optional true ]
+    ) .
+
+:CorrespondingExposureScenario a samm:Entity ;
+    samm:preferredName "Corresponding Exposure Scenario"@en ;
+    samm:properties (
+        [ samm:property :exposureScenarioName ; samm:optional true ]
+        [ samm:property :legalDocumentFileName ; samm:optional true ]
+        [ samm:property :legalDocumentPrintDate ; samm:optional true ]
+        [ samm:property :legalDocumentSignature ; samm:optional true ]
+        [ samm:property :escomFileName ; samm:optional true ]
+    ) .
+
+:CorrosionIrritationData a samm:Entity ;
+    samm:preferredName "Corrosion Irritation Data"@en ;
+    samm:description "CorrosionIrritationData, source: Chapter 11"@en ;
+    samm:properties (
+        [ samm:property :investigationMethod ; samm:optional true ]
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :exposureTime ; samm:optional true ]
+        [ samm:property :speciesSpecies ; samm:optional true ]
+        [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
+        [ samm:property :resultEvaluation ; samm:optional true ]
+        [ samm:property :resultEvaluationScore ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:CorrosiveToMetals a samm:Entity ;
+    samm:preferredName "Corrosive To Metals"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+        [ samm:property :exposureTime ; samm:optional true ]
+        [ samm:property :intrusionDepth ; samm:optional true ]
+        [ samm:property :materialType ; samm:optional true ]
+    ) .
+
+:Datasheet a samm:Entity ;
+    samm:preferredName "Datasheet"@en ;
+    samm:properties (
+        :identificationSubstPrep
+        :hazardIdentification
+        :composition
+        :firstAidMeasures
+        :fireFightingMeasures
+        :accidentalReleaseMeasures
+        :handlingAndStorage
+        :exposureControlPersonalProtectionExposureControlPersonalProtection
+        :physicalChemicalPropertiesPhysicalChemicalProperties
+        :stabilityReactivity
+        :toxicologicalInformationToxicologicalInformation
+        :ecologicalInformationEcologicalInformation
+        :disposalConsiderations
+        :transportInformation
+        :regulatoryInformation
+        :otherInformation
+        [ samm:property :regionEuAnnexesEu ; samm:optional true ]
+    ) .
+
+:DegradationElimination a samm:Entity ;
+    samm:preferredName "Degradation Elimination"@en ;
+    samm:description "DegradationElimination, source: Chapter 12"@en ;
+    samm:properties (
+        [ samm:property :halfLifeTime ; samm:optional true ]
+        [ samm:property :pH ; samm:optional true ]
+        [ samm:property :source ; samm:optional true ]
+    ) .
+
+:Densities a samm:Entity ;
+    samm:preferredName "Densities"@en ;
+    samm:properties (
+        [ samm:property :relativeDensity ; samm:optional true ]
+        [ samm:property :density ; samm:optional true ]
+        [ samm:property :bulkDensity ; samm:optional true ]
+    ) .
+
+:DescriptionOfFirstAidMeasures a samm:Entity ;
+    samm:preferredName "Description Of First Aid Measures"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :firstAidInhalation ; samm:optional true ]
+        [ samm:property :firstAidSkin ; samm:optional true ]
+        [ samm:property :firstAidEye ; samm:optional true ]
+        [ samm:property :firstAidIngestion ; samm:optional true ]
+        [ samm:property :personalProtectionFirstAider ; samm:optional true ]
+    ) .
+
+:Detergents a samm:Entity ;
+    samm:preferredName "Detergents"@en ;
+    samm:properties (
+        [ samm:property :isDetergent ; samm:optional true ]
+        [ samm:property :nameDetergentsRegulation ; samm:optional true ]
+        [ samm:property :detergentInformation ; samm:optional true ]
+    ) .
+
+:DisposalConsiderations a samm:Entity ;
+    samm:preferredName "Disposal Considerations"@en ;
+    samm:description "SDS section 13"@en ;
+    samm:properties (
+        [ samm:property :wasteTreatment ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+        [ samm:property :regionEuDisposalConsiderationsEu ; samm:optional true ]
+        [ samm:property :regionUsDisposalConsiderationsUs ; samm:optional true ]
+    ) .
+
+:DisposalConsiderationsEu a samm:Entity ;
+    samm:preferredName "Disposal Considerations Eu"@en ;
+    samm:properties (
+        [ samm:property :europeanWasteList ; samm:optional true ]
+        [ samm:property :euWasteRegulations ; samm:optional true ]
+    ) .
+
+:DisposalConsiderationsUs a samm:Entity ;
+    samm:preferredName "Disposal Considerations Us"@en ;
+    samm:properties (
+        [ samm:property :federal ; samm:optional true ]
+        [ samm:property :state ; samm:optional true ]
+    ) .
+
+:DissociationConstant a samm:Entity ;
+    samm:preferredName "Dissociation Constant"@en ;
+    samm:description "DissociationConstant source: Chapter 9"@en ;
+    samm:properties (
+        [ samm:property :valuePhysChemValueWithTemperature ; samm:optional true ]
+        [ samm:property :concentration ; samm:optional true ]
+    ) .
+
+:Dmel a samm:Entity ;
+    samm:preferredName "Dmel"@en ;
+    samm:description "DNEL source: Chapter 8"@en ;
+    samm:properties (
+        :exposureRouteFrequencyAndEffect
+        :dmelValue
+        [ samm:property :assessmentFactor ; samm:optional true ]
+        [ samm:property :reference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:Dnel a samm:Entity ;
+    samm:preferredName "Dnel"@en ;
+    samm:description "DNEL, source: Chapter 8"@en ;
+    samm:properties (
+        :exposureGroup
+        :exposureRouteFrequencyAndEffect
+        :dnelValue
+        [ samm:property :assessmentFactor ; samm:optional true ]
+        [ samm:property :reference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:Dose a samm:Entity ;
+    samm:preferredName "Dose"@en ;
+    samm:properties (
+        :typeDoseEnum
+        [ samm:property :typeFulltext ; samm:optional true ]
+    ) .
+
+:EcologicalInformation a samm:Entity ;
+    samm:preferredName "Ecological Information"@en ;
+    samm:description "SDS section 12."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :ecotoxicologicalInformation ; samm:optional true ]
+        [ samm:property :persistenceDegradability ; samm:optional true ]
+        [ samm:property :bioaccumulation ; samm:optional true ]
+        [ samm:property :mobility ; samm:optional true ]
+        [ samm:property :otherAdverseEffects ; samm:optional true ]
+        [ samm:property :additionalEcotoxInformation ; samm:optional true ]
+        [ samm:property :regionEu ; samm:optional true ]
+    ) .
+
+:Ecotoxicity a samm:Entity ;
+    samm:preferredName "Ecotoxicity"@en ;
+    samm:description "Ecotoxicity for plants and mammals. Source: Chapter 12."@en ;
+    samm:properties (
+        [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
+        [ samm:property :effectDoseConcentration ; samm:optional true ]
+        [ samm:property :exposureTime ; samm:optional true ]
+        [ samm:property :speciesSpecies ; samm:optional true ]
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :evaluationPhrase ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:EcotoxicityAquatic a samm:Entity ;
+    samm:preferredName "Ecotoxicity Aquatic"@en ;
+    samm:description "Ecotoxicity for aquatic environment. Source: Chapter 12."@en ;
+    samm:properties (
+        [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
+        [ samm:property :effectDoseConcentration ; samm:optional true ]
+        [ samm:property :testDuration ; samm:optional true ]
+        [ samm:property :speciesPhrase ; samm:optional true ]
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :evaluationPhrase ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:EcotoxicologicalInformation a samm:Entity ;
+    samm:preferredName "Ecotoxicological Information"@en ;
+    samm:properties (
+        [ samm:property :aquaticToxicity ; samm:optional true ]
+        [ samm:property :sedimentToxicity ; samm:optional true ]
+        [ samm:property :terrestrialToxicity ; samm:optional true ]
+        [ samm:property :ecotoxicologyOverallEvaluation ; samm:optional true ]
+    ) .
+
+:EmergencyPhone a samm:Entity ;
+    samm:preferredName "Emergency Phone"@en ;
+    samm:properties (
+        [ samm:property :noString256 ; samm:optional true ]
+        [ samm:property :emergencyPhoneDescription ; samm:optional true ]
+    ) .
+
+:EnvironmentalExposureControls a samm:Entity ;
+    samm:preferredName "Environmental Exposure Controls"@en ;
+    samm:properties (
+        [ samm:property :environmentalExposureControls ; samm:optional true ]
+        [ samm:property :appropriateEnvionmentalExposureControl ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:EnvironmentalReleaseCategory a samm:Entity ;
+    samm:preferredName "Environmental Release Category"@en ;
+    samm:description "Environmental Release Category, source: Chapter 1, used by: CT \"IdentifiedUse\""@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        :ercCode
+        [ samm:property :ercFulltext ; samm:optional true ]
+    ) .
+
+:Equipment a samm:Entity ;
+    samm:preferredName "Equipment"@en ;
+    samm:properties (
+        [ samm:property :suitableGlovesType ; samm:optional true ]
+        [ samm:property :suitableMaterial ; samm:optional true ]
+        [ samm:property :gloveBreakthroughTime ; samm:optional true ]
+        [ samm:property :thicknessOfGloveMaterial ; samm:optional true ]
+        [ samm:property :maxWearDurationOccasionalContact ; samm:optional true ]
+        [ samm:property :maxWearDurationPermanentContact ; samm:optional true ]
+        [ samm:property :article ; samm:optional true ]
+    ) .
+
+:EuLegislation a samm:Entity ;
+    samm:preferredName "Eu Legislation"@en ;
+    samm:properties (
+        [ samm:property :assessedLegislation ; samm:optional true ]
+        [ samm:property :authorisationNo ; samm:optional true ]
+        [ samm:property :euAuthorisation ; samm:optional true ]
+        [ samm:property :euRestrictionsOnUse ; samm:optional true ]
+        [ samm:property :euRestrictionsOfOccupation ; samm:optional true ]
+        [ samm:property :restrictionsAccordingReach ; samm:optional true ]
+        [ samm:property :inciName ; samm:optional true ]
+        [ samm:property :detergents ; samm:optional true ]
+        [ samm:property :voc ; samm:optional true ]
+        [ samm:property :biocides ; samm:optional true ]
+        [ samm:property :seveso ; samm:optional true ]
+        [ samm:property :industrialEmissions ; samm:optional true ]
+        [ samm:property :certainFluorinatedGreenhouseGases ; samm:optional true ]
+        [ samm:property :otherEuLegislation ; samm:optional true ]
+        [ samm:property :exposureScenarioIdentificationString ; samm:optional true ]
+    ) .
+
+:EupcsCategory a samm:Entity ;
+    samm:preferredName "Eupcs Category"@en ;
+    samm:description "EuPCS Category, source: Chapter 1, used by: CT \"IdentifiedUse\""@en ;
+    samm:properties (
+        :eupcsCode
+        [ samm:property :eupcsFulltext ; samm:optional true ]
+    ) .
+
+:EuropeanWasteList a samm:Entity ;
+    samm:preferredName "European Waste List"@en ;
+    samm:properties (
+        [ samm:property :ewlProduct ; samm:optional true ]
+        [ samm:property :ewlPacking ; samm:optional true ]
+    ) .
+
+:ExplosionLimit a samm:Entity ;
+    samm:preferredName "Explosion Limit"@en ;
+    samm:properties (
+        [ samm:property :lowerExplosionLimit ; samm:optional true ]
+        [ samm:property :upperExplosionLimit ; samm:optional true ]
+    ) .
+
+:Explosives a samm:Entity ;
+    samm:preferredName "Explosives"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :screeningProcedures ; samm:optional true ]
+        [ samm:property :testPerformed ; samm:optional true ]
+    ) .
+
+:ExposureControlAppropriateMeasures a samm:Entity ;
+    samm:preferredName "Exposure Control Appropriate Measures"@en ;
+    samm:properties (
+        [ samm:property :appropriateEngineeringControls ; samm:optional true ]
+        [ samm:property :productRelatedMeasures ; samm:optional true ]
+        [ samm:property :instructionalMeasures ; samm:optional true ]
+        [ samm:property :organisationalMeasures ; samm:optional true ]
+        [ samm:property :organisationalSigns ; samm:optional true ]
+        [ samm:property :technicalMeasures ; samm:optional true ]
+        [ samm:property :technicalSigns ; samm:optional true ]
+    ) .
+
+:ExposureControlPersonalProtection a samm:Entity ;
+    samm:preferredName "Exposure Control Personal Protection"@en ;
+    samm:description "SDS section 8."@en ;
+    samm:properties (
+        [ samm:property :preventiveIndustrialMedicalExaminationRequired ; samm:optional true ]
+        [ samm:property :controlParameters ; samm:optional true ]
+        [ samm:property :summaryRmMeasures ; samm:optional true ]
+        [ samm:property :exposureControlAppropriateMeasures ; samm:optional true ]
+        [ samm:property :personalProtectionEquipment ; samm:optional true ]
+        [ samm:property :environmentalExposureControls ; samm:optional true ]
+        [ samm:property :consumerExposureControl ; samm:optional true ]
+        [ samm:property :exposureControlsPersonalProtectionAdditionalInfo ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:ExposureGroup a samm:Entity ;
+    samm:preferredName "Exposure Group"@en ;
+    samm:properties (
+        :group
+        [ samm:property :groupFulltext ; samm:optional true ]
+    ) .
+
+:ExposureRoute a samm:Entity ;
+    samm:preferredName "Exposure Route"@en ;
+    samm:properties (
+        :route
+        [ samm:property :routeFulltext ; samm:optional true ]
+    ) .
+
+:ExposureRouteFrequencyAndEffect a samm:Entity ;
+    samm:preferredName "Exposure Route Frequency And Effect"@en ;
+    samm:properties (
+        :typeEffectLevelTypeEnum
+        [ samm:property :typeFulltext ; samm:optional true ]
+    ) .
+
+:ExposureScenario a samm:Entity ;
+    samm:preferredName "Exposure Scenario"@en ;
+    samm:properties (
+        [ samm:property :mixtureExposureScenarioInAnnex ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:ExtinguishingMedia a samm:Entity ;
+    samm:preferredName "Extinguishing Media"@en ;
+    samm:properties (
+        [ samm:property :mediaToBeUsed ; samm:optional true ]
+        [ samm:property :mediaNotBeUsed ; samm:optional true ]
+    ) .
+
+:EyeDamageOrIrritation a samm:Entity ;
+    samm:preferredName "Eye Damage Or Irritation"@en ;
+    samm:properties (
+        [ samm:property :eyeDamageOrIrritationTestResults ; samm:optional true ]
+        [ samm:property :eyeIrritation ; samm:optional true ]
+        [ samm:property :eyeCorrosivity ; samm:optional true ]
+        [ samm:property :eyeDamageOrIrritationHumanExperience ; samm:optional true ]
+        [ samm:property :assessmentEyeDamageOrIrritationClassification ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:EyeProtection a samm:Entity ;
+    samm:preferredName "Eye Protection"@en ;
+    samm:properties (
+        [ samm:property :requiredProperties ; samm:optional true ]
+        [ samm:property :suitableEyeProtection ; samm:optional true ]
+        [ samm:property :unsuitableEyeProtection ; samm:optional true ]
+        [ samm:property :eyeProtectionEquipment ; samm:optional true ]
+        [ samm:property :additionalEyeProtectionMeasures ; samm:optional true ]
+        [ samm:property :referenceRelevantStandard ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:Federal a samm:Entity ;
+    samm:preferredName "Federal"@en ;
+    samm:properties (
+        [ samm:property :rcraWasteCode ; samm:optional true ]
+        [ samm:property :hazardousWasteCharacteristics ; samm:optional true ]
+        [ samm:property :rcraBasisForListing ; samm:optional true ]
+    ) .
+
+:FireFightingMeasures a samm:Entity ;
+    samm:preferredName "Fire Fighting Measures"@en ;
+    samm:description "SDS section 5"@en ;
+    samm:properties (
+        [ samm:property :extinguishingMedia ; samm:optional true ]
+        [ samm:property :fireAndExplosionHazards ; samm:optional true ]
+        [ samm:property :hazardCombustionProd ; samm:optional true ]
+        [ samm:property :fireFightingPrecautions ; samm:optional true ]
+        [ samm:property :fireFightingProcedures ; samm:optional true ]
+        [ samm:property :specialProtectiveEquipmentForFirefighters ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:FirstAidMeasures a samm:Entity ;
+    samm:preferredName "First Aid Measures"@en ;
+    samm:description "SDS section 4"@en ;
+    samm:properties (
+        [ samm:property :descriptionOfFirstAidMeasures ; samm:optional true ]
+        [ samm:property :informationToHealthProfessionals ; samm:optional true ]
+        [ samm:property :medicalAttentionAndSpecialTreatmentNeeded ; samm:optional true ]
+        [ samm:property :specificFirstAidEquipment ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:FlammableAerosols a samm:Entity ;
+    samm:preferredName "Flammable Aerosols"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:FlammableGases a samm:Entity ;
+    samm:preferredName "Flammable Gases"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:FlammableLiquids a samm:Entity ;
+    samm:preferredName "Flammable Liquids"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:FlammableSolids a samm:Entity ;
+    samm:preferredName "Flammable Solids"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:FlashPoint a samm:Entity ;
+    samm:preferredName "Flash Point"@en ;
+    samm:description "FlashPoint source: Chapter 9"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :valuePhysChemUnitValue ; samm:optional true ]
+        [ samm:property :evaluationPhrase ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:ForNonEmergencyPersonnel a samm:Entity ;
+    samm:preferredName "For Non Emergency Personnel"@en ;
+    samm:properties (
+        [ samm:property :personalPrecautions ; samm:optional true ]
+        [ samm:property :protectiveEquipment ; samm:optional true ]
+        [ samm:property :emergencyProcedures ; samm:optional true ]
+    ) .
+
+:FurtherEcologicalData a samm:Entity ;
+    samm:preferredName "Further Ecological Data"@en ;
+    samm:description "FurtherEcologicalData, source: Chapter 12"@en ;
+    samm:properties (
+        :valuePhysChemUnitValueWithTemperature
+        [ samm:property :concentration ; samm:optional true ]
+        [ samm:property :testDuration ; samm:optional true ]
+    ) .
+
+:GasGroup a samm:Entity ;
+    samm:preferredName "Gas Group"@en ;
+    samm:description "GasGroup. Source: Chapter 9."@en ;
+    samm:properties (
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :source ; samm:optional true ]
+        [ samm:property :testResults ; samm:optional true ]
+        [ samm:property :evaluationGasGroupEnum ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:GasesUnderPressure a samm:Entity ;
+    samm:preferredName "Gases Under Pressure"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:GbClpHazardClassification2020 a samm:Entity ;
+    samm:preferredName "Gb Clp Hazard Classification2020"@en ;
+    samm:properties (
+        [ samm:property :classification ; samm:optional true ]
+        [ samm:property :multiplyingFactor ; samm:optional true ]
+        [ samm:property :specificConcLimit ; samm:optional true ]
+        [ samm:property :unknownToxicity ; samm:optional true ]
+        [ samm:property :ate ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+        [ samm:property :supplementalHazardInformation ; samm:optional true ]
+        [ samm:property :classificationNotes ; samm:optional true ]
+    ) .
+
+:GbClpHazardLabelling2020 a samm:Entity ;
+    samm:preferredName "Gb Clp Hazard Labelling2020"@en ;
+    samm:properties (
+        [ samm:property :hazardPictogram ; samm:optional true ]
+        [ samm:property :signalWord ; samm:optional true ]
+        [ samm:property :hazardStatement ; samm:optional true ]
+        [ samm:property :precautionaryStatement ; samm:optional true ]
+        [ samm:property :supplementalHazardInformation ; samm:optional true ]
+        [ samm:property :specialSupplementalLabelInfoMixtures ; samm:optional true ]
+        [ samm:property :additionalLabellingInfo ; samm:optional true ]
+        [ samm:property :specialRulesOnPackaging ; samm:optional true ]
+        [ samm:property :tactileWarning ; samm:optional true ]
+        [ samm:property :childResistantOpening ; samm:optional true ]
+    ) .
+
+:GeneralDescription a samm:Entity ;
+    samm:preferredName "General Description"@en ;
+    samm:properties (
+        [ samm:property :useDescriptors ; samm:optional true ]
+        [ samm:property :swedReference ; samm:optional true ]
+        [ samm:property :text ; samm:optional true ]
+    ) .
+
+:GermCellMutagenicity a samm:Entity ;
+    samm:preferredName "Germ Cell Mutagenicity"@en ;
+    samm:properties (
+        [ samm:property :testResults ; samm:optional true ]
+        [ samm:property :germCellMutagenicityHumanExperience ; samm:optional true ]
+        [ samm:property :assessmentGermCellMutagenicityClassification ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:Ghs03HazardStatementUs a samm:Entity ;
+    samm:preferredName "Ghs03Hazard Statement Us"@en ;
+    samm:description "GHS Hazard Statement. Contrary to the type Ghs03HazardStatement used in other regions, the phrase code is optional here because additional US hazard statements come without a code."@en ;
+    samm:properties (
+        [ samm:property :phraseCodeGhs03HazardEnum ; samm:optional true ]
+        [ samm:property :fullText ; samm:optional true ]
+        [ samm:property :mergePhrase ; samm:optional true ]
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+    ) .
+
+:Ghs03PrecautionaryStatement a samm:Entity ;
+    samm:preferredName "Ghs03Precautionary Statement"@en ;
+    samm:description "GHS Precautionary Statement"@en ;
+    samm:properties (
+        :phraseCodeGhs03PrecautionEnum
+        :fullText
+        [ samm:property :mergePhrase ; samm:optional true ]
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+    ) .
+
+:Ghs05HazardStatement a samm:Entity ;
+    samm:preferredName "Ghs05Hazard Statement"@en ;
+    samm:description "GHS Hazard Statement. Note that Systems may export PhraseCode only, without FullText or PhraseId, if used for applications like workplace safety lists."@en ;
+    samm:properties (
+        :phraseCodeGhs05HazardEnum
+        [ samm:property :fullText ; samm:optional true ]
+        [ samm:property :mergePhrase ; samm:optional true ]
+        [ samm:property :organ ; samm:optional true ]
+        [ samm:property :exposureRoutePhrase ; samm:optional true ]
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+    ) .
+
+:Ghs05PrecautionaryStatement a samm:Entity ;
+    samm:preferredName "Ghs05Precautionary Statement"@en ;
+    samm:description "GHS Precautionary Statement"@en ;
+    samm:properties (
+        :phraseCodeGhs05PrecautionEnum
+        :fullText
+        [ samm:property :mergePhrase ; samm:optional true ]
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+    ) .
+
+:Ghs07HazardStatement a samm:Entity ;
+    samm:preferredName "Ghs07Hazard Statement"@en ;
+    samm:description "GHS Hazard Statement. Note that Systems may export PhraseCode only, without FullText or PhraseId, if used for applications like workplace safety lists."@en ;
+    samm:properties (
+        :phraseCodeGhs07HazardEnum
+        [ samm:property :fullText ; samm:optional true ]
+        [ samm:property :mergePhrase ; samm:optional true ]
+        [ samm:property :organ ; samm:optional true ]
+        [ samm:property :exposureRoutePhrase ; samm:optional true ]
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+    ) .
+
+:Ghs07PrecautionaryStatement a samm:Entity ;
+    samm:preferredName "Ghs07Precautionary Statement"@en ;
+    samm:description "GHS Precautionary Statement"@en ;
+    samm:properties (
+        :phraseCodeGhs07PrecautionEnum
+        :fullText
+        [ samm:property :mergePhrase ; samm:optional true ]
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+    ) .
+
+:GhsSignalWord a samm:Entity ;
+    samm:preferredName "Ghs Signal Word"@en ;
+    samm:description "GHS Signal Word, ie. danger or warning."@en ;
+    samm:properties (
+        :phraseCodeGhsSignalWordEnum
+        [ samm:property :fullText ; samm:optional true ]
+        [ samm:property :mergePhrase ; samm:optional true ]
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+    ) .
+
+:GoodPracticeAdvice a samm:Entity ;
+    samm:preferredName "Good Practice Advice"@en ;
+    samm:properties (
+        [ samm:property :text ; samm:optional true ]
+        [ samm:property :agpaPictogram ; samm:optional true ]
+    ) .
+
+:HandProtection a samm:Entity ;
+    samm:preferredName "Hand Protection"@en ;
+    samm:properties (
+        [ samm:property :skinHandProtectionShortTermContact ; samm:optional true ]
+        [ samm:property :skinHandProtectionLongTermContact ; samm:optional true ]
+        [ samm:property :unsuitableMaterials ; samm:optional true ]
+        [ samm:property :handProtectionNecessaryProperties ; samm:optional true ]
+        [ samm:property :equipment ; samm:optional true ]
+        [ samm:property :additionalHandProtectionMeasures ; samm:optional true ]
+        [ samm:property :referenceRelevantStandard ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:HandlingAndStorage a samm:Entity ;
+    samm:preferredName "Handling And Storage"@en ;
+    samm:description "SDS section 7"@en ;
+    samm:properties (
+        [ samm:property :safeHandling ; samm:optional true ]
+        [ samm:property :storagePrecautions ; samm:optional true ]
+        [ samm:property :conditionsToAvoid ; samm:optional true ]
+        [ samm:property :conditionsForSafeStorage ; samm:optional true ]
+        [ samm:property :specificEndUses ; samm:optional true ]
+    ) .
+
+:HazardIdentification a samm:Entity ;
+    samm:preferredName "Hazard Identification"@en ;
+    samm:description "SDS section 2"@en ;
+    samm:properties (
+        [ samm:property :regionAr ; samm:optional true ]
+        [ samm:property :regionBr ; samm:optional true ]
+        [ samm:property :regionCa ; samm:optional true ]
+        [ samm:property :regionEu ; samm:optional true ]
+        [ samm:property :regionGb ; samm:optional true ]
+        [ samm:property :regionMx ; samm:optional true ]
+        [ samm:property :regionTr ; samm:optional true ]
+        [ samm:property :regionUs ; samm:optional true ]
+    ) .
+
+:HazardLabellingAr a samm:Entity ;
+    samm:preferredName "Hazard Labelling Ar"@en ;
+    samm:properties ( [ samm:property :srt2015HazardLabelling ; samm:optional true ] ) .
+
+:HazardLabellingBr a samm:Entity ;
+    samm:preferredName "Hazard Labelling Br"@en ;
+    samm:properties ( [ samm:property :abntNrb2017HazardLabelling ; samm:optional true ] ) .
+
+:HazardLabellingCa a samm:Entity ;
+    samm:preferredName "Hazard Labelling Ca"@en ;
+    samm:properties ( ) .
+
+:HazardLabellingGb a samm:Entity ;
+    samm:preferredName "Hazard Labelling Gb"@en ;
+    samm:properties ( [ samm:property :gbClpHazardLabelling2020 ; samm:optional true ] ) .
+
+:HazardLabellingMx a samm:Entity ;
+    samm:preferredName "Hazard Labelling Mx"@en ;
+    samm:properties ( [ samm:property :nom2015HazardLabelling ; samm:optional true ] ) .
+
+:HazardLabellingTr a samm:Entity ;
+    samm:preferredName "Hazard Labelling Tr"@en ;
+    samm:properties ( [ samm:property :seaHazardLabelling2021 ; samm:optional true ] ) .
+
+:HazardLabellingUs a samm:Entity ;
+    samm:preferredName "Hazard Labelling Us"@en ;
+    samm:properties (
+        [ samm:property :hazcom2012HazardLabelling ; samm:optional true ]
+        [ samm:property :labellingAccordingToOtherLegislation ; samm:optional true ]
+    ) .
+
+:Hazcom2012HazardClassification a samm:Entity ;
+    samm:preferredName "Hazcom2012Hazard Classification"@en ;
+    samm:properties (
+        :hazardClassCategory
+        :hazardClassCategoryPrintable
+        [ samm:property :organ ; samm:optional true ]
+        [ samm:property :exposureRoutePhrase ; samm:optional true ]
+        [ samm:property :classificationProcedure ; samm:optional true ]
+        [ samm:property :unknownToxicity ; samm:optional true ]
+        [ samm:property :ate ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+    ) .
+
+:Hazcom2012HazardLabelling a samm:Entity ;
+    samm:preferredName "Hazcom2012Hazard Labelling"@en ;
+    samm:properties (
+        [ samm:property :hazardPictogram ; samm:optional true ]
+        [ samm:property :signalWord ; samm:optional true ]
+        [ samm:property :hazardStatement ; samm:optional true ]
+        [ samm:property :precautionaryStatement ; samm:optional true ]
+        [ samm:property :additionalLabellingInfo ; samm:optional true ]
+        [ samm:property :tactileWarning ; samm:optional true ]
+        [ samm:property :childResistantOpening ; samm:optional true ]
+    ) .
+
+:HumanExperience a samm:Entity ;
+    samm:preferredName "Human Experience"@en ;
+    samm:properties (
+        [ samm:property :respiratorySensitisationHumanExperience ; samm:optional true ]
+        [ samm:property :skinSensitisationHumanExperience ; samm:optional true ]
+    ) .
+
+:HydrolysisRate a samm:Entity ;
+    samm:preferredName "Hydrolysis Rate"@en ;
+    samm:description "HydrolysisRate source: Chapter 9"@en ;
+    samm:properties (
+        [ samm:property :valuePhysChemValueWithTemperature ; samm:optional true ]
+        [ samm:property :concentration ; samm:optional true ]
+        [ samm:property :phValue ; samm:optional true ]
+    ) .
+
+:IataDgr a samm:Entity ;
+    samm:preferredName "Iata Dgr"@en ;
+    samm:properties (
+        [ samm:property :unNo ; samm:optional true ]
+        [ samm:property :properShippingNameEnglish ; samm:optional true ]
+        [ samm:property :dangerReleasingSubstanceEnglish ; samm:optional true ]
+        [ samm:property :classTransportClassEnum ; samm:optional true ]
+        [ samm:property :subsidiaryRisk ; samm:optional true ]
+        [ samm:property :hazardLabelEnglish ; samm:optional true ]
+        [ samm:property :packingGroup ; samm:optional true ]
+        [ samm:property :otherInformation ; samm:optional true ]
+    ) .
+
+:IdentificationSubstPrep a samm:Entity ;
+    samm:preferredName "Identification Subst Prep"@en ;
+    samm:description "SDS section 1"@en ;
+    samm:properties (
+        [ samm:property :specificationNo ; samm:optional true ]
+        :tradeProductIdentity
+        [ samm:property :targetGroup ; samm:optional true ]
+        [ samm:property :use ; samm:optional true ]
+        [ samm:property :useAdvisedAgainst ; samm:optional true ]
+        [ samm:property :regionCaSdsSupplierInfo ; samm:optional true ]
+        [ samm:property :regionEuSdsSupplierInfoEu ; samm:optional true ]
+        [ samm:property :regionUsSdsSupplierInfo ; samm:optional true ]
+    ) .
+
+:IdentifiedUse a samm:Entity ;
+    samm:preferredName "Identified Use"@en ;
+    samm:properties (
+        [ samm:property :sectorOfUse ; samm:optional true ]
+        [ samm:property :productCategory ; samm:optional true ]
+        [ samm:property :processCategory ; samm:optional true ]
+        [ samm:property :environmentalReleaseCategory ; samm:optional true ]
+        [ samm:property :specificEnvironmentalReleaseCategory ; samm:optional true ]
+        [ samm:property :articleCategoryNoIntendedRelease ; samm:optional true ]
+        [ samm:property :articleCategoryWithIntendedRelease ; samm:optional true ]
+        [ samm:property :correspondingExposureScenario ; samm:optional true ]
+        [ samm:property :identifiedUseId ; samm:optional true ]
+        [ samm:property :printAsAttachment ; samm:optional true ]
+    ) .
+
+:Imdg a samm:Entity ;
+    samm:preferredName "Imdg"@en ;
+    samm:properties (
+        [ samm:property :unNo ; samm:optional true ]
+        [ samm:property :properShippingNameEnglish ; samm:optional true ]
+        [ samm:property :dangerReleasingSubstanceEnglish ; samm:optional true ]
+        [ samm:property :classTransportClassEnum ; samm:optional true ]
+        [ samm:property :subsidiaryRisk ; samm:optional true ]
+        [ samm:property :packingGroup ; samm:optional true ]
+        [ samm:property :marinePollutant ; samm:optional true ]
+        [ samm:property :otherInformation ; samm:optional true ]
+    ) .
+
+:IndustrialEmissions a samm:Entity ;
+    samm:preferredName "Industrial Emissions"@en ;
+    samm:properties (
+        [ samm:property :vocInPercentByWeight ; samm:optional true ]
+        [ samm:property :vocValue ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:InformationFromExportingSystem a samm:Entity ;
+    samm:preferredName "Information From Exporting System"@en ;
+    samm:properties (
+        :sdscomVersionNo
+        [ samm:property :sdscomSubset ; samm:optional true ]
+        [ samm:property :phraseCatalogue ; samm:optional true ]
+        :language
+        :regulationsRelatedToCountryOrRegion
+        :systemUsedInPreparation
+        :dateGeneratedExport
+    ) .
+
+:InformationToHealthProfessionals a samm:Entity ;
+    samm:preferredName "Information To Health Professionals"@en ;
+    samm:properties (
+        [ samm:property :symptomsAndEffectsGeneral ; samm:optional true ]
+        [ samm:property :acuteSymptomsAndEffects ; samm:optional true ]
+        [ samm:property :delayedSymptomsAndEffects ; samm:optional true ]
+    ) .
+
+:InvestigationMethod a samm:Entity ;
+    samm:preferredName "Investigation Method"@en ;
+    samm:properties (
+        :methodInvestigationMethodEnum
+        [ samm:property :methodFulltext ; samm:optional true ]
+    ) .
+
+:LabellingAccordingToOtherLegislation a samm:Entity ;
+    samm:preferredName "Labelling According To Other Legislation"@en ;
+    samm:properties (
+        [ samm:property :vocLabelling ; samm:optional true ]
+        [ samm:property :detergentLabelling ; samm:optional true ]
+        [ samm:property :aerosolLabelling ; samm:optional true ]
+        [ samm:property :otherEuLabellingRequirements ; samm:optional true ]
+    ) .
+
+:Language a samm:Entity ;
+    samm:preferredName "Language"@en ;
+    samm:properties (
+        :freetextLanguageCode
+        [ samm:property :freetextLanguageCountryCode ; samm:optional true ]
+        [ samm:property :freetextLanguageName ; samm:optional true ]
+    ) .
+
+:LegalDocument a samm:Entity ;
+    samm:preferredName "Legal Document"@en ;
+    samm:properties (
+        :legalDocumentFileName
+        [ samm:property :legalDocumentPrintDate ; samm:optional true ]
+        [ samm:property :legalDocumentSignature ; samm:optional true ]
+        [ samm:property :internalSdsId ; samm:optional true ]
+    ) .
+
+:MajorAccidentsOrdinance a samm:Entity ;
+    samm:preferredName "Major Accidents Ordinance"@en ;
+    samm:properties (
+        [ samm:property :healthHazardThreshold ; samm:optional true ]
+        [ samm:property :physicalHazardThreshold ; samm:optional true ]
+        [ samm:property :environmantalHazardThreshold ; samm:optional true ]
+        [ samm:property :otherHazardThreshold ; samm:optional true ]
+    ) .
+
+:MedicalAttentionAndSpecialTreatmentNeeded a samm:Entity ;
+    samm:preferredName "Medical Attention And Special Treatment Needed"@en ;
+    samm:properties (
+        [ samm:property :medicalTreatment ; samm:optional true ]
+        [ samm:property :requiredClinicalTesting ; samm:optional true ]
+        [ samm:property :requiredMedicalMonitoring ; samm:optional true ]
+        [ samm:property :specificAntidotes ; samm:optional true ]
+        [ samm:property :contraindications ; samm:optional true ]
+    ) .
+
+:MeltingPointRelated a samm:Entity ;
+    samm:preferredName "Melting Point Related"@en ;
+    samm:properties (
+        [ samm:property :meltingPoint ; samm:optional true ]
+        [ samm:property :freezingPoint ; samm:optional true ]
+        [ samm:property :softeningPoint ; samm:optional true ]
+        [ samm:property :solidificationPoint ; samm:optional true ]
+        [ samm:property :cloudPoint ; samm:optional true ]
+        [ samm:property :crystallisationPoint ; samm:optional true ]
+        [ samm:property :droppingPoint ; samm:optional true ]
+        [ samm:property :pourPoint ; samm:optional true ]
+    ) .
+
+:MergePhrase a samm:Entity ;
+    samm:preferredName "Merge Phrase"@en ;
+    samm:description "Phrase, using references to a coordination body assigning ids to all phrases. Ids have precedence over textual phrase values if both are present. Note the use of MergePhrase restricts the nesting depth to one level."@en ;
+    samm:properties (
+        [ samm:property :mergeText ; samm:optional true ]
+        [ samm:property :delimiter ; samm:optional true ]
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+        [ samm:property :mergePhraseNo ; samm:optional true ]
+        [ samm:property :listItemNo ; samm:optional true ]
+    ) .
+
+:Mobility a samm:Entity ;
+    samm:preferredName "Mobility"@en ;
+    samm:properties (
+        [ samm:property :distribution ; samm:optional true ]
+        [ samm:property :transportType ; samm:optional true ]
+        [ samm:property :result ; samm:optional true ]
+        [ samm:property :source ; samm:optional true ]
+        [ samm:property :mobilityEvaluation ; samm:optional true ]
+    ) .
+
+:MultiplyingFactor a samm:Entity ;
+    samm:preferredName "Multiplying Factor"@en ;
+    samm:properties (
+        [ samm:property :acute ; samm:optional true ]
+        [ samm:property :chronic ; samm:optional true ]
+    ) .
+
+:NationalLegislation a samm:Entity ;
+    samm:preferredName "National Legislation"@en ;
+    samm:properties (
+        [ samm:property :nationalLegislationAndorra ; samm:optional true ]
+        [ samm:property :nationalLegislationAlbania ; samm:optional true ]
+        [ samm:property :nationalLegislationAustria ; samm:optional true ]
+        [ samm:property :nationalLegislationBosniaAndHerzegovina ; samm:optional true ]
+        [ samm:property :nationalLegislationBelgium ; samm:optional true ]
+        [ samm:property :nationalLegislationBulgaria ; samm:optional true ]
+        [ samm:property :nationalLegislationSwitzerland ; samm:optional true ]
+        [ samm:property :nationalLegislationCyprus ; samm:optional true ]
+        [ samm:property :nationalLegislationCzechRepublic ; samm:optional true ]
+        [ samm:property :nationalLegislationGermany ; samm:optional true ]
+        [ samm:property :nationalLegislationDenmark ; samm:optional true ]
+        [ samm:property :nationalLegislationEstonia ; samm:optional true ]
+        [ samm:property :nationalLegislationSpain ; samm:optional true ]
+        [ samm:property :nationalLegislationFinland ; samm:optional true ]
+        [ samm:property :nationalLegislationFrance ; samm:optional true ]
+        [ samm:property :nationalLegislationUnitedKingdom ; samm:optional true ]
+        [ samm:property :nationalLegislationGreece ; samm:optional true ]
+        [ samm:property :nationalLegislationCroatia ; samm:optional true ]
+        [ samm:property :nationalLegislationHungary ; samm:optional true ]
+        [ samm:property :nationalLegislationIreland ; samm:optional true ]
+        [ samm:property :nationalLegislationIceland ; samm:optional true ]
+        [ samm:property :nationalLegislationItaly ; samm:optional true ]
+        [ samm:property :nationalLegislationLiechtenstein ; samm:optional true ]
+        [ samm:property :nationalLegislationLithuania ; samm:optional true ]
+        [ samm:property :nationalLegislationLuxembourg ; samm:optional true ]
+        [ samm:property :nationalLegislationLatvia ; samm:optional true ]
+        [ samm:property :nationalLegislationMonaco ; samm:optional true ]
+        [ samm:property :nationalLegislationMontenegro ; samm:optional true ]
+        [ samm:property :nationalLegislationNorthMacedonia ; samm:optional true ]
+        [ samm:property :nationalLegislationMalta ; samm:optional true ]
+        [ samm:property :nationalLegislationNetherlands ; samm:optional true ]
+        [ samm:property :nationalLegislationNorway ; samm:optional true ]
+        [ samm:property :nationalLegislationPoland ; samm:optional true ]
+        [ samm:property :nationalLegislationPortugal ; samm:optional true ]
+        [ samm:property :nationalLegislationRomania ; samm:optional true ]
+        [ samm:property :nationalLegislationSerbia ; samm:optional true ]
+        [ samm:property :nationalLegislationSweden ; samm:optional true ]
+        [ samm:property :nationalLegislationSlovenia ; samm:optional true ]
+        [ samm:property :nationalLegislationSlovakia ; samm:optional true ]
+        [ samm:property :nationalLegislationSanMarino ; samm:optional true ]
+        [ samm:property :nationalLegislationUkraine ; samm:optional true ]
+        [ samm:property :nationalLegislationVaticanCityState ; samm:optional true ]
+    ) .
+
+:NationalWasteLegislationCh a samm:Entity ;
+    samm:preferredName "National Waste Legislation Ch"@en ;
+    samm:description "NationalWasteLegislation Switzerland"@en ;
+    samm:properties (
+        [ samm:property :wasteCodeWasteCode ; samm:optional true ]
+        [ samm:property :text ; samm:optional true ]
+        [ samm:property :remark ; samm:optional true ]
+    ) .
+
+:NationalWasteLegislationDe a samm:Entity ;
+    samm:preferredName "National Waste Legislation De"@en ;
+    samm:description "NationalWasteLegislationDE"@en ;
+    samm:properties (
+        [ samm:property :wasteCodePhrase ; samm:optional true ]
+        [ samm:property :wasteRegulations ; samm:optional true ]
+    ) .
+
+:NationalWasteLegislationNo a samm:Entity ;
+    samm:preferredName "National Waste Legislation No"@en ;
+    samm:properties (
+        [ samm:property :nationalWasteCode ; samm:optional true ]
+        [ samm:property :nationalRegulations ; samm:optional true ]
+    ) .
+
+:Nom2015HazardClassification a samm:Entity ;
+    samm:preferredName "Nom2015Hazard Classification"@en ;
+    samm:properties (
+        :hazardClassCategory
+        :hazardClassCategoryPrintable
+        [ samm:property :organ ; samm:optional true ]
+        [ samm:property :exposureRoutePhrase ; samm:optional true ]
+        [ samm:property :classificationProcedure ; samm:optional true ]
+        [ samm:property :unknownToxicity ; samm:optional true ]
+        [ samm:property :ate ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+    ) .
+
+:Nom2015HazardLabelling a samm:Entity ;
+    samm:preferredName "Nom2015Hazard Labelling"@en ;
+    samm:properties (
+        [ samm:property :hazardPictogram ; samm:optional true ]
+        [ samm:property :signalWord ; samm:optional true ]
+        [ samm:property :hazardStatement ; samm:optional true ]
+        [ samm:property :precautionaryStatement ; samm:optional true ]
+        [ samm:property :additionalLabellingInfo ; samm:optional true ]
+    ) .
+
+:NonHumanToxicologicalData a samm:Entity ;
+    samm:preferredName "Non Human Toxicological Data"@en ;
+    samm:properties (
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :speciesSpecies ; samm:optional true ]
+        :dose
+        [ samm:property :exposureRouteExposureRoute ; samm:optional true ]
+        [ samm:property :results ; samm:optional true ]
+    ) .
+
+:NumericRangeWithQualifier a samm:Entity ;
+    samm:preferredName "Numeric Range With Qualifier"@en ;
+    samm:description "eSDScom type NumericRangeWithQualifier (internal structure not expanded)."@en ;
+    samm:properties ( ) .
+
+:NumericRangeWithUnitAndQualifier a samm:Entity ;
+    samm:preferredName "Numeric Range With Unit And Qualifier"@en ;
+    samm:description "eSDScom type NumericRangeWithUnitAndQualifier (internal structure not expanded)."@en ;
+    samm:properties ( ) .
+
+:NumericValue a samm:Entity ;
+    samm:preferredName "Numeric Value"@en ;
+    samm:properties ( :exactValue ) .
+
+:NumericValueWithUnit a samm:Entity ;
+    samm:preferredName "Numeric Value With Unit"@en ;
+    samm:properties ( :exactValue ) .
+
+:NumericValueWithUnitAndQualifier a samm:Entity ;
+    samm:preferredName "Numeric Value With Unit And Qualifier"@en ;
+    samm:properties (
+        [ samm:property :exactValueSymbol ; samm:optional true ]
+        :exactValue
+    ) .
+
+:OccupationalAirRequirementNo a samm:Entity ;
+    samm:preferredName "Occupational Air Requirement No"@en ;
+    samm:properties (
+        [ samm:property :oarGroup ; samm:optional true ]
+        [ samm:property :oarValue ; samm:optional true ]
+    ) .
+
+:OccupationalExposureLimit a samm:Entity ;
+    samm:preferredName "Occupational Exposure Limit"@en ;
+    samm:description "see Github issue #116 regarding multiple limit values"@en ;
+    samm:properties (
+        [ samm:property :limitValueTypeWithCountryOrOrganisation ; samm:optional true ]
+        [ samm:property :limit8H ; samm:optional true ]
+        [ samm:property :limitShortTerm ; samm:optional true ]
+        [ samm:property :peakLimitation ; samm:optional true ]
+        [ samm:property :recommendedMonitoringProcedure ; samm:optional true ]
+        [ samm:property :particleFraction ; samm:optional true ]
+        [ samm:property :reference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:OccupationalExposureLimits a samm:Entity ;
+    samm:preferredName "Occupational Exposure Limits"@en ;
+    samm:properties (
+        [ samm:property :occupationalExposureLimit ; samm:optional true ]
+        [ samm:property :intendedUseOccupationalExposureLimit ; samm:optional true ]
+    ) .
+
+:OperationalConditions a samm:Entity ;
+    samm:preferredName "Operational Conditions"@en ;
+    samm:properties (
+        [ samm:property :properties ; samm:optional true ]
+        [ samm:property :text ; samm:optional true ]
+    ) .
+
+:OrganicPeroxides a samm:Entity ;
+    samm:preferredName "Organic Peroxides"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:OtherAdverseEffects a samm:Entity ;
+    samm:preferredName "Other Adverse Effects"@en ;
+    samm:properties (
+        [ samm:property :ozoneDepletionPotential ; samm:optional true ]
+        [ samm:property :photochemicalOzoneCreationPotential ; samm:optional true ]
+        [ samm:property :globalWarmingPotential ; samm:optional true ]
+        [ samm:property :atmosphericLifetime ; samm:optional true ]
+        [ samm:property :endocrineDisruptingPotential ; samm:optional true ]
+    ) .
+
+:OtherHazardsInfo a samm:Entity ;
+    samm:preferredName "Other Hazards Info"@en ;
+    samm:properties (
+        [ samm:property :hazardDescriptionGeneral ; samm:optional true ]
+        [ samm:property :physicochemicalEffect ; samm:optional true ]
+        [ samm:property :healthEffect ; samm:optional true ]
+        [ samm:property :environmentalEffect ; samm:optional true ]
+        [ samm:property :effectsOfMisuse ; samm:optional true ]
+        [ samm:property :otherHazardsPhrase ; samm:optional true ]
+    ) .
+
+:OtherInformation a samm:Entity ;
+    samm:preferredName "Other Information"@en ;
+    samm:properties (
+        [ samm:property :limitedQty ; samm:optional true ]
+        [ samm:property :exceptedQty ; samm:optional true ]
+        [ samm:property :specialProvisions ; samm:optional true ]
+        [ samm:property :emsCode ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:OtherSafetyInformation a samm:Entity ;
+    samm:preferredName "Other Safety Information"@en ;
+    samm:properties (
+        [ samm:property :miscibility ; samm:optional true ]
+        [ samm:property :anilinePoint ; samm:optional true ]
+        [ samm:property :electricConductivity ; samm:optional true ]
+        [ samm:property :gasGroup ; samm:optional true ]
+        [ samm:property :solventSeparationTest ; samm:optional true ]
+        [ samm:property :contentOfVoc ; samm:optional true ]
+        [ samm:property :solidContent ; samm:optional true ]
+        [ samm:property :propellantContent ; samm:optional true ]
+        [ samm:property :sinterTemperature ; samm:optional true ]
+        [ samm:property :acidNo ; samm:optional true ]
+        [ samm:property :dissociationConstant ; samm:optional true ]
+        [ samm:property :hydrolysisRate ; samm:optional true ]
+        [ samm:property :waterReactive ; samm:optional true ]
+        [ samm:property :airReactive ; samm:optional true ]
+        [ samm:property :penetrationNo ; samm:optional true ]
+        [ samm:property :particleSize ; samm:optional true ]
+        [ samm:property :criticalPressure ; samm:optional true ]
+        [ samm:property :expansionCoefficient ; samm:optional true ]
+        [ samm:property :redoxPotential ; samm:optional true ]
+        [ samm:property :radicalFormationPotential ; samm:optional true ]
+        [ samm:property :photocatalyticProperties ; samm:optional true ]
+        [ samm:property :numberAverageMolecularWeight ; samm:optional true ]
+        [ samm:property :weightAverageMolecularWeight ; samm:optional true ]
+        [ samm:property :molecularWeightDistribution ; samm:optional true ]
+        [ samm:property :lowMolecularWeightContentOfPolymers ; samm:optional true ]
+        [ samm:property :solutionExtractionBehaviourOfPolymersInWater ; samm:optional true ]
+        [ samm:property :refractionIndex ; samm:optional true ]
+        [ samm:property :surfaceTension ; samm:optional true ]
+    ) .
+
+:OxidisingGases a samm:Entity ;
+    samm:preferredName "Oxidising Gases"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:OxidisingLiquids a samm:Entity ;
+    samm:preferredName "Oxidising Liquids"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:OxidisingSolids a samm:Entity ;
+    samm:preferredName "Oxidising Solids"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:Packaging a samm:Entity ;
+    samm:preferredName "Packaging"@en ;
+    samm:properties (
+        [ samm:property :packagingType ; samm:optional true ]
+        [ samm:property :packagingTypeDescription ; samm:optional true ]
+        [ samm:property :packagingSize ; samm:optional true ]
+        [ samm:property :packagingMaterial ; samm:optional true ]
+        [ samm:property :packagingMaterialDescription ; samm:optional true ]
+    ) .
+
+:ParticleFraction a samm:Entity ;
+    samm:preferredName "Particle Fraction"@en ;
+    samm:properties (
+        :particleFraction
+        [ samm:property :particleFractionFulltext ; samm:optional true ]
+    ) .
+
+:PartitionCoefficient a samm:Entity ;
+    samm:preferredName "Partition Coefficient"@en ;
+    samm:description "PartitionCoefficient n-octanol/water (log P O/W) source: Chapter 9, 12"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :valuePhysChemUnitValueWithTemperature ; samm:optional true ]
+        [ samm:property :ph ; samm:optional true ]
+    ) .
+
+:PeakLimitation a samm:Entity ;
+    samm:preferredName "Peak Limitation"@en ;
+    samm:properties (
+        [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
+        [ samm:property :peakLimitationOverflowFactor ; samm:optional true ]
+    ) .
+
+:PercentageRange a samm:Entity ;
+    samm:preferredName "Percentage Range"@en ;
+    samm:description "Basically a numeric range with a fixed unit \"%\""@en ;
+    samm:properties (
+        [ samm:property :exactValueSymbol ; samm:optional true ]
+        [ samm:property :exactValue ; samm:optional true ]
+        [ samm:property :upperValueSymbol ; samm:optional true ]
+        [ samm:property :upperValue ; samm:optional true ]
+        [ samm:property :lowerValueSymbol ; samm:optional true ]
+        [ samm:property :lowerValue ; samm:optional true ]
+    ) .
+
+:PersistenceDegradability a samm:Entity ;
+    samm:preferredName "Persistence Degradability"@en ;
+    samm:properties (
+        [ samm:property :biologicalDegradability ; samm:optional true ]
+        [ samm:property :abioticDegradation ; samm:optional true ]
+        [ samm:property :persistenceDegradabilityEvaluation ; samm:optional true ]
+    ) .
+
+:PersonalProtectionEquipment a samm:Entity ;
+    samm:preferredName "Personal Protection Equipment"@en ;
+    samm:properties (
+        [ samm:property :respiratoryProtection ; samm:optional true ]
+        [ samm:property :eyeProtection ; samm:optional true ]
+        [ samm:property :handProtection ; samm:optional true ]
+        [ samm:property :skinProtection ; samm:optional true ]
+        [ samm:property :thermalHazardsProtection ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+        [ samm:property :specificHygieneMeasures ; samm:optional true ]
+        [ samm:property :safetySigns ; samm:optional true ]
+    ) .
+
+:PhValue a samm:Entity ;
+    samm:preferredName "Ph Value"@en ;
+    samm:description "PhValue source: Chapter 9"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :state ; samm:optional true ]
+        [ samm:property :valuePhysChemValueWithTemperature ; samm:optional true ]
+        [ samm:property :concentration ; samm:optional true ]
+        [ samm:property :phNotRelevant ; samm:optional true ]
+    ) .
+
+:Phototoxicity a samm:Entity ;
+    samm:preferredName "Phototoxicity"@en ;
+    samm:properties (
+        [ samm:property :phototoxicityTestResults ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:PhototoxicityTestResults a samm:Entity ;
+    samm:preferredName "Phototoxicity Test Results"@en ;
+    samm:properties (
+        :investigationMethod
+        [ samm:property :testMethod ; samm:optional true ]
+        [ samm:property :dose ; samm:optional true ]
+        :exposureRouteExposureRoute
+        [ samm:property :testDuration ; samm:optional true ]
+        :results
+        [ samm:property :speciesSpecies ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:Phrase a samm:Entity ;
+    samm:preferredName "Phrase"@en ;
+    samm:description "eSDScom type Phrase (internal structure not expanded)."@en ;
+    samm:properties ( ) .
+
+:PhraseCatalogue a samm:Entity ;
+    samm:preferredName "Phrase Catalogue"@en ;
+    samm:description "Catalogue of standard phrases used in the datasheet. Used in chapter 0 and referred in for example exposure scenarios. PhraseCatalogues and PhraseIds simplifies translation to other languages. Example: EUPhraC catalogue."@en ;
+    samm:properties (
+        [ samm:property :phraseCatalogueName ; samm:optional true ]
+        [ samm:property :phraseCatalogueIssuer ; samm:optional true ]
+        [ samm:property :phraseCatalogueVersion ; samm:optional true ]
+        :phraseCatalogueDate
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+    ) .
+
+:PhysChemUnitValue a samm:Entity ;
+    samm:preferredName "Phys Chem Unit Value"@en ;
+    samm:description "PhysChemUnitValue, used to specify a value with unit derived from a duration-independent measurement."@en ;
+    samm:properties (
+        [ samm:property :unitValue ; samm:optional true ]
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :reasonForWaiving ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:PhysChemUnitValueWithTemperature a samm:Entity ;
+    samm:preferredName "Phys Chem Unit Value With Temperature"@en ;
+    samm:description "eSDScom type PhysChemUnitValueWithTemperature (internal structure not expanded)."@en ;
+    samm:properties ( ) .
+
+:PhysChemValue a samm:Entity ;
+    samm:preferredName "Phys Chem Value"@en ;
+    samm:description "PhysChemValue, used to specify a value derived from a duration-independent measurement."@en ;
+    samm:properties (
+        [ samm:property :valueNumericRangeWithQualifier ; samm:optional true ]
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :reasonForWaiving ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:PhysChemValueWithTemperature a samm:Entity ;
+    samm:preferredName "Phys Chem Value With Temperature"@en ;
+    samm:description "PhysChemValueWithTemperature. Source: Chapter 9."@en ;
+    samm:properties (
+        [ samm:property :valueNumericRangeWithQualifier ; samm:optional true ]
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :reasonForWaiving ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:PhysicalChemicalProperties a samm:Entity ;
+    samm:preferredName "Physical Chemical Properties"@en ;
+    samm:description "SDS section 9."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :appearance ; samm:optional true ]
+        [ samm:property :safetyRelevantInformation ; samm:optional true ]
+        [ samm:property :physicalHazards ; samm:optional true ]
+        [ samm:property :otherSafetyInformation ; samm:optional true ]
+        [ samm:property :otherPhysicalChemicalProperty ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:PhysicalHazards a samm:Entity ;
+    samm:preferredName "Physical Hazards"@en ;
+    samm:properties (
+        [ samm:property :explosives ; samm:optional true ]
+        [ samm:property :flammableGases ; samm:optional true ]
+        [ samm:property :flammableAerosols ; samm:optional true ]
+        [ samm:property :oxidisingGases ; samm:optional true ]
+        [ samm:property :gasesUnderPressure ; samm:optional true ]
+        [ samm:property :flammableLiquids ; samm:optional true ]
+        [ samm:property :flammableSolids ; samm:optional true ]
+        [ samm:property :selfreactiveSubstancesAndMixtures ; samm:optional true ]
+        [ samm:property :pyrophoricLiquids ; samm:optional true ]
+        [ samm:property :pyrophoricSolids ; samm:optional true ]
+        [ samm:property :selfheatingSubstancesAndMixtures ; samm:optional true ]
+        [ samm:property :substancesWhichInContactWithWaterEmitFlammableGases ; samm:optional true ]
+        [ samm:property :oxidisingLiquids ; samm:optional true ]
+        [ samm:property :oxidisingSolids ; samm:optional true ]
+        [ samm:property :organicPeroxides ; samm:optional true ]
+        [ samm:property :corrosiveToMetals ; samm:optional true ]
+    ) .
+
+:PhysicalHazardsGeneralInformation a samm:Entity ;
+    samm:preferredName "Physical Hazards General Information"@en ;
+    samm:description "PhysicalHazardsGeneralInformation. Source: Chapter 9."@en ;
+    samm:properties (
+        [ samm:property :justificationForDataWaiving ; samm:optional true ]
+        [ samm:property :assessmentPhrase ; samm:optional true ]
+        [ samm:property :classificationPhrase ; samm:optional true ]
+    ) .
+
+:PhysicalHazardsSafetyCharacteristics a samm:Entity ;
+    samm:preferredName "Physical Hazards Safety Characteristics"@en ;
+    samm:description "PhysicalHazardsSafetyCharacteristics source: Chapter 9"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :safetyParameter ; samm:optional true ]
+        [ samm:property :safetyResult ; samm:optional true ]
+    ) .
+
+:PhysicalHazardsScreeningProcedures a samm:Entity ;
+    samm:preferredName "Physical Hazards Screening Procedures"@en ;
+    samm:description "PhysicalHazardsScreeningProcedures source: Chapter 9"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :screeningType ; samm:optional true ]
+        [ samm:property :screeningResult ; samm:optional true ]
+    ) .
+
+:Pnec a samm:Entity ;
+    samm:preferredName "Pnec"@en ;
+    samm:description "PNEC source: Chapter 8"@en ;
+    samm:properties (
+        :typePnecTypeEnum
+        :pnecValue
+        [ samm:property :assessmentFactor ; samm:optional true ]
+        [ samm:property :reference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:PrProductRegistrationNo a samm:Entity ;
+    samm:preferredName "Pr Product Registration No"@en ;
+    samm:properties (
+        [ samm:property :prProductNo ; samm:optional true ]
+        [ samm:property :notApplicableReason ; samm:optional true ]
+        [ samm:property :prProductCode ; samm:optional true ]
+        [ samm:property :ucnCode ; samm:optional true ]
+        [ samm:property :sicCode ; samm:optional true ]
+        [ samm:property :norwegianPrFunctionCode ; samm:optional true ]
+    ) .
+
+:PrecautionaryMeasures a samm:Entity ;
+    samm:preferredName "Precautionary Measures"@en ;
+    samm:properties (
+        [ samm:property :protectiveMeasures ; samm:optional true ]
+        [ samm:property :measuresToPreventFire ; samm:optional true ]
+        [ samm:property :measuresToPreventAerosolAndDust ; samm:optional true ]
+        [ samm:property :measuresToProtectEnvironment ; samm:optional true ]
+    ) .
+
+:ProcessCategory a samm:Entity ;
+    samm:preferredName "Process Category"@en ;
+    samm:description "ProcessCategory, source: Chapter 1, used by: CT \"IdentifiedUse\""@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        :procCode
+        [ samm:property :procFulltext ; samm:optional true ]
+    ) .
+
+:ProductCategory a samm:Entity ;
+    samm:preferredName "Product Category"@en ;
+    samm:description "ProductCategory, source: Chapter 1, used by: CT \"IdentifiedUse\""@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        :pcCode
+        [ samm:property :pcFulltext ; samm:optional true ]
+    ) .
+
+:ProductGtin a samm:Entity ;
+    samm:preferredName "Product Gtin"@en ;
+    samm:description "ProductGtin"@en ;
+    samm:properties (
+        :noInt20
+        [ samm:property :name ; samm:optional true ]
+    ) .
+
+:ProductIdentifiers a samm:Entity ;
+    samm:preferredName "Product Identifiers"@en ;
+    samm:properties (
+        [ samm:property :tradeName ; samm:optional true ]
+        [ samm:property :regionEu ; samm:optional true ]
+    ) .
+
+:Properties a samm:Entity ;
+    samm:preferredName "Properties"@en ;
+    samm:properties (
+        [ samm:property :maxDuration ; samm:optional true ]
+        [ samm:property :rangeOfApplication ; samm:optional true ]
+        [ samm:property :airExchangeRate ; samm:optional true ]
+        [ samm:property :other ; samm:optional true ]
+    ) .
+
+:ProtectionArticle a samm:Entity ;
+    samm:preferredName "Protection Article"@en ;
+    samm:description "ProtectionArticle source: Chapter 8"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :description ; samm:optional true ]
+        [ samm:property :manufacturer ; samm:optional true ]
+        [ samm:property :sourcesOfSupply ; samm:optional true ]
+        [ samm:property :referenceRelevantStandard ; samm:optional true ]
+    ) .
+
+:PyrophoricLiquids a samm:Entity ;
+    samm:preferredName "Pyrophoric Liquids"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:PyrophoricSolids a samm:Entity ;
+    samm:preferredName "Pyrophoric Solids"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:RegionAr a samm:Entity ;
+    samm:preferredName "Region Ar"@en ;
+    samm:properties (
+        [ samm:property :classificationClassificationAr ; samm:optional true ]
+        [ samm:property :hazardLabelling ; samm:optional true ]
+    ) .
+
+:RegionBr a samm:Entity ;
+    samm:preferredName "Region Br"@en ;
+    samm:properties (
+        [ samm:property :classificationClassificationBr ; samm:optional true ]
+        [ samm:property :hazardLabelling ; samm:optional true ]
+    ) .
+
+:RegionCa a samm:Entity ;
+    samm:preferredName "Region Ca"@en ;
+    samm:properties (
+        [ samm:property :classificationClassificationCa ; samm:optional true ]
+        [ samm:property :hazardLabelling ; samm:optional true ]
+    ) .
+
+:RegionEu a samm:Entity ;
+    samm:preferredName "Region Eu"@en ;
+    samm:properties ( [ samm:property :ufi ; samm:optional true ] ) .
+
+:RegionGb a samm:Entity ;
+    samm:preferredName "Region Gb"@en ;
+    samm:properties (
+        [ samm:property :classificationClassificationGb ; samm:optional true ]
+        [ samm:property :hazardLabelling ; samm:optional true ]
+    ) .
+
+:RegionMx a samm:Entity ;
+    samm:preferredName "Region Mx"@en ;
+    samm:properties (
+        [ samm:property :classificationClassificationMx ; samm:optional true ]
+        [ samm:property :hazardLabelling ; samm:optional true ]
+    ) .
+
+:RegionTr a samm:Entity ;
+    samm:preferredName "Region Tr"@en ;
+    samm:properties (
+        [ samm:property :classificationClassificationTr ; samm:optional true ]
+        [ samm:property :hazardLabelling ; samm:optional true ]
+    ) .
+
+:RegionUs a samm:Entity ;
+    samm:preferredName "Region Us"@en ;
+    samm:properties (
+        [ samm:property :classificationClassificationUs ; samm:optional true ]
+        [ samm:property :hazardLabelling ; samm:optional true ]
+        [ samm:property :otherHazardsInfo ; samm:optional true ]
+    ) .
+
+:RegulationsAr a samm:Entity ;
+    samm:preferredName "Regulations Ar"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentTR."@en ;
+    samm:properties ( [ samm:property :otherLegislation ; samm:optional true ] ) .
+
+:RegulationsAt a samm:Entity ;
+    samm:preferredName "Regulations At"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentTR."@en ;
+    samm:properties ( :vbfClass ) .
+
+:RegulationsBr a samm:Entity ;
+    samm:preferredName "Regulations Br"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentTR."@en ;
+    samm:properties ( [ samm:property :otherLegislation ; samm:optional true ] ) .
+
+:RegulationsCa a samm:Entity ;
+    samm:preferredName "Regulations Ca"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentCA."@en ;
+    samm:properties ( ) .
+
+:RegulationsCh a samm:Entity ;
+    samm:preferredName "Regulations Ch"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentCH."@en ;
+    samm:properties (
+        [ samm:property :majorAccidentsOrdinance ; samm:optional true ]
+        [ samm:property :nationalWasteLegislationCh ; samm:optional true ]
+        [ samm:property :storageClassCh ; samm:optional true ]
+        [ samm:property :cpid ; samm:optional true ]
+    ) .
+
+:RegulationsDe a samm:Entity ;
+    samm:preferredName "Regulations De"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, create type ComponentDE or refer to ComponentEU."@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :restrictionsOfOccupation ; samm:optional true ]
+        [ samm:property :stoerfallverordnung ; samm:optional true ]
+        [ samm:property :taLuft ; samm:optional true ]
+        [ samm:property :waterHazardClass ; samm:optional true ]
+        [ samm:property :otherRestrictionsAndProhibitionRegulations ; samm:optional true ]
+        [ samm:property :registrationNoAccordingToBiozidMeldeverordnung ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+        [ samm:property :nationalWasteLegislationDe ; samm:optional true ]
+        [ samm:property :storageClassDe ; samm:optional true ]
+        [ samm:property :gisCode ; samm:optional true ]
+    ) .
+
+:RegulationsDk a samm:Entity ;
+    samm:preferredName "Regulations Dk"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentTR."@en ;
+    samm:properties (
+        [ samm:property :malCodeDeliveryState ; samm:optional true ]
+        [ samm:property :malCodeReadyToUse ; samm:optional true ]
+    ) .
+
+:RegulationsEu a samm:Entity ;
+    samm:preferredName "Regulations Eu"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentEU."@en ;
+    samm:properties (
+        [ samm:property :euLegislation ; samm:optional true ]
+        [ samm:property :nationalLegislation ; samm:optional true ]
+        [ samm:property :chemicalSafetyAssessmentInfo ; samm:optional true ]
+        [ samm:property :chemicalSafetyReport ; samm:optional true ]
+        [ samm:property :exposureScenario ; samm:optional true ]
+    ) .
+
+:RegulationsGb a samm:Entity ;
+    samm:preferredName "Regulations Gb"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentGB."@en ;
+    samm:properties ( ) .
+
+:RegulationsJp a samm:Entity ;
+    samm:preferredName "Regulations Jp"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentJP."@en ;
+    samm:properties ( :pdscl ) .
+
+:RegulationsMx a samm:Entity ;
+    samm:preferredName "Regulations Mx"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentTR."@en ;
+    samm:properties ( [ samm:property :otherLegislation ; samm:optional true ] ) .
+
+:RegulationsNo a samm:Entity ;
+    samm:preferredName "Regulations No"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentNO."@en ;
+    samm:properties (
+        [ samm:property :productFunctionCode ; samm:optional true ]
+        [ samm:property :assessedRegulations ; samm:optional true ]
+        [ samm:property :nationalLegislationsDescription ; samm:optional true ]
+        [ samm:property :prProductRegistration ; samm:optional true ]
+        [ samm:property :occupationalAirRequirement ; samm:optional true ]
+        [ samm:property :nationalWasteLegislation ; samm:optional true ]
+    ) .
+
+:RegulationsRelatedToCountryOrRegion a samm:Entity ;
+    samm:preferredName "Regulations Related To Country Or Region"@en ;
+    samm:properties (
+        :regulationsRelatedToCountryOrRegionCode
+        [ samm:property :regulationsRelatedToCountryOrRegionName ; samm:optional true ]
+        [ samm:property :legalDocument ; samm:optional true ]
+        [ samm:property :relatedDocuments ; samm:optional true ]
+    ) .
+
+:RegulationsRu a samm:Entity ;
+    samm:preferredName "Regulations Ru"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentTR."@en ;
+    samm:properties (
+        [ samm:property :nationalLegislationBelarus ; samm:optional true ]
+        [ samm:property :nationalLegislationKazakhstan ; samm:optional true ]
+        [ samm:property :nationalLegislationRussianFederation ; samm:optional true ]
+    ) .
+
+:RegulationsTr a samm:Entity ;
+    samm:preferredName "Regulations Tr"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentTR."@en ;
+    samm:properties ( :certification ) .
+
+:RegulationsUs a samm:Entity ;
+    samm:preferredName "Regulations Us"@en ;
+    samm:description "Regulations valid for the product of mixture as a whole. For ingredient information, refer to type ComponentUS."@en ;
+    samm:properties (
+        [ samm:property :federal ; samm:optional true ]
+        [ samm:property :state ; samm:optional true ]
+    ) .
+
+:RegulatoryInformation a samm:Entity ;
+    samm:preferredName "Regulatory Information"@en ;
+    samm:description "SDS section 15. This type covers information on the product. Any information on substances which might be necessary to be listed in section 15 is covered in type \"Substance\"."@en ;
+    samm:properties (
+        [ samm:property :additionalInfo ; samm:optional true ]
+        [ samm:property :regionAr ; samm:optional true ]
+        [ samm:property :regionBrRegulationsBr ; samm:optional true ]
+        [ samm:property :regionCaRegulationsCa ; samm:optional true ]
+        [ samm:property :regionEuRegulationsEu ; samm:optional true ]
+        [ samm:property :regionGb ; samm:optional true ]
+        [ samm:property :regionJp ; samm:optional true ]
+        [ samm:property :regionMxRegulationsMx ; samm:optional true ]
+        [ samm:property :regionRu ; samm:optional true ]
+        [ samm:property :regionTr ; samm:optional true ]
+        [ samm:property :regionUsRegulationsUs ; samm:optional true ]
+    ) .
+
+:RelatedDocuments a samm:Entity ;
+    samm:preferredName "Related Documents"@en ;
+    samm:properties (
+        :fileName
+        [ samm:property :description ; samm:optional true ]
+    ) .
+
+:RelativeVapourDensity a samm:Entity ;
+    samm:preferredName "Relative Vapour Density"@en ;
+    samm:description "RelativeVapourDensity source: Chapter 9"@en ;
+    samm:properties (
+        [ samm:property :valuePhysChemUnitValueWithTemperature ; samm:optional true ]
+        [ samm:property :referenceGas ; samm:optional true ]
+    ) .
+
+:RelevantIdentifiedUse a samm:Entity ;
+    samm:preferredName "Relevant Identified Use"@en ;
+    samm:properties (
+        [ samm:property :identifiedUse ; samm:optional true ]
+        [ samm:property :productType ; samm:optional true ]
+        [ samm:property :productFunctionDescription ; samm:optional true ]
+    ) .
+
+:ReproductiveToxicity a samm:Entity ;
+    samm:preferredName "Reproductive Toxicity"@en ;
+    samm:properties (
+        [ samm:property :reproductiveToxicityType ; samm:optional true ]
+        [ samm:property :reproductiveToxicityTestResults ; samm:optional true ]
+        [ samm:property :reproductiveToxicityHumanExperience ; samm:optional true ]
+        [ samm:property :assessmentReproductiveToxicityClassification ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:ReproductiveToxicityType a samm:Entity ;
+    samm:preferredName "Reproductive Toxicity Type"@en ;
+    samm:properties (
+        :typeReproductiveToxicityTypeEnum
+        [ samm:property :typeFulltext ; samm:optional true ]
+    ) .
+
+:RespiratoryOrSkinSensitisation a samm:Entity ;
+    samm:preferredName "Respiratory Or Skin Sensitisation"@en ;
+    samm:properties (
+        [ samm:property :respiratoryOrSkinSensitisationTestResults ; samm:optional true ]
+        [ samm:property :humanExperience ; samm:optional true ]
+        [ samm:property :classificationAssessment ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:RespiratoryOrSkinSensitisationTestResults a samm:Entity ;
+    samm:preferredName "Respiratory Or Skin Sensitisation Test Results"@en ;
+    samm:properties (
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :dose ; samm:optional true ]
+        [ samm:property :exposureTime ; samm:optional true ]
+        [ samm:property :testDuration ; samm:optional true ]
+        [ samm:property :speciesSpecies ; samm:optional true ]
+        [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
+        [ samm:property :result ; samm:optional true ]
+        [ samm:property :resultEvaluation ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:RespiratoryProtection a samm:Entity ;
+    samm:preferredName "Respiratory Protection"@en ;
+    samm:properties (
+        [ samm:property :respiratoryProtectionGeneral ; samm:optional true ]
+        [ samm:property :respiratoryProtectionNecessaryAt ; samm:optional true ]
+        [ samm:property :tasksNeedingRespiratoryProtection ; samm:optional true ]
+        [ samm:property :suitableRespiratoryProtectionEquipment ; samm:optional true ]
+        [ samm:property :recommendedRespiratoryProtectionArticles ; samm:optional true ]
+        [ samm:property :additionalRespiratoryProtectionMeasures ; samm:optional true ]
+        [ samm:property :referenceRelevantStandard ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:RespiratoryProtectionArticle a samm:Entity ;
+    samm:preferredName "Respiratory Protection Article"@en ;
+    samm:description "RespiratoryProtectionArticle source: Chapter 8"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :type ; samm:optional true ]
+        [ samm:property :description ; samm:optional true ]
+        [ samm:property :manufacturer ; samm:optional true ]
+        [ samm:property :sourcesOfSupply ; samm:optional true ]
+        [ samm:property :referenceRelevantStandard ; samm:optional true ]
+    ) .
+
+:Results a samm:Entity ;
+    samm:preferredName "Results"@en ;
+    samm:properties (
+        [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
+        [ samm:property :photoIrritationFactor ; samm:optional true ]
+        [ samm:property :meanPhotoEffect ; samm:optional true ]
+        [ samm:property :evaluationPhrase ; samm:optional true ]
+    ) .
+
+:RiskManagementMeasures a samm:Entity ;
+    samm:preferredName "Risk Management Measures"@en ;
+    samm:properties (
+        :rmmWorker
+        [ samm:property :rmmPictogram ; samm:optional true ]
+        [ samm:property :rmmEnvironment ; samm:optional true ]
+    ) .
+
+:RmmControlBandingApproach a samm:Entity ;
+    samm:preferredName "Rmm Control Banding Approach"@en ;
+    samm:properties (
+        [ samm:property :task ; samm:optional true ]
+        [ samm:property :hazardBand ; samm:optional true ]
+        [ samm:property :scaleOfUse ; samm:optional true ]
+        [ samm:property :abilityToBecomeAirborne ; samm:optional true ]
+        [ samm:property :controlApproach ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:Role a samm:Entity ;
+    samm:preferredName "Role"@en ;
+    samm:properties (
+        [ samm:property :roleCode ; samm:optional true ]
+        [ samm:property :roleDescription ; samm:optional true ]
+    ) .
+
+:SafeHandling a samm:Entity ;
+    samm:preferredName "Safe Handling"@en ;
+    samm:properties (
+        [ samm:property :handlingPrecautions ; samm:optional true ]
+        [ samm:property :safeHandlingOfGasContainers ; samm:optional true ]
+        [ samm:property :precautionaryMeasures ; samm:optional true ]
+        [ samm:property :generalOccupationalHygiene ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:SafetyRelevantInformation a samm:Entity ;
+    samm:preferredName "Safety Relevant Information"@en ;
+    samm:properties (
+        [ samm:property :phValue ; samm:optional true ]
+        [ samm:property :meltingPointRelated ; samm:optional true ]
+        [ samm:property :boilingPointRelated ; samm:optional true ]
+        [ samm:property :flashPoint ; samm:optional true ]
+        [ samm:property :evaporationRate ; samm:optional true ]
+        [ samm:property :flammability ; samm:optional true ]
+        [ samm:property :explosionLimit ; samm:optional true ]
+        [ samm:property :vapourPressure ; samm:optional true ]
+        [ samm:property :relativeVapourDensity ; samm:optional true ]
+        [ samm:property :densities ; samm:optional true ]
+        [ samm:property :solubilities ; samm:optional true ]
+        [ samm:property :partitionCoefficient ; samm:optional true ]
+        [ samm:property :autoignitionTemperature ; samm:optional true ]
+        [ samm:property :decompositionTemperature ; samm:optional true ]
+        [ samm:property :viscosity ; samm:optional true ]
+        [ samm:property :explosiveProperties ; samm:optional true ]
+        [ samm:property :oxidisingProperties ; samm:optional true ]
+    ) .
+
+:SdsSupplierInfo a samm:Entity ;
+    samm:preferredName "Sds Supplier Info"@en ;
+    samm:properties (
+        [ samm:property :sdsName ; samm:optional true ]
+        [ samm:property :sdsNotLegallyRequired ; samm:optional true ]
+        [ samm:property :versionNo ; samm:optional true ]
+        :issueDate
+        [ samm:property :revisionDate ; samm:optional true ]
+        [ samm:property :editingDate ; samm:optional true ]
+        [ samm:property :distributionStoppedDate ; samm:optional true ]
+        :supplierInformation
+        [ samm:property :emergencyPhone ; samm:optional true ]
+    ) .
+
+:SdsSupplierInfoEu a samm:Entity ;
+    samm:preferredName "Sds Supplier Info Eu"@en ;
+    samm:properties (
+        [ samm:property :sdsName ; samm:optional true ]
+        [ samm:property :sdsNotLegallyRequired ; samm:optional true ]
+        [ samm:property :versionNo ; samm:optional true ]
+        :issueDate
+        [ samm:property :revisionDate ; samm:optional true ]
+        [ samm:property :editingDate ; samm:optional true ]
+        [ samm:property :distributionStoppedDate ; samm:optional true ]
+        :supplierInformation
+        [ samm:property :emergencyPhone ; samm:optional true ]
+        [ samm:property :completeSdsWithEsIncorporated ; samm:optional true ]
+        [ samm:property :mainIntendedUse ; samm:optional true ]
+        [ samm:property :secondaryUses ; samm:optional true ]
+        [ samm:property :relevantIdentifiedUse ; samm:optional true ]
+    ) .
+
+:SeaHazardClassification2021 a samm:Entity ;
+    samm:preferredName "Sea Hazard Classification2021"@en ;
+    samm:properties (
+        [ samm:property :classification ; samm:optional true ]
+        [ samm:property :multiplyingFactor ; samm:optional true ]
+        [ samm:property :specificConcLimit ; samm:optional true ]
+        [ samm:property :unknownToxicity ; samm:optional true ]
+        [ samm:property :ate ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+        [ samm:property :supplementalHazardInformation ; samm:optional true ]
+        [ samm:property :classificationNotes ; samm:optional true ]
+    ) .
+
+:SeaHazardLabelling2021 a samm:Entity ;
+    samm:preferredName "Sea Hazard Labelling2021"@en ;
+    samm:properties (
+        [ samm:property :hazardPictogram ; samm:optional true ]
+        [ samm:property :signalWord ; samm:optional true ]
+        [ samm:property :hazardStatement ; samm:optional true ]
+        [ samm:property :precautionaryStatement ; samm:optional true ]
+        [ samm:property :supplementalHazardInformation ; samm:optional true ]
+        [ samm:property :specialSupplementalLabelInfoMixtures ; samm:optional true ]
+        [ samm:property :additionalLabellingInfo ; samm:optional true ]
+        [ samm:property :specialRulesOnPackaging ; samm:optional true ]
+        [ samm:property :tactileWarning ; samm:optional true ]
+        [ samm:property :childResistantOpening ; samm:optional true ]
+    ) .
+
+:SectorOfUse a samm:Entity ;
+    samm:preferredName "Sector Of Use"@en ;
+    samm:description "SectorOfUse, source: Chapter 1, used by: CT \"IdentifiedUse\""@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        :suCode
+        [ samm:property :suFulltext ; samm:optional true ]
+    ) .
+
+:SelfheatingSubstancesAndMixtures a samm:Entity ;
+    samm:preferredName "Selfheating Substances And Mixtures"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+        [ samm:property :maxTemperatureReached ; samm:optional true ]
+        [ samm:property :inductionTime ; samm:optional true ]
+    ) .
+
+:SelfreactiveSubstancesAndMixtures a samm:Entity ;
+    samm:preferredName "Selfreactive Substances And Mixtures"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :screeningProcedures ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:SevesoDe a samm:Entity ;
+    samm:preferredName "Seveso De"@en ;
+    samm:properties (
+        [ samm:property :healthHazardsSevesoEntryDe ; samm:optional true ]
+        [ samm:property :physicalHazardsSevesoEntryDe ; samm:optional true ]
+        [ samm:property :environmentalHazardsSevesoEntryDe ; samm:optional true ]
+        [ samm:property :otherHazardsSevesoEntryDe ; samm:optional true ]
+    ) .
+
+:SevesoEntryDe a samm:Entity ;
+    samm:preferredName "Seveso Entry De"@en ;
+    samm:properties (
+        :code
+        :lowerTierQuantity
+        :upperTierQuantity
+        :bimschNumber
+    ) .
+
+:SevesoEntryEu a samm:Entity ;
+    samm:preferredName "Seveso Entry Eu"@en ;
+    samm:description "according to Directive 2012/18/EC"@en ;
+    samm:properties (
+        :code
+        :lowerTierQuantity
+        :upperTierQuantity
+    ) .
+
+:SevesoEu a samm:Entity ;
+    samm:preferredName "Seveso Eu"@en ;
+    samm:properties (
+        [ samm:property :healthHazardsSevesoEntryEu ; samm:optional true ]
+        [ samm:property :physicalHazardsSevesoEntryEu ; samm:optional true ]
+        [ samm:property :environmentalHazardsSevesoEntryEu ; samm:optional true ]
+        [ samm:property :otherHazardsSevesoEntryEu ; samm:optional true ]
+    ) .
+
+:SkinCorrosionAcidicOrAlkalineReserve a samm:Entity ;
+    samm:preferredName "Skin Corrosion Acidic Or Alkaline Reserve"@en ;
+    samm:properties (
+        [ samm:property :skinCorrosionAcidicReserve ; samm:optional true ]
+        [ samm:property :skinCorrosionAlkalineReserve ; samm:optional true ]
+    ) .
+
+:SkinCorrosionIrritation a samm:Entity ;
+    samm:preferredName "Skin Corrosion Irritation"@en ;
+    samm:properties (
+        [ samm:property :skinCorrosionIrritationTestResults ; samm:optional true ]
+        [ samm:property :skinCorrosionAcidicOrAlkalineReserve ; samm:optional true ]
+        [ samm:property :irritation ; samm:optional true ]
+        [ samm:property :corrosivity ; samm:optional true ]
+        [ samm:property :skinCorrosionIrritationHumanExperience ; samm:optional true ]
+        [ samm:property :assessmentCorrosionIrritationClassification ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:SkinProtection a samm:Entity ;
+    samm:preferredName "Skin Protection"@en ;
+    samm:properties (
+        [ samm:property :suitableProtectiveClothing ; samm:optional true ]
+        [ samm:property :unsuitableProtectiveClothing ; samm:optional true ]
+        [ samm:property :protectiveClothingNecessaryProperties ; samm:optional true ]
+        [ samm:property :protectiveClothingRecommendedMaterial ; samm:optional true ]
+        [ samm:property :recommendedProtectiveClothingArticles ; samm:optional true ]
+        [ samm:property :additionalSkinProtectionMeasures ; samm:optional true ]
+        [ samm:property :skinBodyOtherProtection ; samm:optional true ]
+        [ samm:property :referenceRelevantStandard ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:Solubilities a samm:Entity ;
+    samm:preferredName "Solubilities"@en ;
+    samm:description "Describes the solutibities in one medium, optionally at various temperatures (section 9)."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :solubilityDescription ; samm:optional true ]
+        [ samm:property :solubility ; samm:optional true ]
+    ) .
+
+:Solubility a samm:Entity ;
+    samm:preferredName "Solubility"@en ;
+    samm:properties (
+        :medium
+        [ samm:property :mediumDescription ; samm:optional true ]
+        [ samm:property :valuePhysChemUnitValueWithTemperature ; samm:optional true ]
+    ) .
+
+:SolutionExtractionBehaviourOfPolymersInWater a samm:Entity ;
+    samm:preferredName "Solution Extraction Behaviour Of Polymers In Water"@en ;
+    samm:description "SolutionExtractionBehaviourOfPolymersInWater source: Chapter 9"@en ;
+    samm:properties (
+        [ samm:property :valuePhysChemUnitValueWithTemperature ; samm:optional true ]
+        [ samm:property :phValue ; samm:optional true ]
+    ) .
+
+:Species a samm:Entity ;
+    samm:preferredName "Species"@en ;
+    samm:description "Species used in tests"@en ;
+    samm:properties (
+        :valuePhrase
+        [ samm:property :gender ; samm:optional true ]
+    ) .
+
+:SpecificConcLimit a samm:Entity ;
+    samm:preferredName "Specific Conc Limit"@en ;
+    samm:properties (
+        [ samm:property :hazardClassCategory ; samm:optional true ]
+        [ samm:property :hazardClassCategoryPrintable ; samm:optional true ]
+        [ samm:property :organ ; samm:optional true ]
+        [ samm:property :exposureRoutePhrase ; samm:optional true ]
+        [ samm:property :classificationProcedure ; samm:optional true ]
+        [ samm:property :supplementalHazard ; samm:optional true ]
+        :minPercentage
+        [ samm:property :maxPercentage ; samm:optional true ]
+    ) .
+
+:SpecificEndUses a samm:Entity ;
+    samm:preferredName "Specific End Uses"@en ;
+    samm:properties (
+        [ samm:property :recommendations ; samm:optional true ]
+        [ samm:property :industrialSectorSpecificSolutions ; samm:optional true ]
+    ) .
+
+:SpecificEnvironmentalReleaseCategory a samm:Entity ;
+    samm:preferredName "Specific Environmental Release Category"@en ;
+    samm:description "Specific Environmental Release Category, source: Chapter 1, used by: CT \"IdentifiedUse\""@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        :spercCode
+        [ samm:property :spercFulltext ; samm:optional true ]
+    ) .
+
+:SpecificTargetOrganRe a samm:Entity ;
+    samm:preferredName "Specific Target Organ Re"@en ;
+    samm:properties (
+        [ samm:property :specificTargetOrganReTestResults ; samm:optional true ]
+        [ samm:property :specificTargetOrganReHumanExperience ; samm:optional true ]
+        [ samm:property :assessmentSpecificTargetOrganReClassification ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:SpecificTargetOrganSe a samm:Entity ;
+    samm:preferredName "Specific Target Organ Se"@en ;
+    samm:properties (
+        [ samm:property :specificTargetOrganSeTestResults ; samm:optional true ]
+        [ samm:property :specificTargetOrganSeHumanExperience ; samm:optional true ]
+        [ samm:property :assessmentSpecificTargetOrganSeClassification ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:SpecificTargetOrganSe3 a samm:Entity ;
+    samm:preferredName "Specific Target Organ Se3"@en ;
+    samm:properties (
+        [ samm:property :irritationToRespiratoryTract ; samm:optional true ]
+        [ samm:property :narcoticEffects ; samm:optional true ]
+        [ samm:property :specificTargetOrganSeTestResults ; samm:optional true ]
+        [ samm:property :assessmentSpecificTargetOrganSeClassification ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:Srt2015HazardClassification a samm:Entity ;
+    samm:preferredName "Srt2015Hazard Classification"@en ;
+    samm:properties (
+        :hazardClassCategory
+        :hazardClassCategoryPrintable
+        [ samm:property :organ ; samm:optional true ]
+        [ samm:property :exposureRoutePhrase ; samm:optional true ]
+        [ samm:property :classificationProcedure ; samm:optional true ]
+        [ samm:property :unknownToxicity ; samm:optional true ]
+        [ samm:property :ate ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+    ) .
+
+:Srt2015HazardLabelling a samm:Entity ;
+    samm:preferredName "Srt2015Hazard Labelling"@en ;
+    samm:properties (
+        [ samm:property :hazardPictogram ; samm:optional true ]
+        [ samm:property :signalWord ; samm:optional true ]
+        [ samm:property :hazardStatement ; samm:optional true ]
+        [ samm:property :precautionaryStatement ; samm:optional true ]
+        [ samm:property :additionalLabellingInfo ; samm:optional true ]
+    ) .
+
+:StabilityReactivity a samm:Entity ;
+    samm:preferredName "Stability Reactivity"@en ;
+    samm:description "SDS section 10"@en ;
+    samm:properties (
+        [ samm:property :reactivityDescription ; samm:optional true ]
+        [ samm:property :stabilityDescription ; samm:optional true ]
+        [ samm:property :hazardousReactions ; samm:optional true ]
+        [ samm:property :conditionsToAvoid ; samm:optional true ]
+        [ samm:property :materialsToAvoid ; samm:optional true ]
+        [ samm:property :hazardousDecompositionProducts ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:State a samm:Entity ;
+    samm:preferredName "State"@en ;
+    samm:properties ( [ samm:property :california ; samm:optional true ] ) .
+
+:StateUnderStandardConditions a samm:Entity ;
+    samm:preferredName "State Under Standard Conditions"@en ;
+    samm:properties (
+        :state
+        [ samm:property :stateFulltext ; samm:optional true ]
+    ) .
+
+:Stel a samm:Entity ;
+    samm:preferredName "Stel"@en ;
+    samm:description "Short Term Exposure Limit"@en ;
+    samm:properties (
+        [ samm:property :valueNumericRangeWithUnitAndQualifier ; samm:optional true ]
+        [ samm:property :appraisalPeriod ; samm:optional true ]
+    ) .
+
+:StorageStability a samm:Entity ;
+    samm:preferredName "Storage Stability"@en ;
+    samm:properties (
+        [ samm:property :storageTemperature ; samm:optional true ]
+        [ samm:property :pressure ; samm:optional true ]
+        [ samm:property :maximumStoragePeriod ; samm:optional true ]
+    ) .
+
+:StotData a samm:Entity ;
+    samm:preferredName "Stot Data"@en ;
+    samm:description "STOTData, source: Chapter 11 used by DT: STOT"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :exposureRouteExposureRoute ; samm:optional true ]
+        [ samm:property :dose ; samm:optional true ]
+        [ samm:property :exposureTime ; samm:optional true ]
+        [ samm:property :testDuration ; samm:optional true ]
+        [ samm:property :exposureFrequency ; samm:optional true ]
+        :speciesSpecies
+        [ samm:property :specificEffect ; samm:optional true ]
+        [ samm:property :organAffected ; samm:optional true ]
+        :result
+        [ samm:property :resultEvaluation ; samm:optional true ]
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:SubstanceIdentifiers a samm:Entity ;
+    samm:preferredName "Substance Identifiers"@en ;
+    samm:properties (
+        [ samm:property :iupacName ; samm:optional true ]
+        [ samm:property :casInventoryName ; samm:optional true ]
+        [ samm:property :genericName ; samm:optional true ]
+        [ samm:property :otherName ; samm:optional true ]
+        [ samm:property :casNo ; samm:optional true ]
+        [ samm:property :regionEuSubstanceIdentityEu ; samm:optional true ]
+    ) .
+
+:SubstanceIdentityEu a samm:Entity ;
+    samm:preferredName "Substance Identity Eu"@en ;
+    samm:properties (
+        [ samm:property :indexNo ; samm:optional true ]
+        [ samm:property :ecNo ; samm:optional true ]
+        [ samm:property :reachRegNo ; samm:optional true ]
+    ) .
+
+:SubstancesWhichInContactWithWaterEmitFlammableGases a samm:Entity ;
+    samm:preferredName "Substances Which In Contact With Water Emit Flammable Gases"@en ;
+    samm:properties (
+        [ samm:property :generalInformation ; samm:optional true ]
+        [ samm:property :safetyCharacteristics ; samm:optional true ]
+    ) .
+
+:Sumi a samm:Entity ;
+    samm:preferredName "Sumi"@en ;
+    samm:description "Safe Use Information for Mixtures. Based on a draft prepared by Qualisys GmbH, Langenfeld, Germany, and published under CC license BY-SA 4.0 during the BDI workshop in Berlin, 26 October 2016. Includes information from the presentation of Martin Kops at ENES 8 and other documents."@en ;
+    samm:properties (
+        [ samm:property :sumiReference ; samm:optional true ]
+        :title
+        :generalDescription
+        :operationalConditions
+        :riskManagementMeasures
+        [ samm:property :goodPracticeAdvice ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+        [ samm:property :disclaimerBoundaries ; samm:optional true ]
+    ) .
+
+:SumiReference a samm:Entity ;
+    samm:preferredName "Sumi Reference"@en ;
+    samm:properties (
+        [ samm:property :sectorSumiCode ; samm:optional true ]
+        [ samm:property :versionNumber ; samm:optional true ]
+    ) .
+
+:SummaryRmMeasures a samm:Entity ;
+    samm:preferredName "Summary Rm Measures"@en ;
+    samm:properties (
+        [ samm:property :summaryRmMeasuresMan ; samm:optional true ]
+        [ samm:property :summaryRmMeasuresEnvironm ; samm:optional true ]
+        [ samm:property :rmmControlBandingApproach ; samm:optional true ]
+    ) .
+
+:SupplementalHazardInformation a samm:Entity ;
+    samm:preferredName "Supplemental Hazard Information"@en ;
+    samm:description "Supplemental Hazard Information Statement CLP"@en ;
+    samm:properties (
+        [ samm:property :phraseId ; samm:optional true ]
+        :phraseCodeAtp12SupplementalHazardInformationEnum
+        [ samm:property :fullText ; samm:optional true ]
+        [ samm:property :mergePhrase ; samm:optional true ]
+        [ samm:property :phraseId ; samm:optional true ]
+        [ samm:property :phraseCatalogueId ; samm:optional true ]
+    ) .
+
+:SupplierInformation a samm:Entity ;
+    samm:preferredName "Supplier Information"@en ;
+    samm:properties (
+        [ samm:property :role ; samm:optional true ]
+        :country
+        :name
+        :address
+        :phone
+        [ samm:property :fax ; samm:optional true ]
+        [ samm:property :email ; samm:optional true ]
+        [ samm:property :companyUrl ; samm:optional true ]
+        [ samm:property :companyContact ; samm:optional true ]
+        [ samm:property :duns ; samm:optional true ]
+    ) .
+
+:SurfaceTension a samm:Entity ;
+    samm:preferredName "Surface Tension"@en ;
+    samm:description "SurfaceTension, source: Chapter 9"@en ;
+    samm:properties (
+        :valuePhysChemUnitValueWithTemperature
+        [ samm:property :concentration ; samm:optional true ]
+    ) .
+
+:SymptomsOfExposure a samm:Entity ;
+    samm:preferredName "Symptoms Of Exposure"@en ;
+    samm:properties (
+        [ samm:property :inCaseOfIngestion ; samm:optional true ]
+        [ samm:property :inCaseOfSkinContact ; samm:optional true ]
+        [ samm:property :inCaseOfInhalation ; samm:optional true ]
+        [ samm:property :inCaseOfEyeContact ; samm:optional true ]
+    ) .
+
+:TaLuft a samm:Entity ;
+    samm:preferredName "Ta Luft"@en ;
+    samm:properties (
+        [ samm:property :weightFraction ; samm:optional true ]
+        [ samm:property :classOrClasses ; samm:optional true ]
+        [ samm:property :noPhrase ; samm:optional true ]
+        [ samm:property :remark ; samm:optional true ]
+    ) .
+
+:TargetGroup a samm:Entity ;
+    samm:preferredName "Target Group"@en ;
+    samm:properties (
+        :industrialUse
+        :professionalUse
+        :consumerUse
+    ) .
+
+:TerrestrialToxicity a samm:Entity ;
+    samm:preferredName "Terrestrial Toxicity"@en ;
+    samm:properties (
+        [ samm:property :soilMicroorganismsToxicity ; samm:optional true ]
+        [ samm:property :acuteEarthwormToxicity ; samm:optional true ]
+        [ samm:property :chronicEarthwormToxicity ; samm:optional true ]
+        [ samm:property :insectToxicity ; samm:optional true ]
+        [ samm:property :acutePlantToxicity ; samm:optional true ]
+        [ samm:property :chronicPlantToxicity ; samm:optional true ]
+        [ samm:property :acuteSubchronicBirdToxicity ; samm:optional true ]
+        [ samm:property :birdReproductionToxicity ; samm:optional true ]
+    ) .
+
+:TestPerformed a samm:Entity ;
+    samm:preferredName "Test Performed"@en ;
+    samm:properties (
+        [ samm:property :parameterTested ; samm:optional true ]
+        [ samm:property :testResult ; samm:optional true ]
+    ) .
+
+:TestResults a samm:Entity ;
+    samm:preferredName "Test Results"@en ;
+    samm:properties (
+        :effectTested
+        :exposureRouteExposureRoute
+        [ samm:property :methodPhrase ; samm:optional true ]
+        [ samm:property :exposureTime ; samm:optional true ]
+        :valueNumericRangeWithUnitAndQualifier
+        :speciesSpecies
+        [ samm:property :testReference ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:ToxInfoStotSe3 a samm:Entity ;
+    samm:preferredName "Tox Info Stot Se3"@en ;
+    samm:properties (
+        [ samm:property :humanExperience ; samm:optional true ]
+        [ samm:property :source ; samm:optional true ]
+        [ samm:property :assessmentOrClassification ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:ToxicokineticInfo a samm:Entity ;
+    samm:preferredName "Toxicokinetic Info"@en ;
+    samm:properties (
+        [ samm:property :nonHumanToxicologicalData ; samm:optional true ]
+        [ samm:property :humanToxicologicalData ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:ToxicologicalInformation a samm:Entity ;
+    samm:preferredName "Toxicological Information"@en ;
+    samm:description "SDS section 11."@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :toxicokineticInfo ; samm:optional true ]
+        [ samm:property :acuteToxicity ; samm:optional true ]
+        [ samm:property :skinCorrosionIrritation ; samm:optional true ]
+        [ samm:property :eyeDamageOrIrritation ; samm:optional true ]
+        [ samm:property :respiratoryOrSkinSensitisation ; samm:optional true ]
+        [ samm:property :germCellMutagenicity ; samm:optional true ]
+        [ samm:property :carcinogenicity ; samm:optional true ]
+        [ samm:property :reproductiveToxicity ; samm:optional true ]
+        [ samm:property :overallAssessmentOnCmrProperties ; samm:optional true ]
+        [ samm:property :specificTargetOrganSe ; samm:optional true ]
+        [ samm:property :specificTargetOrganSe3 ; samm:optional true ]
+        [ samm:property :specificTargetOrganRe ; samm:optional true ]
+        [ samm:property :aspirationHazard ; samm:optional true ]
+        [ samm:property :symptomsOfExposure ; samm:optional true ]
+        [ samm:property :phototoxicity ; samm:optional true ]
+        [ samm:property :endocrineDisruption ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:TradeProductIdentity a samm:Entity ;
+    samm:preferredName "Trade Product Identity"@en ;
+    samm:properties (
+        [ samm:property :userId ; samm:optional true ]
+        :productNoUser
+        [ samm:property :substanceIdentifiers ; samm:optional true ]
+        [ samm:property :productIdentifiers ; samm:optional true ]
+        [ samm:property :productGtin ; samm:optional true ]
+        [ samm:property :productDefinition ; samm:optional true ]
+        [ samm:property :packaging ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:TransportBr a samm:Entity ;
+    samm:preferredName "Transport Br"@en ;
+    samm:properties (
+        [ samm:property :unNo ; samm:optional true ]
+        [ samm:property :properShippingName ; samm:optional true ]
+        [ samm:property :dangerReleasingSubstance ; samm:optional true ]
+        [ samm:property :classTransportClassEnum ; samm:optional true ]
+        [ samm:property :division ; samm:optional true ]
+        [ samm:property :subrisk ; samm:optional true ]
+        [ samm:property :hazardNumber ; samm:optional true ]
+        [ samm:property :packingGroup ; samm:optional true ]
+        [ samm:property :otherInformation ; samm:optional true ]
+    ) .
+
+:TransportCa a samm:Entity ;
+    samm:preferredName "Transport Ca"@en ;
+    samm:properties (
+        [ samm:property :unNo ; samm:optional true ]
+        [ samm:property :properShippingName ; samm:optional true ]
+        [ samm:property :dangerReleasingSubstance ; samm:optional true ]
+        [ samm:property :classTransportClassEnum ; samm:optional true ]
+        [ samm:property :subrisk ; samm:optional true ]
+        [ samm:property :packingGroup ; samm:optional true ]
+        [ samm:property :otherInformation ; samm:optional true ]
+    ) .
+
+:TransportEu a samm:Entity ;
+    samm:preferredName "Transport Eu"@en ;
+    samm:properties (
+        [ samm:property :adrRid ; samm:optional true ]
+        [ samm:property :adn ; samm:optional true ]
+        [ samm:property :transportInBulk ; samm:optional true ]
+    ) .
+
+:TransportInBulk a samm:Entity ;
+    samm:preferredName "Transport In Bulk"@en ;
+    samm:properties (
+        [ samm:property :productName ; samm:optional true ]
+        [ samm:property :shipType ; samm:optional true ]
+        [ samm:property :pollutionCategory ; samm:optional true ]
+    ) .
+
+:TransportInformation a samm:Entity ;
+    samm:preferredName "Transport Information"@en ;
+    samm:description "SDS section 14. No specific transport regulation data for Argentina."@en ;
+    samm:properties (
+        [ samm:property :imdg ; samm:optional true ]
+        [ samm:property :iataDgr ; samm:optional true ]
+        [ samm:property :specialPrecautionUser ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+        [ samm:property :regionBrTransportBr ; samm:optional true ]
+        [ samm:property :regionCaTransportCa ; samm:optional true ]
+        [ samm:property :regionEuTransportEu ; samm:optional true ]
+        [ samm:property :regionMxTransportMx ; samm:optional true ]
+        [ samm:property :regionUsTransportUs ; samm:optional true ]
+    ) .
+
+:TransportMx a samm:Entity ;
+    samm:preferredName "Transport Mx"@en ;
+    samm:properties (
+        [ samm:property :unNo ; samm:optional true ]
+        [ samm:property :properShippingName ; samm:optional true ]
+        [ samm:property :dangerReleasingSubstance ; samm:optional true ]
+        [ samm:property :classTransportClassEnum ; samm:optional true ]
+        [ samm:property :subrisk ; samm:optional true ]
+        [ samm:property :packingGroup ; samm:optional true ]
+        [ samm:property :otherInformation ; samm:optional true ]
+    ) .
+
+:TransportUs a samm:Entity ;
+    samm:preferredName "Transport Us"@en ;
+    samm:properties (
+        [ samm:property :idNoUsaDot ; samm:optional true ]
+        [ samm:property :properShippingName ; samm:optional true ]
+        [ samm:property :dangerReleasingSubstance ; samm:optional true ]
+        [ samm:property :classTransportClassEnum ; samm:optional true ]
+        [ samm:property :subrisk ; samm:optional true ]
+        [ samm:property :hazardLabel ; samm:optional true ]
+        [ samm:property :packingGroup ; samm:optional true ]
+        [ samm:property :otherInformation ; samm:optional true ]
+    ) .
+
+:Type a samm:Entity ;
+    samm:preferredName "Type"@en ;
+    samm:properties (
+        [ samm:property :equipmentForSelfRescue ; samm:optional true ]
+        [ samm:property :maskType ; samm:optional true ]
+        [ samm:property :filterApparatusType ; samm:optional true ]
+    ) .
+
+:UnknownToxicity a samm:Entity ;
+    samm:preferredName "Unknown Toxicity"@en ;
+    samm:properties (
+        [ samm:property :inhalation ; samm:optional true ]
+        [ samm:property :dermal ; samm:optional true ]
+        [ samm:property :oral ; samm:optional true ]
+        [ samm:property :aquatic ; samm:optional true ]
+    ) .
+
+:UseDescriptors a samm:Entity ;
+    samm:preferredName "Use Descriptors"@en ;
+    samm:properties (
+        [ samm:property :sectorOfUse ; samm:optional true ]
+        [ samm:property :processCategory ; samm:optional true ]
+    ) .
+
+:Viscosity a samm:Entity ;
+    samm:preferredName "Viscosity"@en ;
+    samm:description "Viscosity source: Chapter 9"@en ;
+    samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        [ samm:property :valuePhysChemUnitValueWithTemperature ; samm:optional true ]
+        [ samm:property :typeViscosityTypeEnum ; samm:optional true ]
+        [ samm:property :typeDescription ; samm:optional true ]
+        [ samm:property :concentration ; samm:optional true ]
+    ) .
+
+:Voc a samm:Entity ;
+    samm:preferredName "Voc"@en ;
+    samm:properties (
+        [ samm:property :vocInPercentByWeight ; samm:optional true ]
+        [ samm:property :vocValue ; samm:optional true ]
+        [ samm:property :additionalInfo ; samm:optional true ]
+    ) .
+
+:VocLabelling a samm:Entity ;
+    samm:preferredName "Voc Labelling"@en ;
+    samm:properties (
+        [ samm:property :productSubcategory ; samm:optional true ]
+        [ samm:property :vocLimitForSubcategory ; samm:optional true ]
+        [ samm:property :maxVocConcInMixture ; samm:optional true ]
+    ) .
+
+:WasteListEntry a samm:Entity ;
+    samm:preferredName "Waste List Entry"@en ;
+    samm:description "WasteListEntry, source: Chapter 13."@en ;
+    samm:properties (
+        :wasteCodeWasteCode
+        [ samm:property :wasteDescription ; samm:optional true ]
+        [ samm:property :hazardousWaste ; samm:optional true ]
+    ) .
+
+:WasteTreatment a samm:Entity ;
+    samm:preferredName "Waste Treatment"@en ;
+    samm:properties (
+        [ samm:property :productWaste ; samm:optional true ]
+        [ samm:property :packagingWaste ; samm:optional true ]
+    ) .
+
+:WaterHazardClass a samm:Entity ;
+    samm:preferredName "Water Hazard Class"@en ;
+    samm:description "WaterHazardClass"@en ;
+    samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:properties (
+        :classWaterHazardClassEnum
+        [ samm:property :source ; samm:optional true ]
+        [ samm:property :remark ; samm:optional true ]
+    ) .
+
+:Whmis2015HazardClassification a samm:Entity ;
+    samm:preferredName "Whmis2015Hazard Classification"@en ;
+    samm:properties (
+        :hazardClassCategory
+        :hazardClassCategoryPrintable
+        [ samm:property :organ ; samm:optional true ]
+        [ samm:property :exposureRoutePhrase ; samm:optional true ]
+        [ samm:property :classificationProcedure ; samm:optional true ]
+        [ samm:property :unknownToxicity ; samm:optional true ]
+        [ samm:property :ate ; samm:optional true ]
+        [ samm:property :additionalInformation ; samm:optional true ]
+    ) .

--- a/io.catenax.esdscom/1.0.0/eSDScom.ttl
+++ b/io.catenax.esdscom/1.0.0/eSDScom.ttl
@@ -1,7 +1,9 @@
 #######################################################################
 # Copyright(c) 2026 Qualisys GmbH
 # Copyright(c) 2026 Volkswagen AG
-# Copyright(c) 2026 BASF Intertrade AG
+# Copyright(c) 2026 BASF SE
+# Copyright(c) 2026 Henkel AG & Co KGaA
+# Copyright(c) 2026 Gestamp
 # Copyright(c) 2026 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -13,6 +15,10 @@
 # https://creativecommons.org/licenses/by/4.0/legalcode.
 #
 # SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+#
+# This ontology was generated from an XML schema definition by a
+# script and thus lacks the perfection of a native TTL file.
 #######################################################################
 @prefix :       <urn:samm:io.catenax.esdscom:1.0.0#> .
 @prefix samm:   <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
@@ -95,6 +101,7 @@
     samm:preferredName "Acute"@en ;
     samm:description "Acute M-factor or acute assessment value; dimensionless, if M-factor."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :acuteAlgaeToxicity a samm:Property ;
@@ -217,6 +224,7 @@
 :agpaPictogram a samm:Property ;
     samm:preferredName "Agpa Pictogram"@en ;
     samm:description "Pictogram for good practice or safe use; coded symbol."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :airExchangeRate a samm:Property ;
@@ -410,11 +418,13 @@
     samm:preferredName "Authorisation No"@en ;
     samm:description "Authorisation number: For chemicals subject to authorisation according to REACH Annex XIV, which have been granted authorisation for the actual use."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :authorizationNo a samm:Property ;
     samm:preferredName "Authorization No"@en ;
     samm:description "Authorisation number, e.g. for biocidal product or other regulatory authorisation."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :autoignitionTemperature a samm:Property ;
@@ -426,6 +436,7 @@
 :bimschNumber a samm:Property ;
     samm:preferredName "Bimsch Number"@en ;
     samm:description "Number according to Table 1 of 12 BImSchV, the German implementation of EU's Seveso III Directive"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :bioaccumulation a samm:Property ;
@@ -523,12 +534,14 @@
 :casInventoryName a samm:Property ;
     samm:preferredName "Cas Inventory Name"@en ;
     samm:description "a.k.a CAIN, Name in the CAS Online Inventory"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :casNo a samm:Property ;
     samm:preferredName "Cas No"@en ;
     samm:description "CAS RN: Registration Number for chemical substances, including some groups and more complex cases like polymers and reaction products, issued by Chemical Abstract Service. For a discussion why there is just one CAS RN per substance, see issue #111."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :certainFluorinatedGreenhouseGases a samm:Property ;
@@ -559,6 +572,7 @@
 :chemicalSafetyAssessmentCarriedOut a samm:Property ;
     samm:preferredName "Chemical Safety Assessment Carried Out"@en ;
     samm:description "Chemical safety assessment (CSA) carried out: To state if CSA has been performed on the substance or the individual substances of a mixture."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :chemicalSafetyAssessmentInfo a samm:Property ;
@@ -574,12 +588,14 @@
 :childResistantOpening a samm:Property ;
     samm:preferredName "Child Resistant Opening"@en ;
     samm:description "Child Resistant Fastening: To inform if the packaging must be supplied with such fastening if the chemical is supplied to the general public."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :chronic a samm:Property ;
     samm:preferredName "Chronic"@en ;
     samm:description "Chronic M-factor or chronic assessment value; dimensionless, if M-factor."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :chronicAlgaeToxicity a samm:Property ;
@@ -613,6 +629,7 @@
 :classCode a samm:Property ;
     samm:preferredName "Class Code"@en ;
     samm:description "Transport hazard class or classification code; coded value."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :classOrClasses a samm:Property ;
@@ -713,6 +730,7 @@
 :code a samm:Property ;
     samm:preferredName "Code"@en ;
     samm:description "code of a category, rule or classification; meaning from context."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :colour a samm:Property ;
@@ -748,6 +766,7 @@
     samm:preferredName "Company Url"@en ;
     samm:description "Company URL: Web address to the company’s home page"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "https://example.com"^^xsd:anyURI ;
     samm:characteristic samm-c:ResourcePath .
 
 :completeSdsWithEsIncorporated a samm:Property ;
@@ -791,6 +810,7 @@
 :consumerUse a samm:Property ;
     samm:preferredName "Consumer Use"@en ;
     samm:description "Indicates whether consumer use is intended; yes/no or description."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :containment a samm:Property ;
@@ -849,6 +869,7 @@
 :cpId a samm:Property ;
     samm:preferredName "Cp Id"@en ;
     samm:description "The product registration number for Swiss FOPH. Part of section 15 of SDS"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :criticalPressure a samm:Property ;
@@ -870,6 +891,7 @@
 :csrRequired a samm:Property ;
     samm:preferredName "Csr Required"@en ;
     samm:description "Indicates whether a chemical safety report is required; yes/no."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :dangerReleasingSubstance a samm:Property ;
@@ -921,6 +943,7 @@
 :delimiter a samm:Property ;
     samm:preferredName "Delimiter"@en ;
     samm:description "Delimiter for composite phrases."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :densities a samm:Property ;
@@ -954,6 +977,7 @@
 :description a samm:Property ;
     samm:preferredName "Description"@en ;
     samm:description "Description of the file type etc."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :descriptionOfFirstAidMeasures a samm:Property ;
@@ -1015,6 +1039,7 @@
     samm:preferredName "Division"@en ;
     samm:description "Subclass/division under dangerous goods law, e.g. 1.1 or 2.1."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :dmelValue a samm:Property ;
@@ -1042,12 +1067,14 @@
 :duns a samm:Property ;
     samm:preferredName "Duns"@en ;
     samm:description "The D-U-N-S Number references a legal entity and allows access to what could be considered a self-maintaining address book, created for the automotive and chemical industry. It should be added to any address in SDScom to help data integration. See also https://www.upik.de/"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :ecNo a samm:Property ;
     samm:preferredName "Ec No"@en ;
     samm:description "EC number of the substance according to EU inventories; coded value."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :ecologicalInformationEcologicalInformation a samm:Property ;
@@ -1104,12 +1131,14 @@
     samm:preferredName "Email"@en ;
     samm:description "e-mail address to the company:"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :emailCompetentPerson a samm:Property ;
     samm:preferredName "Email Competent Person"@en ;
     samm:description "Email address of the competent person responsible for the safety data sheet."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :emergencyPhone a samm:Property ;
@@ -1132,6 +1161,7 @@
 :emsCode a samm:Property ;
     samm:preferredName "Ems Code"@en ;
     samm:description "EmS code under the IMDG code for emergency measures at sea; coded value."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :endocrineDisruptingPotential a samm:Property ;
@@ -1215,6 +1245,7 @@
 :escomFileName a samm:Property ;
     samm:preferredName "Escom File Name"@en ;
     samm:description "File name if the exposure scenarios is available in EScom XML format."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :euAuthorisation a samm:Property ;
@@ -1309,6 +1340,7 @@
 :exceptedQty a samm:Property ;
     samm:preferredName "Excepted Qty"@en ;
     samm:description "Excepted quantity under dangerous goods regulations; coded or quantity value."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :expansionCoefficient a samm:Property ;
@@ -1384,11 +1416,13 @@
 :exposureScenarioIdentificationString a samm:Property ;
     samm:preferredName "Exposure Scenario Identification String"@en ;
     samm:description "Link to ESCom exposure scenario. The referenced exposure scenario(s) must be delivered in one or more separate file(s) in ESCom format. In its element ExposureScenario/IdentificationString, ESCom provides the UUID which is referenced here."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :exposureScenarioName a samm:Property ;
     samm:preferredName "Exposure Scenario Name"@en ;
     samm:description "name of the exposure scenario."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :exposureTime a samm:Property ;
@@ -1400,6 +1434,7 @@
 :extendedSdsWithEsIncorporated a samm:Property ;
     samm:preferredName "Extended Sds With Es Incorporated"@en ;
     samm:description "Exposure scenarios incorporated in the SDS: To state if the SDS is complete (eSDS) - meaning that the user has to adapt to the information in the SDS within 12 months."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :extinguishingMedia a samm:Property ;
@@ -1448,6 +1483,7 @@
     samm:preferredName "Fax"@en ;
     samm:description "Faximile number:"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :federal a samm:Property ;
@@ -1458,6 +1494,7 @@
 :fileName a samm:Property ;
     samm:preferredName "File Name"@en ;
     samm:description "File name: For example, a locked PDF document. A fixed URL is possible."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :filterApparatusType a samm:Property ;
@@ -1664,6 +1701,7 @@
     samm:preferredName "Generic Name"@en ;
     samm:description "Alternative chemical name to protect Confidential Business Information (in Europe, according to CLP article 24)"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :germCellMutagenicity a samm:Property ;
@@ -1680,6 +1718,7 @@
     samm:preferredName "Gis Code"@en ;
     samm:description "German GisCode of the BGBau for the construction industrie"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :globalWarmingPotential a samm:Property ;
@@ -1744,6 +1783,7 @@
 :hazardClassCategory a samm:Property ;
     samm:preferredName "Hazard Class Category"@en ;
     samm:description "Hazard class and category according to GHS/CLP-System; coded value."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :hazardClassCategoryPrintable a samm:Property ;
@@ -1773,11 +1813,13 @@
 :hazardLabel a samm:Property ;
     samm:preferredName "Hazard Label"@en ;
     samm:description "Danger label under dangerous goods law; number or code."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :hazardLabelAdr a samm:Property ;
     samm:preferredName "Hazard Label Adr"@en ;
     samm:description "ADR label; number or code."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :hazardLabelEnglish a samm:Property ;
@@ -1788,6 +1830,7 @@
 :hazardLabelRid a samm:Property ;
     samm:preferredName "Hazard Label Rid"@en ;
     samm:description "RID label; number or code."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :hazardLabelling a samm:Property ;
@@ -1800,6 +1843,7 @@
     samm:preferredName "Hazard Number"@en ;
     samm:description "Hazard identification number/Kemler code for dangerous goods transport; dimensionless."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :hazardPictogram a samm:Property ;
@@ -1831,6 +1875,7 @@
     samm:preferredName "Hazardous Waste"@en ;
     samm:description "optional because this property can be dreived from WasteCode"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :hazardousWasteCharacteristics a samm:Property ;
@@ -1841,6 +1886,7 @@
 :hazardousWasteCode a samm:Property ;
     samm:preferredName "Hazardous Waste Code"@en ;
     samm:description "US state of California: Regional hazardous waste code; coded value."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :hazardousWasteStatus a samm:Property ;
@@ -1909,6 +1955,7 @@
 :idNoUsaDot a samm:Property ;
     samm:preferredName "Id No Usa Dot"@en ;
     samm:description "U.S. transportation numbers are either preceded with \"UN\" or with \"NA\""@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :identificationSubstPrep a samm:Property ;
@@ -1957,12 +2004,14 @@
 :inciName a samm:Property ;
     samm:preferredName "Inci Name"@en ;
     samm:description "according to EU cosmetics regulation"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :indexNo a samm:Property ;
     samm:preferredName "Index No"@en ;
     samm:description "Index number under Annex VI CLP; coded value."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :inductionTime a samm:Property ;
@@ -1984,6 +2033,7 @@
 :industrialUse a samm:Property ;
     samm:preferredName "Industrial Use"@en ;
     samm:description "Indicates whether industrial use is intended; yes/no or description."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :informationFromExportingSystem a samm:Property ;
@@ -2043,6 +2093,7 @@
     samm:preferredName "Internal Sds Id"@en ;
     samm:description "Internal SDS identitifier: The identity of the SDS in the system that generates the XML file. This field will usually not be shown in the SDS, but will be useful in future updates with new versions of previously received data sheets. This field is sufficiently large to accept GUID (Global Unique ID) on each SDS. System generated identity – not to be displayed. Use the same id independetly of the version of the SDS."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :intrusionDepth a samm:Property ;
@@ -2075,16 +2126,19 @@
 :isBiocide a samm:Property ;
     samm:preferredName "Is Biocide"@en ;
     samm:description "Indicates whether the product is a biocide; yes/no."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :isDetergent a samm:Property ;
     samm:preferredName "Is Detergent"@en ;
     samm:description "Indicates whether the product is a detergent; yes/no."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :isTreatedArticle a samm:Property ;
     samm:preferredName "Is Treated Article"@en ;
     samm:description "Indicates whether it is a treated article; yes/no."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :issueDate a samm:Property ;
@@ -2098,6 +2152,7 @@
     samm:preferredName "Iupac Name"@en ;
     samm:description "IUPAC or chemical name"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :justificationForDataWaiving a samm:Property ;
@@ -2133,6 +2188,7 @@
     samm:preferredName "Legal Document File Name"@en ;
     samm:description "File name: For example, a locked PDF document. A fixed URL is possible."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :legalDocumentPrintDate a samm:Property ;
@@ -2144,6 +2200,7 @@
 :legalDocumentSignature a samm:Property ;
     samm:preferredName "Legal Document Signature"@en ;
     samm:description "Digital signature: Digital signature to verify the document."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :limit8H a samm:Property ;
@@ -2165,6 +2222,7 @@
 :limitedQty a samm:Property ;
     samm:preferredName "Limited Qty"@en ;
     samm:description "Limited quantity under dangerous goods regulations; unit depends on the entry, e.g. L or kg."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :listItemNo a samm:Property ;
@@ -2220,11 +2278,13 @@
 :malCodeDeliveryState a samm:Property ;
     samm:preferredName "Mal Code Delivery State"@en ;
     samm:description "MAL code in the delivery state under Danish requirements; code usually formatted as two numbers separated by a hyphen (example: 00-1)"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :malCodeReadyToUse a samm:Property ;
     samm:preferredName "Mal Code Ready To Use"@en ;
     samm:description "If the application requires mixing or thinning, Mal codes should be determined also for the ready to use product. Omit if this is not the case."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :manufacturer a samm:Property ;
@@ -2236,6 +2296,7 @@
 :marinePollutant a samm:Property ;
     samm:preferredName "Marine Pollutant"@en ;
     samm:description "Marine pollutant: To state if the chemical is classified as a marine pollutant."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :maskType a samm:Property ;
@@ -2389,6 +2450,7 @@
 :mergeText a samm:Property ;
     samm:preferredName "Merge Text"@en ;
     samm:description "Merged text from phrase components."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :methodFulltext a samm:Property ;
@@ -2427,6 +2489,7 @@
 :mixtureExposureScenarioInAnnex a samm:Property ;
     samm:preferredName "Mixture Exposure Scenario In Annex"@en ;
     samm:description "Exposure scenarios for the mixture: To state if information on the actual use of the mixture, similar to information in an exposure scenario for a substance, is enclosed the SDS."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :mobility a samm:Property ;
@@ -2452,12 +2515,14 @@
 :name a samm:Property ;
     samm:preferredName "Name"@en ;
     samm:description "name or designation of the product, GTIN entry or element."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nameDetergentsRegulation a samm:Property ;
     samm:preferredName "Name Detergents Regulation"@en ;
     samm:description "Designation of the applicable detergent regulation or information."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :narcoticEffects a samm:Property ;
@@ -2470,6 +2535,7 @@
     samm:preferredName "National Contact"@en ;
     samm:description "National contact person or contact point for regional requirements."@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislation a samm:Property ;
@@ -2481,11 +2547,13 @@
 :nationalLegislationAlbania a samm:Property ;
     samm:preferredName "National Legislation Albania"@en ;
     samm:description "EU candidate"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationAndorra a samm:Property ;
     samm:preferredName "National Legislation Andorra"@en ;
     samm:description "not part of the EU, but closely connected and currently without relevant national regulations. This element is a placeholder."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationAustria a samm:Property ;
@@ -2496,36 +2564,43 @@
 :nationalLegislationBelarus a samm:Property ;
     samm:preferredName "National Legislation Belarus"@en ;
     samm:description "National legislation for Belarus."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationBelgium a samm:Property ;
     samm:preferredName "National Legislation Belgium"@en ;
     samm:description "National legislation for Belgium; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationBosniaAndHerzegovina a samm:Property ;
     samm:preferredName "National Legislation Bosnia And Herzegovina"@en ;
     samm:description "not a EU member and witout chemicals law - except for the Srpska province, which aligns its safety data sheet to the EU."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationBulgaria a samm:Property ;
     samm:preferredName "National Legislation Bulgaria"@en ;
     samm:description "National legislation for Bulgaria; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationCroatia a samm:Property ;
     samm:preferredName "National Legislation Croatia"@en ;
     samm:description "National legislation for Croatia; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationCyprus a samm:Property ;
     samm:preferredName "National Legislation Cyprus"@en ;
     samm:description "National legislation for Cyprus; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationCzechRepublic a samm:Property ;
     samm:preferredName "National Legislation Czech Republic"@en ;
     samm:description "National legislation for Czech Republic; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationDenmark a samm:Property ;
@@ -2536,16 +2611,19 @@
 :nationalLegislationEstonia a samm:Property ;
     samm:preferredName "National Legislation Estonia"@en ;
     samm:description "National legislation for Estonia; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationFinland a samm:Property ;
     samm:preferredName "National Legislation Finland"@en ;
     samm:description "National legislation for Finland; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationFrance a samm:Property ;
     samm:preferredName "National Legislation France"@en ;
     samm:description "includes French Guayana, Guadeloupe, Martinique, Réunion, Mayotte and Saint Martin, which are not part of the European Customs Union."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationGermany a samm:Property ;
@@ -2557,76 +2635,91 @@
 :nationalLegislationGreece a samm:Property ;
     samm:preferredName "National Legislation Greece"@en ;
     samm:description "National legislation for Greece; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationHungary a samm:Property ;
     samm:preferredName "National Legislation Hungary"@en ;
     samm:description "National legislation for Hungary; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationIceland a samm:Property ;
     samm:preferredName "National Legislation Iceland"@en ;
     samm:description "not part of the EU, but chemical legislation aligned with EU legislation."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationIreland a samm:Property ;
     samm:preferredName "National Legislation Ireland"@en ;
     samm:description "National legislation for Ireland; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationItaly a samm:Property ;
     samm:preferredName "National Legislation Italy"@en ;
     samm:description "National legislation for Italy; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationKazakhstan a samm:Property ;
     samm:preferredName "National Legislation Kazakhstan"@en ;
     samm:description "National legislation for Kazakhstan."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationLatvia a samm:Property ;
     samm:preferredName "National Legislation Latvia"@en ;
     samm:description "National legislation for Latvia; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationLiechtenstein a samm:Property ;
     samm:preferredName "National Legislation Liechtenstein"@en ;
     samm:description "not part of the EU, but closely connected."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationLithuania a samm:Property ;
     samm:preferredName "National Legislation Lithuania"@en ;
     samm:description "National legislation for Lithuania; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationLuxembourg a samm:Property ;
     samm:preferredName "National Legislation Luxembourg"@en ;
     samm:description "National legislation for Luxembourg; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationMalta a samm:Property ;
     samm:preferredName "National Legislation Malta"@en ;
     samm:description "National legislation for Malta; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationMonaco a samm:Property ;
     samm:preferredName "National Legislation Monaco"@en ;
     samm:description "not part of the EU, but closely connected."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationMontenegro a samm:Property ;
     samm:preferredName "National Legislation Montenegro"@en ;
     samm:description "EU candidate"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationNetherlands a samm:Property ;
     samm:preferredName "National Legislation Netherlands"@en ;
     samm:description "National legislation for Netherlands; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationNorthMacedonia a samm:Property ;
     samm:preferredName "National Legislation North Macedonia"@en ;
     samm:description "EU candidate"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationNorway a samm:Property ;
@@ -2637,51 +2730,61 @@
 :nationalLegislationPoland a samm:Property ;
     samm:preferredName "National Legislation Poland"@en ;
     samm:description "National legislation for Poland; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationPortugal a samm:Property ;
     samm:preferredName "National Legislation Portugal"@en ;
     samm:description "includes the Azores and Madeira"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationRomania a samm:Property ;
     samm:preferredName "National Legislation Romania"@en ;
     samm:description "National legislation for Romania; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationRussianFederation a samm:Property ;
     samm:preferredName "National Legislation Russian Federation"@en ;
     samm:description "National legislation for Russian Federation."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationSanMarino a samm:Property ;
     samm:preferredName "National Legislation San Marino"@en ;
     samm:description "not part of the EU, but closely connected and currently without relevant national regulations. This element is a placeholder."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationSerbia a samm:Property ;
     samm:preferredName "National Legislation Serbia"@en ;
     samm:description "EU candidate"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationSlovakia a samm:Property ;
     samm:preferredName "National Legislation Slovakia"@en ;
     samm:description "National legislation for Slovakia; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationSlovenia a samm:Property ;
     samm:preferredName "National Legislation Slovenia"@en ;
     samm:description "National legislation for Slovenia; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationSpain a samm:Property ;
     samm:preferredName "National Legislation Spain"@en ;
     samm:description "Includes the Canaries. Includes Ceuta and Melilla which are not part of the European Customs Union."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationSweden a samm:Property ;
     samm:preferredName "National Legislation Sweden"@en ;
     samm:description "National legislation for Sweden; structured value, code or phrase."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationSwitzerland a samm:Property ;
@@ -2692,16 +2795,19 @@
 :nationalLegislationUkraine a samm:Property ;
     samm:preferredName "National Legislation Ukraine"@en ;
     samm:description "not part of the EU, but legislation allows SDS according to EU standards."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationUnitedKingdom a samm:Property ;
     samm:preferredName "National Legislation United Kingdom"@en ;
     samm:description "No EU member anymore after March 29, 2019. Until deviating legislation is established, the UK will be covered with a EU safety data sheet. Includes Gibraltar, which is not part of the European Customs Union."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationVaticanCityState a samm:Property ;
     samm:preferredName "National Legislation Vatican City State"@en ;
     samm:description "not part of the EU, but closely connected and currently without relevant national regulations. This element is a placeholder."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nationalLegislationsDescription a samm:Property ;
@@ -2737,11 +2843,13 @@
 :newLine a samm:Property ;
     samm:preferredName "New Line"@en ;
     samm:description "specify this empty tag to indicate a line break"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :noInt20 a samm:Property ;
     samm:preferredName "No"@en ;
     samm:description "GTIN No:"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :noPhrase a samm:Property ;
@@ -2753,6 +2861,7 @@
     samm:preferredName "No"@en ;
     samm:description "Telephone number:"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :nom2015HazardClassification a samm:Property ;
@@ -2788,11 +2897,13 @@
 :oarGroup a samm:Property ;
     samm:preferredName "Oar Group"@en ;
     samm:description "Norway: Group or category of occupational air requirement."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :oarValue a samm:Property ;
     samm:preferredName "Oar Value"@en ;
     samm:description "Norway: numerical value for occupational air requirement."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :occupationalAirRequirement a samm:Property ;
@@ -2857,6 +2968,7 @@
 :organisationalSigns a samm:Property ;
     samm:preferredName "Organisational Signs"@en ;
     samm:description "Organisational signs or notices, e.g. warning, prohibition or mandatory signs."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :other a samm:Property ;
@@ -2921,6 +3033,7 @@
     samm:preferredName "Other Name"@en ;
     samm:description "Includes trade name(s) of the chemical that appear on the packages / hazard label."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :otherPhysicalChemicalProperty a samm:Property ;
@@ -3138,6 +3251,7 @@
     samm:preferredName "Phone"@en ;
     samm:description "Telephone number:"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :photoIrritationFactor a samm:Property ;
@@ -3188,18 +3302,21 @@
     samm:preferredName "Phrase Catalogue Issuer"@en ;
     samm:description "Phrase catalogue issuer: Identification of the suppler of the phrase catalogue to the exporting system, eg. EuPhraC-Workinggroup."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :phraseCatalogueName a samm:Property ;
     samm:preferredName "Phrase Catalogue Name"@en ;
     samm:description "Phrase catalogue Name, eg. EuPhraC"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :phraseCatalogueVersion a samm:Property ;
     samm:preferredName "Phrase Catalogue Version"@en ;
     samm:description "Catalogue version: The version no of the phrase catalog the information is based on to identify the actual version of the phrase catalogue applied. Phrase catalogues are updated more or less regularly, and different versions may show some differences."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeAtp12SpecialSupplementalLabelInfoEnum a samm:Property ;
@@ -3217,31 +3334,37 @@
 :phraseCodeGhs03HazardEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
     samm:description "Should be present for GHS hazard statements, and omitted only for additional US hazard statements."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeGhs03PrecautionEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
     samm:description "code of a precautionary statement according to GHS-Revision 3, e.g. P-Satz."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeGhs05HazardEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
     samm:description "code of a hazard statement according to GHS-Revision 5, e.g. H-Satz."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeGhs05PrecautionEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
     samm:description "code of a precautionary statement according to GHS-Revision 5, e.g. P-Satz."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeGhs07HazardEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
     samm:description "code of a hazard statement according to GHS-Revision 7, e.g. H-Satz."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeGhs07PrecautionEnum a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
     samm:description "code of a precautionary statement according to GHS-Revision 7, e.g. P-Satz."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :phraseCodeGhsSignalWordEnum a samm:Property ;
@@ -3253,6 +3376,7 @@
 :phraseCodeString64 a samm:Property ;
     samm:preferredName "Phrase Code"@en ;
     samm:description "Phrase code with a maximum of 64 characters; technical identifier."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :phraseId a samm:Property ;
@@ -3320,30 +3444,35 @@
     samm:preferredName "Post Address Line1"@en ;
     samm:description "Postal address: P.O.Box or street address"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :postAddressLine2 a samm:Property ;
     samm:preferredName "Post Address Line2"@en ;
     samm:description "Second line of the postal address."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :postAddressLine3 a samm:Property ;
     samm:preferredName "Post Address Line3"@en ;
     samm:description "Third line of the postal address."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :postCity a samm:Property ;
     samm:preferredName "Post City"@en ;
     samm:description "Postal city:"@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :postCode a samm:Property ;
     samm:preferredName "Post Code"@en ;
     samm:description "Postal code: Two-letter ISO3166 country code followed by a hyphen and the national postal code."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :pourPoint a samm:Property ;
@@ -3360,11 +3489,13 @@
 :prProductCode a samm:Property ;
     samm:preferredName "Pr Product Code"@en ;
     samm:description "Norway: Product code in PR register or national notification system."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :prProductNo a samm:Property ;
     samm:preferredName "Pr Product No"@en ;
     samm:description "Norway: Product number in PR register or national notification system."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :prProductRegistration a samm:Property ;
@@ -3401,6 +3532,7 @@
 :printAsAttachment a samm:Property ;
     samm:preferredName "Print As Attachment"@en ;
     samm:description "Indicates whether the identified use is to be output as an annex; yes/no."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :procCode a samm:Property ;
@@ -3458,12 +3590,14 @@
 :productName a samm:Property ;
     samm:preferredName "Product Name"@en ;
     samm:description "Product name in transport or bulk transport context."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :productNoUser a samm:Property ;
     samm:preferredName "Product No User"@en ;
     samm:description "The user's item number: The item number(s) used internally by the customer (user). Usually just 1 instance per TradeProductIdentity."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :productRelatedMeasures a samm:Property ;
@@ -3491,6 +3625,7 @@
 :professionalUse a samm:Property ;
     samm:preferredName "Professional Use"@en ;
     samm:description "Indicates whether professional use is intended; yes/no or description."@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :propellantContent a samm:Property ;
@@ -3571,11 +3706,13 @@
 :rcraWasteCode a samm:Property ;
     samm:preferredName "Rcra Waste Code"@en ;
     samm:description "US RCRA hazardous waste code; coded value."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :reachRegNo a samm:Property ;
     samm:preferredName "Reach Reg No"@en ;
     samm:description "REACH registration number of the substance; alphanumeric value."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :reactivityDescription a samm:Property ;
@@ -3987,6 +4124,7 @@
 :rmmPictogram a samm:Property ;
     samm:preferredName "Rmm Pictogram"@en ;
     samm:description "Pictogram for risk management measure; coded symbol"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :rmmWorker a samm:Property ;
@@ -4065,6 +4203,7 @@
 :safetySigns a samm:Property ;
     samm:preferredName "Safety Signs"@en ;
     samm:description "Normally to be displayed or printed at the top of section 8. In case of using information from components, duplicates should be removed."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :scaleOfUse a samm:Property ;
@@ -4094,6 +4233,7 @@
     samm:preferredName "Sds Name"@en ;
     samm:description "Name of the SDS. Shall be identical with the name on the hazard label and package unless the SDS is a group SDS, in which case the hazard label name must match one of the instances of TradeProductIdentity."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :sdsNotLegallyRequired a samm:Property ;
@@ -4142,6 +4282,7 @@
 :sectorSumiCode a samm:Property ;
     samm:preferredName "Sector Sumi Code"@en ;
     samm:description "Leave empty if the Sumi is not published by a chemical sector association and part of Use Map activities (no company specific SUMI codes here!). First word should be the sector name, e.g. AISE or FEICA, followed by the sector's SUMI code."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :sedimentToxicity a samm:Property ;
@@ -4175,6 +4316,7 @@
 :sicCode a samm:Property ;
     samm:preferredName "Sic Code"@en ;
     samm:description "Norway: SIC code for industry sector or activity; coded value."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :signalWord a samm:Property ;
@@ -4320,6 +4462,7 @@
 :specialProvisions a samm:Property ;
     samm:preferredName "Special Provisions"@en ;
     samm:description "Special provisions under dangerous goods law; coded or textual information."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :specialRulesOnPackaging a samm:Property ;
@@ -4428,12 +4571,14 @@
     samm:preferredName "Specification No"@en ;
     samm:description "Sender-defined identification of a specification the chemical is in accordance with, e.g. a formulation number. This is not meant for compliance statements like international or vendor-internal standards!"@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :spercCode a samm:Property ;
     samm:preferredName "Sperc Code"@en ;
     samm:description "SPERC code for specific environmental release category."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :spercFulltext a samm:Property ;
@@ -4659,6 +4804,7 @@
     samm:preferredName "System Used In Preparation"@en ;
     samm:description "Software applied in preparation of information: State which system the information has been exported from. The actual version number of the system applied or any other identifier that helps to understand the export scope or method should also be stated."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :taLuft a samm:Property ;
@@ -4669,6 +4815,7 @@
 :tactileWarning a samm:Property ;
     samm:preferredName "Tactile Warning"@en ;
     samm:description "Tactile Warning: To inform if packaging must be supplied with tactile warning if the chemical is supplied to the gerneral public"@en ;
+    samm:exampleValue "true"^^xsd:boolean ;
     samm:characteristic samm-c:Boolean .
 
 :targetGroup a samm:Property ;
@@ -4700,6 +4847,7 @@
 :technicalSigns a samm:Property ;
     samm:preferredName "Technical Signs"@en ;
     samm:description "Technical labels or signs on installations or work equipment."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :terrestrialToxicity a samm:Property ;
@@ -4801,6 +4949,7 @@
 :tradeName a samm:Property ;
     samm:preferredName "Trade Name"@en ;
     samm:description "for Mixtures"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :tradeProductIdentity a samm:Property ;
@@ -4876,16 +5025,19 @@
 :ucnCode a samm:Property ;
     samm:preferredName "Ucn Code"@en ;
     samm:description "Norway: UCN code in national product register; coded value."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :ufi a samm:Property ;
     samm:preferredName "Ufi"@en ;
     samm:description "Companies are allowed to define multiple UFIs for the same composition, even for the same product. As group safety data sheets are allowed, it should be possible to transmit multiple UFIs although the main intention for multiple UFIs might be to hide the identity of differently named products."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :unNo a samm:Property ;
     samm:preferredName "Un No"@en ;
     samm:description "UN number IMDG:"@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :unit a samm:Property ;
@@ -4954,6 +5106,7 @@
     samm:preferredName "Url"@en ;
     samm:description "URL: Web addressof the company contact"@en ;
     samm:see <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "https://example.com"^^xsd:anyURI ;
     samm:characteristic samm-c:ResourcePath .
 
 :use a samm:Property ;
@@ -4977,6 +5130,7 @@
     samm:preferredName "User Id"@en ;
     samm:description "The user (direct or indirect customer of the supplier, recipient of the SDS) that the information in this instance of TradeIdentity is meant for. Leave empty if this instance of TradeProductIdentity refers to the supplier."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :valueFloat a samm:Property ;
@@ -5034,11 +5188,13 @@
     samm:preferredName "Version No"@en ;
     samm:description "Version No: The current version of the SDS document."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :versionNumber a samm:Property ;
     samm:preferredName "Version Number"@en ;
     samm:description "Version number is optional here because SUMI info is part of the eSDS which is versioned, so the version date is expected to be the same and is sufficient to determine a sector SUMI version."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :viscosity a samm:Property ;
@@ -5050,26 +5206,31 @@
 :visitingAddressCity a samm:Property ;
     samm:preferredName "Visiting Address City"@en ;
     samm:description "city of the visiting address."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :visitingAddressLine1 a samm:Property ;
     samm:preferredName "Visiting Address Line1"@en ;
     samm:description "First line of the visiting address."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :visitingAddressLine2 a samm:Property ;
     samm:preferredName "Visiting Address Line2"@en ;
     samm:description "Second line of the visiting address."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :visitingAddressLine3 a samm:Property ;
     samm:preferredName "Visiting Address Line3"@en ;
     samm:description "Third line of the visiting address."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :visitingAddressPostCode a samm:Property ;
     samm:preferredName "Visiting Address Post Code"@en ;
     samm:description "Postal code: Two-letter ISO3166 country code followed by a hyphen and the national postal code."@en ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :voc a samm:Property ;
@@ -5111,6 +5272,7 @@
     samm:preferredName "Waste Code"@en ;
     samm:description "Waste code according to the applicable waste catalogue, e.g. EWC/AVV-code; coded value."@en ;
     samm:see <https://esdscom.eu/SDScomBau>, <https://esdscom.eu/SDScomChem> ;
+    samm:exampleValue "Example text"^^xsd:string ;
     samm:characteristic samm-c:Text .
 
 :wasteDescription a samm:Property ;

--- a/io.catenax.esdscom/1.0.0/eSDScom.ttl
+++ b/io.catenax.esdscom/1.0.0/eSDScom.ttl
@@ -16,10 +16,7 @@
 #
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
-#
-# This ontology was generated from an XML schema definition by a
-# script and thus lacks the perfection of a native TTL file.
-#######################################################################
+
 @prefix :       <urn:samm:io.catenax.esdscom:1.0.0#> .
 @prefix samm:   <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
@@ -33,7 +30,7 @@
 # Aspect
 # ──────────────────────────────────────────────────────────────────────────
 
-:Esdscom a samm:Aspect ;
+:eSDScom a samm:Aspect ;
     samm:preferredName "Datasheet Feed"@en ;
     samm:description "The SDScom root element"@en ;
     samm:see <https://esdscom.eu/esdscom_5_6> ;

--- a/io.catenax.esdscom/RELEASE_NOTES.md
+++ b/io.catenax.esdscom/RELEASE_NOTES.md
@@ -1,0 +1,18 @@
+\# Changelog
+
+
+
+All notable changes to this model will be documented in this file.
+
+&#x20;
+
+\## \[1.0.0] - R26.09
+
+
+
+\### Added
+
+
+
+\- initial model
+

--- a/io.catenax.esdscom/RELEASE_NOTES.md
+++ b/io.catenax.esdscom/RELEASE_NOTES.md
@@ -1,18 +1,20 @@
-\# Changelog
-
-
+# Changelog
 
 All notable changes to this model will be documented in this file.
 
-&#x20;
+## [1.0.0] 26.09
 
-\## \[1.0.0] - R26.09
+Note: This aspect model was generated from an XML schema definition (sdscom-xml) by a script and thus reflects the XML-structure which is not in line with best practices for SAMM. For this initial version, this structural alignment is intentional to keep deviations between the XML and SAMM versions to a minimum. However, as a result, it lacks modularity and semantical clarity and is restricted to standalone usage; it shall not be reused (imported) in other models. The script used for generation and schema definition are Open Source and available under https://github.com/esdscom/.
 
+### Added
 
+- initial model
 
-\### Added
+### Changed
 
+n/a
 
+### Removed
 
-\- initial model
+n/a
 


### PR DESCRIPTION
## Description

First commit of eSDScom, a model to describe Safety Data Sheets and related regulatory information for the chemical supply chain.

Closes #918

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] payload names and property identifiers must not contain two consecutive underscores ('__') at any position (e.g. `my__model` is not allowed)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [x] all external / imported models have the state "release"
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
