### PR TITLE
Move part instance to new namespace

### DIFF
--- a/io.catenax.batch/1.0.2/metadata.json
+++ b/io.catenax.batch/1.0.2/metadata.json
@@ -1,1 +1,1 @@
-{"status": "deprecated"}
+{"status": "invalidated"}

--- a/io.catenax.batch/2.0.0/metadata.json
+++ b/io.catenax.batch/2.0.0/metadata.json
@@ -1,1 +1,1 @@
-{"status": "deprecated"}
+{"status": "invalidated"}

--- a/io.catenax.batch/2.0.1/metadata.json
+++ b/io.catenax.batch/2.0.1/metadata.json
@@ -1,1 +1,1 @@
-{"status": "deprecated"}
+{"status": "invalidated"}

--- a/io.catenax.batch/3.0.0/metadata.json
+++ b/io.catenax.batch/3.0.0/metadata.json
@@ -1,1 +1,1 @@
-{"status": "release"}
+{"status": "depracted"}

--- a/io.catenax.batch/3.0.0/metadata.json
+++ b/io.catenax.batch/3.0.0/metadata.json
@@ -1,1 +1,1 @@
-{"status": "depracted"}
+{"status": "deprecated"}

--- a/io.catenax.batch/3.0.1/metadata.json
+++ b/io.catenax.batch/3.0.1/metadata.json
@@ -1,1 +1,1 @@
-{"status": "release"}
+{"status": "depracted"}

--- a/io.catenax.batch/3.0.1/metadata.json
+++ b/io.catenax.batch/3.0.1/metadata.json
@@ -1,1 +1,1 @@
-{"status": "depracted"}
+{"status": "deprecated"}

--- a/io.catenax.batch/4.0.0/metadata.json
+++ b/io.catenax.batch/4.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"}
+{ "status" : "depracted"}

--- a/io.catenax.batch/4.0.0/metadata.json
+++ b/io.catenax.batch/4.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "depracted"}
+{ "status" : "deprecated"}

--- a/io.catenax.batch/RELEASE_NOTES.md
+++ b/io.catenax.batch/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 All notable changes to this model will be documented in this file.
 
+## [Moved] 26.09
+
+- moved to new namespace from `io.catenax.batch` to `io.catenax.industry_core.batch`
+
 ## [4.0.0] 26.03
 
 ### Changed

--- a/io.catenax.industry_core.batch/4.0.0/Batch.ttl
+++ b/io.catenax.industry_core.batch/4.0.0/Batch.ttl
@@ -1,0 +1,62 @@
+#######################################################################
+# Copyright(c) 2022 BASF SE
+# Copyright(c) 2022 Bayerische Motoren Werke Aktiengesellschaft(BMW AG)
+# Copyright(c) 2022 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.(represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright(c) 2022 German Edge Cloud GmbH & Co. KG
+# Copyright(c) 2022 Henkel AG & Co. KGaA
+# Copyright(c) 2022 Mercedes Benz AG
+# Copyright(c) 2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright(c) 2022 SAP SE
+# Copyright(c) 2022 Siemens AG
+# Copyright(c) 2022 T-Systems International GmbH
+# Copyright(c) 2024 ZF Friedrichshafen AG
+# Copyright(c) 2026 Catena-X Automotive Network e.V.
+# Copyright(c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International(CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.batch:4.0.0#> .
+@prefix ext-ic: <urn:samm:io.catenax.shared.industry_core.common:1.0.0#> .
+@prefix ext-ic-mx: <urn:samm:io.catenax.shared.industry_core.manufacturing_information:1.0.0#> .
+@prefix ext-ic-pc: <urn:samm:io.catenax.shared.industry_core.part_classification:1.0.0#> .
+
+:Batch a samm:Aspect ;
+   samm:preferredName "batch"@en ;
+   samm:description "A batch is a quantity of(semi-)finished products or(raw)material product that have been produced under the same circumstances(e.g. same production location), as specified groups or amounts, within a certain time frame. Every batch can differ in the number or amount of products. Different batches can have varied specifications, e.g., different colors. A batch is identified via a Batch ID."@en ;
+   samm:properties ( :partTypeInformation ext-ic:globalAssetId ext-ic:localIdentifiers ext-ic-mx:manufacturingInformation ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:partTypeInformation a samm:Property ;
+   samm:preferredName "part type information"@en ;
+   samm:description "The part type of which the batch has been instantiated of."@en ;
+   samm:characteristic :PartTypeInformationCharacteristic .
+
+:PartTypeInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "part type information characteristic"@en ;
+   samm:description "The characteristics of the part type"@en ;
+   samm:dataType :PartTypeInformationEntity .
+
+:PartTypeInformationEntity a samm:Entity ;
+   samm:preferredName "part type information entity"@en ;
+   samm:description "Encapsulation for data related to the part type."@en ;
+
+   samm:properties ( ext-ic:manufacturerPartId ext-ic:nameAtManufacturer [ samm:property ext-ic-pc:partClassification; samm:optional true ] ) .
+
+

--- a/io.catenax.industry_core.batch/4.0.0/metadata.json
+++ b/io.catenax.industry_core.batch/4.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.industry_core.batch/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.batch/RELEASE_NOTES.md
@@ -1,0 +1,80 @@
+# Changelog
+
+All notable changes to this model will be documented in this file.
+
+## [4.0.0] 26.03
+
+### Changed
+
+- moved to new namespace from io.catenax.batch
+
+## [4.0.0] 26.03
+
+### Changed
+
+- introduced `io.catenax.shared.industry_core.common:1.0.0`, `io.catenax.shared.industry_core.manufacturing_information:1.0.0` and `io.catenax.shared.industry_core.part_classification:1.0.0` as shared models
+- renamed `catenaXId` to `globalAssetId`
+- renamed `catenaXsiteId` to `siteId`
+- renamed `classificationID` to `classificationId`
+- renamed `date` to `productionDate`
+
+## [3.0.1] 2025-09-26
+
+### Changed
+
+- Fixed example value of "date" to match the regular expression
+
+## [3.0.0] 2024-02-05
+
+### Added
+
+- Integration of the new shared PartClassification 1.0.0 aspect model as child-property of the PartTypeInformation
+- Added possibility to add date information excluding time
+- Include additional RegEx values for the local identifier key
+
+### Changed
+
+- Change (shared) partSiteInformation to be a child-property of the manufacturerInformation
+
+## [2.0.1] 2023-12-04
+
+### Added
+
+- integration of the sites property and its childtree of the shared PartSiteInformationAsBuilt (1.0.0) aspect model as optional content
+- integration of the shared UUID characteristic and RegEx for the catenaXId property
+
+### Changed
+
+- n/a
+
+### Removed
+
+- removed existing characteristic and RegEx of the catenaXId property and replaced it with content of the shared UUID aspect model (see added information)
+
+## [2.0.0] - 2023-09-04
+
+### Added
+
+- added KeyRegularExpression
+
+### Changed
+
+- changed description of KeyCharacteristic
+
+### Removed
+
+- properties customerId and nameAtCustomer
+
+## [1.0.2] - 2022-11-23
+
+### Added
+
+- initial model
+- fix in example value
+- fix regex
+
+### Changed
+
+n/a
+
+### Removed

--- a/io.catenax.industry_core.batch/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.batch/RELEASE_NOTES.md
@@ -2,11 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
-## [Moved] 26.09
+## [4.0.0] 26.09
 
 - moved to new namespace from `io.catenax.batch`
-
-## [4.0.0] 26.03
 
 ### Changed
 

--- a/io.catenax.industry_core.batch/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.batch/RELEASE_NOTES.md
@@ -2,11 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
-## [4.0.0] 26.03
+## [Moved] 26.09
 
-### Changed
-
-- moved to new namespace from io.catenax.batch
+- moved to new namespace from `io.catenax.batch`
 
 ## [4.0.0] 26.03
 

--- a/io.catenax.industry_core.just_in_sequence_part/4.0.0/JustInSequencePart.ttl
+++ b/io.catenax.industry_core.just_in_sequence_part/4.0.0/JustInSequencePart.ttl
@@ -1,17 +1,17 @@
 #######################################################################
-# Copyright(c) 2022 BASF SE
-# Copyright(c) 2022 Bayerische Motoren Werke Aktiengesellschaft(BMW AG)
-# Copyright(c) 2022 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.(represented by Fraunhofer ISST & Fraunhofer IML)
-# Copyright(c) 2022 German Edge Cloud GmbH & Co. KG
-# Copyright(c) 2022 Henkel AG & Co. KGaA
-# Copyright(c) 2022 Mercedes Benz AG
-# Copyright(c) 2022 Robert Bosch Manufacturing Solutions GmbH
-# Copyright(c) 2022 SAP SE
-# Copyright(c) 2022 Siemens AG
-# Copyright(c) 2022 T-Systems International GmbH
-# Copyright(c) 2024 ZF Friedrichshafen AG
+# Copyright(c) 2023 BASF SE
+# Copyright(c) 2023 Bayerische Motoren Werke Aktiengesellschaft(BMW AG)
+# Copyright(c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.(represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright(c) 2023 German Edge Cloud GmbH & Co. KG
+# Copyright(c) 2023 Henkel AG & Co. KGaA
+# Copyright(c) 2023 Mercedes Benz AG
+# Copyright(c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright(c) 2023 SAP SE
+# Copyright(c) 2023 Siemens AG
+# Copyright(c) 2023 T-Systems International GmbH
+# Copyright(c) 2023 ZF Friedrichshafen AG
 # Copyright(c) 2026 Catena-X Automotive Network e.V.
-# Copyright(c) 2022 Contributors to the Eclipse Foundation
+# Copyright(c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -31,32 +31,30 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <urn:samm:io.catenax.industry_core.batch:4.0.0#> .
+@prefix : <urn:samm:io.catenax.industry_core.just_in_sequence_part:4.0.0#> .
 @prefix ext-ic: <urn:samm:io.catenax.shared.industry_core.common:1.0.0#> .
 @prefix ext-ic-mx: <urn:samm:io.catenax.shared.industry_core.manufacturing_information:1.0.0#> .
 @prefix ext-ic-pc: <urn:samm:io.catenax.shared.industry_core.part_classification:1.0.0#> .
 
-:Batch a samm:Aspect ;
-   samm:preferredName "batch"@en ;
-   samm:description "A batch is a quantity of(semi-)finished products or(raw)material product that have been produced under the same circumstances(e.g. same production location), as specified groups or amounts, within a certain time frame. Every batch can differ in the number or amount of products. Different batches can have varied specifications, e.g., different colors. A batch is identified via a Batch ID."@en ;
-   samm:properties ( :partTypeInformation ext-ic:globalAssetId ext-ic:localIdentifiers ext-ic-mx:manufacturingInformation ) ;
+:JustInSequencePart a samm:Aspect ;
+   samm:preferredName "just in sequence part"@en ;
+   samm:description "A just-in-sequence part is an instantiation of a (design-)part, where the particular instantiation can be uniquely identified by means of a combination of several IDs related to a just-in-sequence process."@en ;
+   samm:properties ( :partTypeInformation ext-ic:localIdentifiers ext-ic-mx:manufacturingInformation ext-ic:globalAssetId ) ;
    samm:operations ( ) ;
    samm:events ( ) .
 
 :partTypeInformation a samm:Property ;
    samm:preferredName "part type information"@en ;
-   samm:description "The part type of which the batch has been instantiated of."@en ;
+   samm:description "The part type or part family from which the just-in-sequence part has been instantiated."@en ;
    samm:characteristic :PartTypeInformationCharacteristic .
 
 :PartTypeInformationCharacteristic a samm:Characteristic ;
    samm:preferredName "part type information characteristic"@en ;
-   samm:description "The characteristics of the part type"@en ;
+   samm:description "The characteristics of the part type."@en ;
+
    samm:dataType :PartTypeInformationEntity .
 
 :PartTypeInformationEntity a samm:Entity ;
    samm:preferredName "part type information entity"@en ;
-   samm:description "Encapsulation for data related to the part type."@en ;
-
-   samm:properties ( ext-ic:manufacturerPartId ext-ic:nameAtManufacturer [ samm:property ext-ic-pc:partClassification; samm:optional true ] ) .
-
-
+   samm:description "Encapsulation for data related to the part type"@en ;
+   samm:properties ( ext-ic:nameAtManufacturer [ samm:property ext-ic:manufacturerPartId; samm:optional true ] [ samm:property ext-ic:customerPartId; samm:optional true ] [ samm:property ext-ic:nameAtCustomer; samm:optional true ] [ samm:property ext-ic-pc:partClassification; samm:optional true ] ) .

--- a/io.catenax.industry_core.just_in_sequence_part/4.0.0/metadata.json
+++ b/io.catenax.industry_core.just_in_sequence_part/4.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.industry_core.just_in_sequence_part/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.just_in_sequence_part/RELEASE_NOTES.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this model will be documented in this file.
+
+## [4.0.0] 26.09
+
+### Changed
+
+- moved to new namespace from io.catenax.just_in_sequence_part
+
+## [4.0.0] 26.03
+
+### Changed
+
+- introduced `io.catenax.shared.industry_core.common:1.0.0`, `io.catenax.shared.industry_core.manufacturing_information:1.0.0` and `io.catenax.shared.industry_core.part_classification:1.0.0` as shared models
+- renamed `catenaXId` to `globalAssetId`
+- renamed `catenaXsiteId` to `siteId`
+- renamed `classificationID` to `classificationId`
+- renamed `date` to `productionDate`
+
+## [3.0.0] 2024-02-05
+
+### Added
+
+- Integration of the new shared PartClassification 1.0.0 aspect model as child-property of the PartTypeInformation
+- Added possibility to add date information excluding time
+- Include additional RegEx values for the local identifier key
+
+### Changed
+
+- Change (shared) partSiteInformation to be a child-property of the manufacturerInformation
+
+## [2.0.0] 2023-11-30
+
+### Added
+
+- integration of the sites property and its childtree of the shared PartSiteInformationAsBuilt (1.0.0) aspect model as optional content
+- integration of the shared UUID characteristic and RegEx for the catenaXId property
+
+### Changed
+
+- migrated current aspect model from BAMM to SAMM
+
+### Removed
+
+- removed existing characteristic and RegEx of the catenaXId property and replaced it with content of the shared UUID aspect model (see added information)
+
+## [1.0.0]
+
+### Added
+
+- initial version of model
+
+### Changed
+
+n/a
+
+### Removed

--- a/io.catenax.industry_core.just_in_sequence_part/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.just_in_sequence_part/RELEASE_NOTES.md
@@ -2,11 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
-## [4.0.0] 26.09
+## [Moved] 26.09
 
-### Changed
-
-- moved to new namespace from io.catenax.just_in_sequence_part
+- moved to new namespace from `io.catenax.just_in_sequence_part`
 
 ## [4.0.0] 26.03
 

--- a/io.catenax.industry_core.just_in_sequence_part/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.just_in_sequence_part/RELEASE_NOTES.md
@@ -2,11 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
-## [Moved] 26.09
+## [4.0.0] 26.09
 
 - moved to new namespace from `io.catenax.just_in_sequence_part`
-
-## [4.0.0] 26.03
 
 ### Changed
 

--- a/io.catenax.industry_core.serial_part/4.0.0/SerialPart.ttl
+++ b/io.catenax.industry_core.serial_part/4.0.0/SerialPart.ttl
@@ -1,0 +1,60 @@
+#######################################################################
+# Copyright(c) 2022 BASF SE
+# Copyright(c) 2022 Bayerische Motoren Werke Aktiengesellschaft(BMW AG)
+# Copyright(c) 2022 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.(represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright(c) 2022 German Edge Cloud GmbH & Co. KG
+# Copyright(c) 2022 Henkel AG & Co. KGaA
+# Copyright(c) 2022 Mercedes Benz AG
+# Copyright(c) 2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright(c) 2022 SAP SE
+# Copyright(c) 2022 Siemens AG
+# Copyright(c) 2022 T-Systems International GmbH
+# Copyright(c) 2022 ZF Friedrichshafen AG
+# Copyright(c) 2026 Catena-X Automotive Network e.V.
+# Copyright(c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International(CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.industry_core.serial_part:4.0.0#> .
+@prefix ext-ic: <urn:samm:io.catenax.shared.industry_core.common:1.0.0#> .
+@prefix ext-ic-mx: <urn:samm:io.catenax.shared.industry_core.manufacturing_information:1.0.0#> .
+@prefix ext-ic-pc: <urn:samm:io.catenax.shared.industry_core.part_classification:1.0.0#> .
+
+:SerialPart a samm:Aspect ;
+   samm:preferredName "serial part"@en ;
+   samm:description "A serialized part is an instantiation of a (design-)part, where the particular instantiation can be uniquely identified by means of a serial number or a similar identifier (e.g. VAN)or a combination of multiple identifiers (e.g. combination of manufacturer, date and number)"@en ;
+   samm:properties ( :partTypeInformation ext-ic:globalAssetId ext-ic:localIdentifiers ext-ic-mx:manufacturingInformation ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:partTypeInformation a samm:Property ;
+   samm:preferredName "part type information"@en ;
+   samm:description "The part type from which the serialized part has been instantiated"@en ;
+   samm:characteristic :PartTypeInformationCharacteristic .
+
+:PartTypeInformationCharacteristic a samm:Characteristic ;
+   samm:preferredName "part type information characteristic"@en ;
+   samm:description "The characteristics of the part type"@en ;
+   samm:dataType :PartTypeInformationEntity .
+
+:PartTypeInformationEntity a samm:Entity ;
+   samm:preferredName "part type information entity"@en ;
+   samm:description "Encapsulation for data related to the part type"@en ;
+   samm:properties ( ext-ic:nameAtCustomer [ samm:property ext-ic:nameAtManufacturer; samm:optional true ] ext-ic:customerPartId [ samm:property ext-ic:manufacturerPartId; samm:optional true ] ext-ic-pc:partClassification ) .
+

--- a/io.catenax.industry_core.serial_part/4.0.0/metadata.json
+++ b/io.catenax.industry_core.serial_part/4.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.industry_core.serial_part/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.serial_part/RELEASE_NOTES.md
@@ -1,0 +1,78 @@
+# Changelog
+
+All notable changes to this model will be documented in this file.
+
+## [4.0.0] 26.03
+
+### Changed
+- moved to new namespace
+
+## [4.0.0] 26.03
+
+### Changed
+
+- introduced `io.catenax.shared.industry_core.common:1.0.0`, `io.catenax.shared.industry_core.manufacturing_information:1.0.0` and `io.catenax.shared.industry_core.part_classification:1.0.0` as shared models
+- renamed `catenaXId` to `globalAssetId`
+- renamed `catenaXsiteId` to `siteId`
+- renamed `classificationID` to `classificationId`
+- renamed `date` to `productionDate`
+
+## [3.0.1] 2025-09-26
+
+- Fixed example value of "date" to match the regular expression
+
+## [3.0.0] 2024-02-05
+
+### Added
+
+- Integration of the new shared PartClassifcation 1.0.0 aspect model as child-property of the PartTypeInformation
+- Added possibility to add date information excluding time
+- Include additional RegEx values for the local identifier key
+
+### Changed
+
+- Change (shared) partSiteInformation to be a child-porperty of the manufacturerInformation
+
+  
+## [2.0.0] 2023-12-04
+
+### Added
+
+- integration of the sites property and its childtree of the shared PartSiteInformationAsBuilt (1.0.0) aspect model as optional content
+- integration of the shared UUID characteristic and RegEx for the catenaXId property
+
+### Changed
+
+- migrated current aspect model from BAMM to SAMM
+
+### Removed
+
+- removed existing characteristic and RegEx of the catenaXId property and replaced it with content of the shared UUID aspect model (see added information)
+
+## [1.0.1]
+
+### Added
+
+n/a
+
+### Changed
+
+- fixed casing in example value for `key` of `localIdentifier` to lower case
+
+### Removed
+
+n/a
+
+## [1.0.0]
+
+### Added
+
+- renamed model from `io.catenax.serial_part_typization:2.0.0#SerialPartTypization`
+
+### Changed
+
+- changed several descriptions due to aspect renaming
+
+### Removed
+
+n/a

--- a/io.catenax.industry_core.serial_part/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.serial_part/RELEASE_NOTES.md
@@ -2,10 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
-## [4.0.0] 26.03
+## [Moved] 26.09
 
-### Changed
-- moved to new namespace
+- moved to new namespace from `io.catenax.serial_part`
 
 ## [4.0.0] 26.03
 

--- a/io.catenax.industry_core.serial_part/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.serial_part/RELEASE_NOTES.md
@@ -2,11 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
-## [Moved] 26.09
+## [4.0.0] 26.09
 
 - moved to new namespace from `io.catenax.serial_part`
-
-## [4.0.0] 26.03
 
 ### Changed
 

--- a/io.catenax.industry_core.single_level_bom_as_built/4.0.0/SingleLevelBomAsBuilt.ttl
+++ b/io.catenax.industry_core.single_level_bom_as_built/4.0.0/SingleLevelBomAsBuilt.ttl
@@ -1,0 +1,70 @@
+#######################################################################
+# Copyright (c) 2022 BASF SE
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright (c) 2022 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2022 Henkel AG & Co. KGaA
+# Copyright (c) 2022 Mercedes Benz AG
+# Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022 T-Systems International GmbH
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2026 Catena-X Automotive Network e.V.
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.industry_core.single_level_bom_as_built:4.0.0#> .
+@prefix ext-ic: <urn:samm:io.catenax.shared.industry_core.common:1.0.0#> .
+@prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:3.0.0#> .
+
+:SingleLevelBomAsBuilt a samm:Aspect ;
+   samm:preferredName "single level bill of material as built"@en ;
+   samm:description "The single-level bill of material represents one sub-level of an assembly and does not include any lower-level subassemblies. The as-built lifecycle references all child items as manufactured by the manufacturer referencing only child items in an as-built lifecycle themselves (e.g. serial parts or batches), unless parts can only be tracked by an part ID (on a type level).\n\nIf it is unclear which item has been built-in into the parent item, all potential parts must be listed. This is the case when, e.g. the same item is supplied by two suppliers and the item is only tracked by a customer part ID during assembly, these items can not be differentiated from each other.\n"@en ;
+   samm:properties ( :childItems ext-ic:globalAssetId ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:childItems a samm:Property ;
+   samm:preferredName "child items"@en ;
+   samm:description "Set of child items, of which the given parent item was assembled by (one structural level down)."@en ;
+   samm:characteristic :SetOfChildItemsCharacteristic .
+
+:SetOfChildItemsCharacteristic a samm-c:Set ;
+   samm:preferredName "set of child items"@en ;
+   samm:description "Set of child items the parent item was assembled by (one structural level down)."@en ;
+   samm:dataType :ChildData .
+
+:ChildData a samm:Entity ;
+   samm:preferredName "child data"@en ;
+   samm:description "Catena-X ID and meta data of the assembled child item."@en ;
+   samm:properties ( :quantity :hasAlternatives [ samm:property ext-ic:lastModifiedOn; samm:optional true ] ext-ic:createdOn ext-ic:globalAssetId ext-ic:businessPartner ) .
+
+:quantity a samm:Property ;
+   samm:preferredName "quantity"@en ;
+   samm:description "Quantity of which the child item is assembled into the parent item. In general it is '1' for serialized parts."@en ;
+   samm:characteristic ext-quantity:ItemQuantityCharacteristic .
+
+:hasAlternatives a samm:Property ;
+   samm:preferredName "has alternatives"@en ;
+   samm:description "Expresses whether the part is built-in or wether it is one of several options. If the value is false, it can be assumed this exact item is built-in. If the value is true, it is unknown wether this or an alternative item is built-in.\nThis is the case when, e.g. the same item is supplied by two suppliers, the item is only tracked by a customer part ID during assembly. Thus, these items can not be differentiated from each other.\n\n"@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue false .
+

--- a/io.catenax.industry_core.single_level_bom_as_built/4.0.0/metadata.json
+++ b/io.catenax.industry_core.single_level_bom_as_built/4.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.industry_core.single_level_bom_as_built/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.single_level_bom_as_built/RELEASE_NOTES.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this model will be documented in this file.
+
+## [4.0.0] 25.12
+
+### Changed
+
+- moved to new namespace from io.catenax.single_level_bom_as_built
+
+## [4.0.0] 25.12
+
+### Changed
+
+- introduced `io.catenax.shared.industry_core.common:1.0.0` and `io.catenax.shared.quantity:3.0.0` as a shared model
+- renamed `catenaXId` to `globalAssetId`
+
+## [3.0.0] 2024-02-26
+
+### Changed
+
+- replaced the `quantityNumber` and `measurementUnit` properties with the `itemUnit` and `quantityValue` properties of the shared quantity 2.0.0 aspect model
+- replaced the whole `CatenaXIdTraitCharacteristic` and its childs with the `UuidV4Trait` of the shared uuid 2.0.0 aspect model
+- replaced the whole `BpnTrait` and its childs with the `BpnlTrait` of the shared business_partner_number 2.0.0 aspect model
+- description of some objects were adjusted
+
+## [2.0.0] 25.09.2023
+
+### Added
+
+- property called hasAlternative
+- Boolean characteristic
+
+### Changed
+
+- Description of the main property 'SingleLevelBomAsBuil' was adapted to the new requirements of the model
+
+## [1.0.0]
+
+### Added
+
+- renamed model from `io.catenax.assembly_part_relationship:1.1.1#AssemblyPartRelationship`
+- optional business partner reference (BPNL) for each child item
+
+### Changed
+
+- changed several descriptions due to aspect renaming
+- changed `childCatenaXId` to `catenaXId`
+- changed `childParts` to `childItems`
+- changed several descriptions to use `item` instead of `part` where applicable
+- fixed camelCase for `NumberOfObjects` characteristic
+
+### Removed
+
+- removed lifecycle context property from child item

--- a/io.catenax.industry_core.single_level_bom_as_built/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.single_level_bom_as_built/RELEASE_NOTES.md
@@ -2,11 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
-## [Moved] 26.09
+## [4.0.0] 25.12
 
 - moved to new namespace from `io.catenax.single_level_bom_as_built`
-
-## [4.0.0] 25.12
 
 ### Changed
 

--- a/io.catenax.industry_core.single_level_bom_as_built/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.single_level_bom_as_built/RELEASE_NOTES.md
@@ -2,11 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
-## [4.0.0] 25.12
+## [Moved] 26.09
 
-### Changed
-
-- moved to new namespace from io.catenax.single_level_bom_as_built
+- moved to new namespace from `io.catenax.single_level_bom_as_built`
 
 ## [4.0.0] 25.12
 

--- a/io.catenax.industry_core.single_level_usage_as_built/4.0.0/SingleLevelUsageAsBuilt.ttl
+++ b/io.catenax.industry_core.single_level_usage_as_built/4.0.0/SingleLevelUsageAsBuilt.ttl
@@ -1,0 +1,70 @@
+#######################################################################
+# Copyright (c) 2022 BASF SE
+# Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2022 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+# Copyright (c) 2022 German Edge Cloud GmbH & Co. KG
+# Copyright (c) 2022 Henkel AG & Co. KGaA
+# Copyright (c) 2022 Mercedes Benz AG
+# Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2022 SAP SE
+# Copyright (c) 2022 Siemens AG
+# Copyright (c) 2022 T-Systems International GmbH
+# Copyright (c) 2022 ZF Friedrichshafen AG
+# Copyright (c) 2026 Catena-X Automotive Network e.V.
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.industry_core.single_level_usage_as_built:4.0.0#> .
+@prefix ext-ic: <urn:samm:io.catenax.shared.industry_core.common:1.0.0#> .
+@prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:3.0.0#> .
+
+:SingleLevelUsageAsBuilt a samm:Aspect ;
+   samm:preferredName "single level usage as built"@en ;
+   samm:description "The aspect provides the information in which parent part(s)/product(s)the given item is assembled in. Could be a 1:1 relationship in terms of an e.g. a brake component or 1:n for e.g. coatings. The parent item must refer to an object from as-built lifecycle phase, i.e. a batch or a serialized part."@en ;
+   samm:properties ( :parentItems ext-ic:customers ext-ic:globalAssetId ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:parentItems a samm:Property ;
+   samm:preferredName "parent items"@en ;
+   samm:description "Set of parent items, in which the given child object is assembled in (one structural level up).\n\nFor serialized items the list should contain only one parent item.\nAs different subsets of a batch might be used by a customer in different items this is a list."@en ;
+   samm:characteristic :SetOfParentItemsCharacteristic .
+
+:SetOfParentItemsCharacteristic a samm-c:Set ;
+   samm:preferredName "set of parent items"@en ;
+   samm:description "Set of parent items the given child object is assembled in (one structural level up)."@en ;
+   samm:dataType :ParentData .
+
+:ParentData a samm:Entity ;
+   samm:preferredName "parent data"@en ;
+   samm:description "Catena-X ID and meta data of the parent item."@en ;
+   samm:properties ( [ samm:property :quantity; samm:optional true ] :isOnlyPotentialParent ext-ic:businessPartner ext-ic:createdOn [ samm:property ext-ic:lastModifiedOn; samm:optional true ] ext-ic:globalAssetId ) .
+
+:quantity a samm:Property ;
+   samm:preferredName "quantity"@en ;
+   samm:description "Quantity of which the child part is assembled into the parent part. In general it is '1' for serialized parts."@en ;
+   samm:characteristic ext-quantity:ItemQuantityCharacteristic .
+
+:isOnlyPotentialParent a samm:Property ;
+   samm:preferredName "is only potential parent"@en ;
+   samm:description "Expresses the certainty whether the part has been used as component or input material in the produced item. If the value is false, it can be assumed that the part has been used. If the value is true, there are alternatives for that part, and it is unknown if this part item or an alternative part item has been used.\nThis is the case when, e.g. the same item is supplied by two suppliers, and the item is only tracked by a customer part ID during assembly. Thus, these items cannot be differentiated from each other.\n"@en ;
+   samm:characteristic samm-c:Boolean ;
+   samm:exampleValue false .
+

--- a/io.catenax.industry_core.single_level_usage_as_built/4.0.0/metadata.json
+++ b/io.catenax.industry_core.single_level_usage_as_built/4.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.industry_core.single_level_usage_as_built/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.single_level_usage_as_built/RELEASE_NOTES.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to this model will be documented in this file.
+
+## [4.0.0] 26.09
+
+### Changed
+
+- moved to new namespace from io.catenax.single_level_usage_as_built
+
+## [4.0.0] 25.12
+
+### Changed
+
+- introduced `io.catenax.shared.industry_core.common:1.0.0` and `io.catenax.shared.quantity:3.0.0` as a shared model
+- renamed `catenaXId` to `globalAssetId`
+
+## [3.0.0] 2024-02-26
+
+### Changed
+
+- changed `parentItems` property to be a mandatory child of the `SingleLevelUsageAsBuilt` aspect property instead of a child of the `customers` property
+- changed `customers` property to be a list of BPNL
+- replaced the `quantityNumber` and `measurementUnit` properties with the `itemUnit` and `quantityValue` properties of the shared quantity 2.0.0 aspect model
+- replaced the whole `CatenaXIdTraitCharacteristic` and its childs with the `UuidV4Trait` of the shared uuid 2.0.0 aspect model
+- replaced the whole `BpnTrait` and its childs with the `BpnlTrait` of the shared business_partner_number 2.0.0 aspect model
+- description of some objects were adjusted
+
+## [2.0.0] 2023-09-01
+
+### Added
+
+- added `customers` to reflect that the relation to parent items is not known at all times. Instead a reference to the customer is made.
+- restructured `parentParts` to be enclosed 
+- added mandatory `businessPartner` to enable decentralized Digital Twin registry
+
+### Changed
+
+- renamed `parentParts` to `parentItems`
+- made `parentItems` optional to reflect that parent items are not known at all times
+- fixed example value for `measurementUnit`
+- fixed link to samm unit catalogue for `measurementUnit`
+- renamed `parentCatenaXId` to `catenaXId`
+- improved some descriptions to reflect change from `part` to `item`
+- generally improved some descriptions
+
+### Removed
+
+## [1.0.1] 2022-08-11
+
+### Added
+
+- initial version of model
+- small bugfix
+
+### Changed
+
+n/a
+
+### Removed

--- a/io.catenax.industry_core.single_level_usage_as_built/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.single_level_usage_as_built/RELEASE_NOTES.md
@@ -2,11 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
-## [Moved] 26.09
+## [4.0.0] 26.09
 
 - moved to new namespace from `io.catenax.single_level_usage_as_built`
-
-## [4.0.0] 25.12
 
 ### Changed
 

--- a/io.catenax.industry_core.single_level_usage_as_built/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.single_level_usage_as_built/RELEASE_NOTES.md
@@ -2,11 +2,9 @@
 
 All notable changes to this model will be documented in this file.
 
-## [4.0.0] 26.09
+## [Moved] 26.09
 
-### Changed
-
-- moved to new namespace from io.catenax.single_level_usage_as_built
+- moved to new namespace from `io.catenax.single_level_usage_as_built`
 
 ## [4.0.0] 25.12
 

--- a/io.catenax.just_in_sequence_part/1.0.0/metadata.json
+++ b/io.catenax.just_in_sequence_part/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "deprecated"} 
+{ "status" : "invalidated"} 

--- a/io.catenax.just_in_sequence_part/2.0.0/metadata.json
+++ b/io.catenax.just_in_sequence_part/2.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "deprecated"} 
+{ "status" : "invalidated"} 

--- a/io.catenax.just_in_sequence_part/3.0.0/metadata.json
+++ b/io.catenax.just_in_sequence_part/3.0.0/metadata.json
@@ -1,1 +1,1 @@
-{"status": "release"}
+{"status": "depracted"}

--- a/io.catenax.just_in_sequence_part/3.0.0/metadata.json
+++ b/io.catenax.just_in_sequence_part/3.0.0/metadata.json
@@ -1,1 +1,1 @@
-{"status": "depracted"}
+{"status": "deprecated"}

--- a/io.catenax.just_in_sequence_part/4.0.0/metadata.json
+++ b/io.catenax.just_in_sequence_part/4.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"}
+{ "status" : "deprecated"}

--- a/io.catenax.just_in_sequence_part/RELEASE_NOTES.md
+++ b/io.catenax.just_in_sequence_part/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 All notable changes to this model will be documented in this file.
 
+## [Moved] 26.09
+
+- moved to new namespace from `io.catenax.just_in_sequence_part` to `io.catenax.industry_core.just_in_sequence_part`
+
 ## [4.0.0] 26.03
 
 ### Changed

--- a/io.catenax.serial_part/1.0.1/metadata.json
+++ b/io.catenax.serial_part/1.0.1/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "deprecated"} 
+{ "status" : "invalidated"} 

--- a/io.catenax.serial_part/2.0.0/metadata.json
+++ b/io.catenax.serial_part/2.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "deprecated"} 
+{ "status" : "invalidated"} 

--- a/io.catenax.serial_part/4.0.0/metadata.json
+++ b/io.catenax.serial_part/4.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"}
+{ "status" : "deprecated"}

--- a/io.catenax.serial_part/RELEASE_NOTES.md
+++ b/io.catenax.serial_part/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 All notable changes to this model will be documented in this file.
 
+## [Moved] 26.09
+
+- moved to new namespace from `io.catenax.serial_part` to `io.catenax.industry_core.serial_part`
+
 ## [4.0.0] 26.03
 
 ### Changed

--- a/io.catenax.single_level_bom_as_built/1.0.0/metadata.json
+++ b/io.catenax.single_level_bom_as_built/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "deprecated"} 
+{ "status" : "invalidated"} 

--- a/io.catenax.single_level_bom_as_built/2.0.0/metadata.json
+++ b/io.catenax.single_level_bom_as_built/2.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "deprecated"} 
+{ "status" : "invalidated"} 

--- a/io.catenax.single_level_bom_as_built/3.0.0/metadata.json
+++ b/io.catenax.single_level_bom_as_built/3.0.0/metadata.json
@@ -1,1 +1,1 @@
-{"status": "release"}
+{"status": "deprecated"}

--- a/io.catenax.single_level_bom_as_built/4.0.0/metadata.json
+++ b/io.catenax.single_level_bom_as_built/4.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"}
+{ "status" : "deprecated"}

--- a/io.catenax.single_level_bom_as_built/RELEASE_NOTES.md
+++ b/io.catenax.single_level_bom_as_built/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 All notable changes to this model will be documented in this file.
 
+## [Moved] 26.09
+
+- moved to new namespace from `io.catenax.single_level_bom_as_built` to `io.catenax.industry_core.single_level_bom_as_built`
+
 ## [4.0.0] 25.12
 
 ### Changed

--- a/io.catenax.single_level_usage_as_built/2.0.0/metadata.json
+++ b/io.catenax.single_level_usage_as_built/2.0.0/metadata.json
@@ -1,1 +1,1 @@
-{"status" : "deprecated"} 
+{"status" : "invalidated"} 

--- a/io.catenax.single_level_usage_as_built/3.0.0/metadata.json
+++ b/io.catenax.single_level_usage_as_built/3.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{ "status" : "deprecated"} 

--- a/io.catenax.single_level_usage_as_built/4.0.0/metadata.json
+++ b/io.catenax.single_level_usage_as_built/4.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"}
+{ "status" : "deprecated"}

--- a/io.catenax.single_level_usage_as_built/RELEASE_NOTES.md
+++ b/io.catenax.single_level_usage_as_built/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 All notable changes to this model will be documented in this file.
 
+## [Moved] 26.09
+
+- moved to new namespace from `io.catenax.single_level_usage_as_built` to `io.catenax.industry_core.single_level_usage_as_built`
+
 ## [4.0.0] 25.12
 
 ### Changed


### PR DESCRIPTION
## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

Closes #978 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [x] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
- [x] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [x] payload names and property identifiers must not contain two consecutive underscores ('__') at any position (e.g. `my__model` is not allowed)
- [x] the identifiers for all model elements **start with a capital letter** except for properties
- [x] the identifier for **properties starts with a small letter**
- [x] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [x] Property and the referenced Characteristic should not have the same name
- [x] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [x] use **abbreviations only when necessary** and if these are sufficiently common
- [x] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [x] fields `preferredName` and `description` are not the same
- [x] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [x] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [x] units are referenced from the SAMM unit catalog whenever possible
- [x] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [x] when relying on **external standards**, they are referenced through a **"see"** element
- [x] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [x] all external / imported models have the state "release"
- [x] metadata.json exists with status "release"
- [x] generated json schema validates against example json payload
- [x] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [x] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [x] All required reviewers have approved this PR (see reviewers section)
- [x] The new aspect (version) will be implemented by at least one data provider
- [x] The new aspect (version) will be consumed by at least one data consumer
- [x] There exists valid test data
- [x] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [x] The model has at least version '1.0.0'
- [x] If a previous model exists, model deprecation has been checked for previous model
- [x] The release date in the Release Note is set to the date of the MS3 approval
