### PR TITLE
Update business partner certificate (Major changes)

### DIFF
--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -1,7 +1,17 @@
 #######################################################################
-# 
-# Copyright (c) 2025 Mercedes-Benz Group AG
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 BASF SE
+# Copyright (c) 2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2026 Cofinity-X GmbH
+# Copyright (c) 2026 Data Space Solutions GmbH
+# Copyright (c) 2026 DCCS GmbH
+# Copyright (c) 2026 Mercedes Benz AG
+# Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2026 SAP SE
+# Copyright (c) 2026 sovity GmbH
+# Copyright (c) 2026 T-Systems International GmbH
+# Copyright (c) 2026 Volkswagen AG
+# Copyright (c) 2026 ZF Friedrichshafen AG
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -27,6 +27,7 @@
 @prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
 
 
+
 :BusinessPartnerCertificate a samm:Aspect ;
    samm:preferredName "Business Partner certificate"@en ;
    samm:description "A business partner certifcate describes a certificate (eg ISO9001, IATF-16949) via a certifcate document  of a Catena-X business partner"@en ;

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -26,10 +26,11 @@
 @prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:2.0.0#> .
 @prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
 
+
 :BusinessPartnerCertificate a samm:Aspect ;
    samm:preferredName "Business Partner certificate"@en ;
    samm:description "A business partner certifcate describes a certificate (eg ISO9001, IATF-16949) via a certifcate document  of a Catena-X business partner"@en ;
-   samm:properties ( :type :registrationNumber [ samm:property :areaOfApplication; samm:optional true ] :validFrom :validUntil [ samm:property :issuer; samm:optional true ] :trustLevel [ samm:property :validator; samm:optional true ] [ samm:property :uploader; samm:optional true ] :document :certificateId :revision :certifiedLocations ) ;
+   samm:properties ( :type :registrationNumber [ samm:property :areaOfApplication; samm:optional true ] :validFrom :validUntil [ samm:property :issuer; samm:optional true ] :trustLevel [ samm:property :validator; samm:optional true ] [ samm:property :uploader; samm:optional true ] :document :certificateId :changeCounter :certifiedLocations ) ;
    samm:operations ( ) ;
    samm:events ( ) .
 
@@ -69,7 +70,7 @@
 
 :trustLevel a samm:Property ;
    samm:preferredName "Trust level"@en ;
-   samm:description "The trust level of the given certificate - low, medium, high"@en ;
+   samm:description "The trust level of the given certificate - none,low, high, trusted"@en ;
    samm:characteristic :TrustLevelValue ;
    samm:exampleValue "high" .
 
@@ -95,10 +96,10 @@
    samm:characteristic :CertificateIdCharacteristic ;
    samm:exampleValue "052395-UM15-2024-001" .
 
-:revision a samm:Property ;
-   samm:preferredName "Revision"@en ;
+:changeCounter a samm:Property ;
+   samm:preferredName "Change Counter"@en ;
    samm:description "Content-mutation counter, starts at 1."@en ;
-   samm:characteristic :RevisionCharacteristic ;
+   samm:characteristic :ChangeCounterCharacteristic ;
    samm:exampleValue "3"^^xsd:positiveInteger .
 
 :certifiedLocations a samm:Property ;
@@ -132,7 +133,7 @@
    samm:description "The Business Partner Number (BPN) of the data service provider who validated the given certificate"@en ;
    samm:dataType :TrustValidatorEntitity .
 
-:DocumentCharacteristic a samm:Characteristic ;
+:DocumentCharacteristic a samm-c:List ;
    samm:preferredName "Document Characteristic"@en ;
    samm:description "Describes the characteristics of the attribute document."@en ;
    samm:dataType :DocumentEntity .
@@ -142,12 +143,12 @@
    samm:description "Logical Identity of an issued certificate."@en ;
    samm:dataType xsd:string .
 
-:RevisionCharacteristic a samm:Characteristic ;
-   samm:preferredName "Revision Characteristic"@en ;
+:ChangeCounterCharacteristic a samm:Characteristic ;
+   samm:preferredName "Change Counter Characteristic"@en ;
    samm:description "Content-mutation counter, starts at 1."@en ;
    samm:dataType xsd:positiveInteger .
 
-:CertifiedLocationsCharacteristic a samm:Characteristic ;
+:CertifiedLocationsCharacteristic a samm-c:List ;
    samm:preferredName "Certified Locations Characteristic"@en ;
    samm:description "All locations explicitly stated on the certificate, each with full business partner context."@en ;
    samm:dataType :CertifiedLocationsEntity .
@@ -155,7 +156,7 @@
 :CertificateTypeEntity a samm:Entity ;
    samm:preferredName "Entity of a certificate type"@en ;
    samm:description "Detailed entity of the certificate like IS09001:2015, IATF 16949:2015 or other, valid types are registered at BPN metadatacontroller"@en ;
-   samm:properties ( :certificateType [ samm:property :certificateVersion; samm:optional true ] ) .
+   samm:properties ( :certificateType [ samm:property :certificateTypeVersion; samm:optional true ] ) .
 
 :IssuerEntity a samm:Entity ;
    samm:preferredName "Issuer Entity"@en ;
@@ -170,7 +171,7 @@
 :DocumentEntity a samm:Entity ;
    samm:preferredName "Document Entity"@en ;
    samm:description "Encapsulation of all document relevant attributes."@en ;
-   samm:properties ( :createdAt :documentID :contentType :contentBase64 ) .
+   samm:properties ( :createdAt :documentID :contentType :contentBase64 :language :version ) .
 
 :CertifiedLocationsEntity a samm:Entity ;
    samm:preferredName "Certified Locations Entity"@en ;
@@ -183,9 +184,9 @@
    samm:characteristic samm-c:Text ;
    samm:exampleValue "ISO9001" .
 
-:certificateVersion a samm:Property ;
-   samm:preferredName "Certificate version"@en ;
-   samm:description "Version of the certificate as defined on the document, usually the specific version of a certification standard"@en ;
+:certificateTypeVersion a samm:Property ;
+   samm:preferredName "Certificate Type Version"@en ;
+   samm:description "Version of the certificate type as defined on the document, usually the specific version of a certification standard"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "2015" .
 
@@ -214,7 +215,7 @@
    samm:exampleValue "BPNL00000007YREZ" .
 
 :createdAt a samm:Property ;
-   samm:preferredName "Creation Timestamp"@en ;
+   samm:preferredName "Creation timestamp"@en ;
    samm:description "The creation date of the document."@en ;
    samm:characteristic samm-c:Timestamp ;
    samm:exampleValue "2024-08-23T13:19:00.280+02:00"^^xsd:dateTime .
@@ -236,6 +237,17 @@
    samm:description "The data is encoded using the Base64 encoding scheme, which converts binary data into a string of ASCII characters. "@en ;
    samm:characteristic :ContentBase64Characteristic ;
    samm:exampleValue "iVBORw0KGgoAAdsfwerTETEfdgd" .
+
+:language a samm:Property ;
+   samm:preferredName "Document Language"@en ;
+   samm:description "The language in which the document is provided. "@en ;
+   samm:characteristic samm-c:Language ;
+   samm:exampleValue "en" .
+
+:version a samm:Property ;
+   samm:preferredName "Document Version counter"@en ;
+   samm:characteristic :VersionCharacteristic ;
+   samm:exampleValue "2"^^xsd:positiveInteger .
 
 :bpnl a samm:Property ;
    samm:preferredName "BPNL"@en ;
@@ -265,9 +277,15 @@
    samm:description "Describes the document's encoded value in a Content Base 64 String. "@en ;
    samm:dataType xsd:string .
 
+:VersionCharacteristic a samm:Characteristic ;
+   samm:preferredName "Version Characteristic"@en ;
+   samm:description "Document version."@en ;
+   samm:dataType xsd:positiveInteger .
+
 :LocationRoleValues a samm-c:Enumeration ;
    samm:preferredName "Location Role Values"@en ;
    samm:description "Possible values of the attribite Location Role. "@en ;
    samm:dataType xsd:string ;
    samm-c:values ( "MAIN_LOCATION" "ENCLOSED_LOCATION" "REMOTE_SUPPORT_LOCATION" "EXTENDED_MANUFACTURING_SITE" ) .
+
 

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -241,7 +241,7 @@
    samm:preferredName "Content Base 64"@en ;
    samm:description "The data is encoded using the Base64 encoding scheme, which converts binary data into a string of ASCII characters. "@en ;
    samm:characteristic :ContentBase64Characteristic ;
-   samm:exampleValue "iVBORw0KGgoAAdsfwerTETEfdgd" .
+   samm:exampleValue "VGhpcyBpcyBhIHRlc3QgcGRmIGZpbGUgZm9yIGNlcnRpZmljYXRlcw=="^^xsd:base64Binary .
 
 :language a samm:Property ;
    samm:preferredName "Document Language"@en ;
@@ -282,7 +282,7 @@
 :ContentBase64Characteristic a samm:Characteristic ;
    samm:preferredName "Content Base 64 Characteristic"@en ;
    samm:description "Describes the document's encoded value in a Content Base 64 String. "@en ;
-   samm:dataType xsd:string .
+   samm:dataType xsd:base64Binary.
 
 :LocationRoleValues a samm-c:Enumeration ;
    samm:preferredName "Location Role Values"@en ;

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -77,7 +77,7 @@
 
 :validator a samm:Property ;
    samm:preferredName "Validator"@en ;
-   samm:description "The Business Partner Number (BPN) of the data service provider who validates the given certificate."@en ;
+   samm:description "The Business Partner Number (BPNL) of the data service provider who validates the given certificate."@en ;
    samm:characteristic :TrustValidatorCharacteristic .
 
 :uploader a samm:Property ;

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -37,6 +37,7 @@
 @prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
 
 
+
 :BusinessPartnerCertificate a samm:Aspect ;
    samm:preferredName "Business Partner certificate"@en ;
    samm:description "A business partner certifcate describes a certificate (eg ISO9001, IATF-16949) via a certifcate document  of a Catena-X business partner"@en ;
@@ -69,7 +70,7 @@
 
 :issuer a samm:Property ;
    samm:preferredName "Issuing authority"@en ;
-   samm:description "The BPN of the issuing authority e.g. TUEV Sued "@en ;
+   samm:description "The BPNL of the issuing authority e.g. TUEV Sued "@en ;
    samm:characteristic :IssuerCharacteristics .
 
 :trustLevel a samm:Property ;
@@ -287,3 +288,5 @@
    samm:description "Possible values of the attribite Location Role. "@en ;
    samm:dataType xsd:string ;
    samm-c:values ( "Certificate Holder" "Certified Location" ) .
+
+

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -136,7 +136,7 @@
 :TrustValidatorCharacteristic a samm:Characteristic ;
    samm:preferredName "Validiator caracteristic"@en ;
    samm:description "The Business Partner Number (BPNL) of the data service provider who validated the given certificate"@en ;
-   samm:dataType :TrustValidatorEntitity .
+   samm:dataType :TrustValidatorEntity .
 
 :DocumentCharacteristic a samm-c:List ;
    samm:preferredName "Document Characteristic"@en ;
@@ -168,7 +168,7 @@
    samm:description "The name and the BPNL of the Issuer. "@en ;
    samm:properties ( :issuerName [ samm:property :issuerBpnl; samm:optional true ] ) .
 
-:TrustValidatorEntitity a samm:Entity ;
+:TrustValidatorEntity a samm:Entity ;
    samm:preferredName "Trust validator entity"@en ;
    samm:description "The Business Partner Number (BPNL) of the data service provider who validated the given certificate."@en ;
    samm:properties ( [ samm:property :validatorName; samm:optional true ] [ samm:property :validatorBpnl; samm:optional true ] ) .

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -71,7 +71,7 @@
 
 :trustLevel a samm:Property ;
    samm:preferredName "Trust level"@en ;
-   samm:description "The trust level of the given certificate - none,low, high, trusted"@en ;
+   samm:description "The trust level of the given certificate - low, medium, high"@en ;
    samm:characteristic :TrustLevelValue ;
    samm:exampleValue "high" .
 

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -124,7 +124,7 @@
 
 :IssuerCharacteristics a samm:Characteristic ;
    samm:preferredName "Issuer Characteristics"@en ;
-   samm:description "Issuer name and the Business Partner Number (BPN) Characteristics."@en ;
+   samm:description "Issuer name and the Business Partner Number (BPNL) Characteristics."@en ;
    samm:dataType :IssuerEntity .
 
 :TrustLevelValue a samm-c:Enumeration ;

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -226,7 +226,7 @@
    samm:exampleValue "2024-08-23T13:19:00.280+02:00"^^xsd:dateTime .
 
 :documentId a samm:Property ;
-   samm:preferredName "Document Id"@en ;
+   samm:preferredName "document identifier"@en ;
    samm:description "A unique UUID of the attached binary representation (PDF) of the certificate, generated each time a document is added or updated."@en ;
    samm:characteristic ext-uuid:UuidV4Trait ;
    samm:exampleValue "urn:uuid:9f6d2c1e-0000-0000-0000-000000000001" .
@@ -250,18 +250,19 @@
    samm:exampleValue "en" .
 
 :bpnl a samm:Property ;
-   samm:preferredName "BPNL"@en ;
+   samm:preferredName "business partner number legal"@en ;
    samm:description "Legal entity the location belongs to. Enables group/matrix certificates across multiple legal entities. "@en ;
    samm:characteristic ext-number:BpnlTrait ;
    samm:exampleValue "BPNL000000000AAA" .
 
 :bpna a samm:Property ;
+   samm:preferredName "business partner number address"@en ;
    samm:description "Golden Record anchor. Mandatory for every entry. Where the certificate prints a postal address, the BPNA is resolved by matching that address against the Golden Record (document-verifiable). Where no address is printed for a stated location, the data provider selects the corresponding BPNA from the Golden Record (site main address or legal address) — a provider statement analogous to the BPNS selection (rules c, d)."@en ;
    samm:characteristic ext-number:BpnaTrait ;
-   samm:exampleValue "BPNA000000000A1" .
+   samm:exampleValue "BPNA0000000000A1" .
 
 :bpns a samm:Property ;
-   samm:preferredName "BPNS"@en ;
+   samm:preferredName "business partner number site"@en ;
    samm:description "Site the BPNA is assigned to in the Golden Record. Not printed on the certificate, therefore not document-verifiable; taken over from the Golden Record."@en ;
    samm:characteristic ext-number:BpnsTrait ;
    samm:exampleValue "BPNS0000000ABS01" .

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -1,0 +1,273 @@
+#######################################################################
+# 
+# Copyright (c) 2025 Mercedes-Benz Group AG
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.business_partner_certificate:4.0.0#> .
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:2.0.0#> .
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
+
+:BusinessPartnerCertificate a samm:Aspect ;
+   samm:preferredName "Business Partner certificate"@en ;
+   samm:description "A business partner certifcate describes a certificate (eg ISO9001, IATF-16949) via a certifcate document  of a Catena-X business partner"@en ;
+   samm:properties ( :type :registrationNumber [ samm:property :areaOfApplication; samm:optional true ] :validFrom :validUntil [ samm:property :issuer; samm:optional true ] :trustLevel [ samm:property :validator; samm:optional true ] [ samm:property :uploader; samm:optional true ] :document :certificateId :revision :certifiedLocations ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:type a samm:Property ;
+   samm:preferredName "Certificate type"@en ;
+   samm:description "Type of the certificate as defined on the document like IS09001, IATF 16949 or other"@en ;
+   samm:characteristic :CertificateTypeCharacteristic .
+
+:registrationNumber a samm:Property ;
+   samm:preferredName "Certificate registration number"@en ;
+   samm:description "The certification scheme registration, exactly as printed on the document."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "12 198 54182 TMS" .
+
+:areaOfApplication a samm:Property ;
+   samm:preferredName "Area of application"@en ;
+   samm:description "Details on which areas / application types a certificate is valid for a company and/or site."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Development, Marketing und Sales and also Procurement for interior components" .
+
+:validFrom a samm:Property ;
+   samm:preferredName "Valid from"@en ;
+   samm:description "Valid from date as defined on the certificate."@en ;
+   samm:characteristic :Date ;
+   samm:exampleValue "2023-01-25"^^xsd:date .
+
+:validUntil a samm:Property ;
+   samm:preferredName "Valid until"@en ;
+   samm:description "Valid valid until as defined on the certificate. If certificate never expires value until expected to be 9999-12-31"@en ;
+   samm:characteristic :Date ;
+   samm:exampleValue "2026-01-24"^^xsd:date .
+
+:issuer a samm:Property ;
+   samm:preferredName "Issuing authority"@en ;
+   samm:description "The BPN of the issuing authority e.g. TUEV Sued "@en ;
+   samm:characteristic :IssuerCharacteristics .
+
+:trustLevel a samm:Property ;
+   samm:preferredName "Trust level"@en ;
+   samm:description "The trust level of the given certificate - none,low, high, trusted"@en ;
+   samm:characteristic :TrustLevelValue ;
+   samm:exampleValue "high" .
+
+:validator a samm:Property ;
+   samm:preferredName "Validator"@en ;
+   samm:description "The Business Partner Number (BPN) of the data service provider who validates the given certificate."@en ;
+   samm:characteristic :TrustValidatorCharacteristic .
+
+:uploader a samm:Property ;
+   samm:preferredName "Certifcate uploader"@en ;
+   samm:description "The Business Partner Number (BPN) of the business partner who originally provided the certifcate data or document."@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL00000003AYRE" .
+
+:document a samm:Property ;
+   samm:preferredName "Document"@en ;
+   samm:description "The content and ID of the document."@en ;
+   samm:characteristic :DocumentCharacteristic .
+
+:certificateId a samm:Property ;
+   samm:preferredName "Certificate Id"@en ;
+   samm:description "Logical identity key of the issued certificate (per issuance)."@en ;
+   samm:characteristic :CertificateIdCharacteristic ;
+   samm:exampleValue "052395-UM15-2024-001" .
+
+:revision a samm:Property ;
+   samm:preferredName "Revision"@en ;
+   samm:description "Content-mutation counter, starts at 1."@en ;
+   samm:characteristic :RevisionCharacteristic ;
+   samm:exampleValue "3"^^xsd:positiveInteger .
+
+:certifiedLocations a samm:Property ;
+   samm:preferredName "Certified Locations"@en ;
+   samm:description "All locations explicitly stated on the certificate, each with full business partner context."@en ;
+   samm:characteristic :CertifiedLocationsCharacteristic .
+
+:CertificateTypeCharacteristic a samm-c:SingleEntity ;
+   samm:preferredName "Certificate Type Characteristic"@en ;
+   samm:description "Describes the characteristics of the Certificate Type."@en ;
+   samm:dataType :CertificateTypeEntity .
+
+:Date a samm:Characteristic ;
+   samm:preferredName "Date"@en ;
+   samm:description "Describes a property which contains the date in english format."@en ;
+   samm:dataType xsd:date .
+
+:IssuerCharacteristics a samm:Characteristic ;
+   samm:preferredName "Issuer Characteristics"@en ;
+   samm:description "Issuer name and the Business Partner Number (BPN) Characteristics."@en ;
+   samm:dataType :IssuerEntity .
+
+:TrustLevelValue a samm-c:Enumeration ;
+   samm:preferredName "Trust level value"@en ;
+   samm:description "The possible trust level values of certificate."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "low" "medium" "high" ) .
+
+:TrustValidatorCharacteristic a samm:Characteristic ;
+   samm:preferredName "Validiator caracteristic"@en ;
+   samm:description "The Business Partner Number (BPN) of the data service provider who validated the given certificate"@en ;
+   samm:dataType :TrustValidatorEntitity .
+
+:DocumentCharacteristic a samm:Characteristic ;
+   samm:preferredName "Document Characteristic"@en ;
+   samm:description "Describes the characteristics of the attribute document."@en ;
+   samm:dataType :DocumentEntity .
+
+:CertificateIdCharacteristic a samm:Characteristic ;
+   samm:preferredName "Certificate Id Characteristic"@en ;
+   samm:description "Logical Identity of an issued certificate."@en ;
+   samm:dataType xsd:string .
+
+:RevisionCharacteristic a samm:Characteristic ;
+   samm:preferredName "Revision Characteristic"@en ;
+   samm:description "Content-mutation counter, starts at 1."@en ;
+   samm:dataType xsd:positiveInteger .
+
+:CertifiedLocationsCharacteristic a samm:Characteristic ;
+   samm:preferredName "Certified Locations Characteristic"@en ;
+   samm:description "All locations explicitly stated on the certificate, each with full business partner context."@en ;
+   samm:dataType :CertifiedLocationsEntity .
+
+:CertificateTypeEntity a samm:Entity ;
+   samm:preferredName "Entity of a certificate type"@en ;
+   samm:description "Detailed entity of the certificate like IS09001:2015, IATF 16949:2015 or other, valid types are registered at BPN metadatacontroller"@en ;
+   samm:properties ( :certificateType [ samm:property :certificateVersion; samm:optional true ] ) .
+
+:IssuerEntity a samm:Entity ;
+   samm:preferredName "Issuer Entity"@en ;
+   samm:description "The name and the BPNL of the Issuer. "@en ;
+   samm:properties ( :issuerName [ samm:property :issuerBpn; samm:optional true ] ) .
+
+:TrustValidatorEntitity a samm:Entity ;
+   samm:preferredName "Trust validator entity"@en ;
+   samm:description "The Business Partner Number (BPN) of the data service provider who validated the given certificate."@en ;
+   samm:properties ( [ samm:property :validatorName; samm:optional true ] [ samm:property :validatorBpn; samm:optional true ] ) .
+
+:DocumentEntity a samm:Entity ;
+   samm:preferredName "Document Entity"@en ;
+   samm:description "Encapsulation of all document relevant attributes."@en ;
+   samm:properties ( :createdAt :documentID :contentType :contentBase64 ) .
+
+:CertifiedLocationsEntity a samm:Entity ;
+   samm:preferredName "Certified Locations Entity"@en ;
+   samm:description "Encapsulation of all defined attributes for certified locations."@en ;
+   samm:properties ( :bpnl :bpna [ samm:property :bpns; samm:optional true ] :locationRole :areaOfApplication ) .
+
+:certificateType a samm:Property ;
+   samm:preferredName "Certificate type"@en ;
+   samm:description "Type of the certificate as defined on the document,valid types are registered at BPN metadatacontroller"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "ISO9001" .
+
+:certificateVersion a samm:Property ;
+   samm:preferredName "Certificate version"@en ;
+   samm:description "Version of the certificate as defined on the document, usually the specific version of a certification standard"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "2015" .
+
+:issuerName a samm:Property ;
+   samm:preferredName "Issuer Name"@en ;
+   samm:description "Name of the Issuer i.e. Certifying Authority."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "TÜV" .
+
+:issuerBpn a samm:Property ;
+   samm:preferredName "Issuer BPN"@en ;
+   samm:description "The Business Partner Number (BPN) of the Issuer."@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL133631123120" .
+
+:validatorName a samm:Property ;
+   samm:preferredName "Validator name"@en ;
+   samm:description "The optional name of the data service provider who validated the given certificate"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Data service provider X" .
+
+:validatorBpn a samm:Property ;
+   samm:preferredName "Certifcate validator Bpn"@en ;
+   samm:description "The Business Partner Number (BPN) of the data service provider who validated the given certificate"@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL00000007YREZ" .
+
+:createdAt a samm:Property ;
+   samm:preferredName "Creation Timestamp"@en ;
+   samm:description "The creation date of the document."@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2024-08-23T13:19:00.280+02:00"^^xsd:dateTime .
+
+:documentID a samm:Property ;
+   samm:preferredName "Document ID"@en ;
+   samm:description "A unique UUID of the attached binary representation (PDF) of the certificate."@en ;
+   samm:characteristic ext-uuid:UuidV4Trait ;
+   samm:exampleValue "urn:uuid:9f6d2c1e-0000-0000-0000-000000000001" .
+
+:contentType a samm:Property ;
+   samm:preferredName "Content Type"@en ;
+   samm:description "The content type of the document."@en ;
+   samm:characteristic samm-c:MimeType ;
+   samm:exampleValue "application/pdf" .
+
+:contentBase64 a samm:Property ;
+   samm:preferredName "Content Base 64"@en ;
+   samm:description "The data is encoded using the Base64 encoding scheme, which converts binary data into a string of ASCII characters. "@en ;
+   samm:characteristic :ContentBase64Characteristic ;
+   samm:exampleValue "iVBORw0KGgoAAdsfwerTETEfdgd" .
+
+:bpnl a samm:Property ;
+   samm:preferredName "BPNL"@en ;
+   samm:description "Legal entity the location belongs to. Enables group/matrix certificates across multiple legal entities. "@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL000000000AAA" .
+
+:bpna a samm:Property ;
+   samm:description "Golden Record anchor. Mandatory for every entry. Where the certificate prints a postal address, the BPNA is resolved by matching that address against the Golden Record (document-verifiable). Where no address is printed for a stated location, the data provider selects the corresponding BPNA from the Golden Record (site main address or legal address) — a provider statement analogous to the BPNS selection (rules c, d)."@en ;
+   samm:characteristic ext-number:BpnaTrait ;
+   samm:exampleValue "BPNA000000000A1" .
+
+:bpns a samm:Property ;
+   samm:preferredName "BPNS"@en ;
+   samm:description "Site the BPNA is assigned to in the Golden Record. Not printed on the certificate, therefore not document-verifiable; taken over from the Golden Record."@en ;
+   samm:characteristic ext-number:BpnsTrait ;
+   samm:exampleValue "BPNS0000000ABS01" .
+
+:locationRole a samm:Property ;
+   samm:preferredName "Location Role"@en ;
+   samm:description "Role as stated on the certificate."@en ;
+   samm:characteristic :LocationRoleValues ;
+   samm:exampleValue "MAIN_LOCATION" .
+
+:ContentBase64Characteristic a samm:Characteristic ;
+   samm:preferredName "Content Base 64 Characteristic"@en ;
+   samm:description "Describes the document's encoded value in a Content Base 64 String. "@en ;
+   samm:dataType xsd:string .
+
+:LocationRoleValues a samm-c:Enumeration ;
+   samm:preferredName "Location Role Values"@en ;
+   samm:description "Possible values of the attribite Location Role. "@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "MAIN_LOCATION" "ENCLOSED_LOCATION" "REMOTE_SUPPORT_LOCATION" "EXTENDED_MANUFACTURING_SITE" ) .
+

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -69,7 +69,7 @@
 
 :trustLevel a samm:Property ;
    samm:preferredName "Trust level"@en ;
-   samm:description "The trust level of the given certificate - none,low, high, trusted"@en ;
+   samm:description "The trust level of the given certificate - low, medium, high"@en ;
    samm:characteristic :TrustLevelValue ;
    samm:exampleValue "high" .
 

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -120,18 +120,18 @@
 
 :IssuerCharacteristics a samm:Characteristic ;
    samm:preferredName "Issuer Characteristics"@en ;
-   samm:description "Issuer name and the Business Partner Number (BPN) Characteristics."@en ;
+   samm:description "Issuer name and the Business Partner Number (BPNL) Characteristics."@en ;
    samm:dataType :IssuerEntity .
 
 :TrustLevelValue a samm-c:Enumeration ;
    samm:preferredName "Trust level value"@en ;
-   samm:description "The possible trust level values of certificate."@en ;
+   samm:description "The possible trust level values of a certificate."@en ;
    samm:dataType xsd:string ;
    samm-c:values ( "low" "medium" "high" ) .
 
 :TrustValidatorCharacteristic a samm:Characteristic ;
    samm:preferredName "Validiator caracteristic"@en ;
-   samm:description "The Business Partner Number (BPN) of the data service provider who validated the given certificate"@en ;
+   samm:description "The Business Partner Number (BPNL) of the data service provider who validated the given certificate"@en ;
    samm:dataType :TrustValidatorEntitity .
 
 :DocumentCharacteristic a samm-c:List ;
@@ -164,9 +164,9 @@
    samm:description "The name and the BPNL of the Issuer. "@en ;
    samm:properties ( :issuerName [ samm:property :issuerBpn; samm:optional true ] ) .
 
-:TrustValidatorEntitity a samm:Entity ;
+:TrustValidatorEntity a samm:Entity ;
    samm:preferredName "Trust validator entity"@en ;
-   samm:description "The Business Partner Number (BPN) of the data service provider who validated the given certificate."@en ;
+   samm:description "The Business Partner Number (BPNL) of the data service provider who validated the given certificate."@en ;
    samm:properties ( [ samm:property :validatorName; samm:optional true ] [ samm:property :validatorBpn; samm:optional true ] ) .
 
 :DocumentEntity a samm:Entity ;
@@ -183,7 +183,7 @@
    samm:preferredName "Certificate type"@en ;
    samm:description "Type of the certificate as defined on the document,valid types are registered at BPN metadatacontroller"@en ;
    samm:characteristic samm-c:Text ;
-   samm:exampleValue "ISO9001" .
+   samm:exampleValue "iso9001" .
 
 :certificateTypeVersion a samm:Property ;
    samm:preferredName "Certificate Type Version"@en ;
@@ -197,9 +197,9 @@
    samm:characteristic samm-c:Text ;
    samm:exampleValue "TÜV" .
 
-:issuerBpn a samm:Property ;
-   samm:preferredName "Issuer BPN"@en ;
-   samm:description "The Business Partner Number (BPN) of the Issuer."@en ;
+:issuerBpnl a samm:Property ;
+   samm:preferredName "Issuer BPNL"@en ;
+   samm:description "The Business Partner Number (BPNL) of the Issuer."@en ;
    samm:characteristic ext-number:BpnlTrait ;
    samm:exampleValue "BPNL133631123120" .
 
@@ -209,9 +209,9 @@
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Data service provider X" .
 
-:validatorBpn a samm:Property ;
-   samm:preferredName "Certifcate validator Bpn"@en ;
-   samm:description "The Business Partner Number (BPN) of the data service provider who validated the given certificate"@en ;
+:validatorBpnl a samm:Property ;
+   samm:preferredName "Certifcate validator BPNL"@en ;
+   samm:description "The Business Partner Number (BPNL) of the data service provider who validated the given certificate"@en ;
    samm:characteristic ext-number:BpnlTrait ;
    samm:exampleValue "BPNL00000007YREZ" .
 
@@ -221,7 +221,7 @@
    samm:characteristic samm-c:Timestamp ;
    samm:exampleValue "2024-08-23T13:19:00.280+02:00"^^xsd:dateTime .
 
-:documentID a samm:Property ;
+:documentId a samm:Property ;
    samm:preferredName "Document ID"@en ;
    samm:description "A unique UUID of the attached binary representation (PDF) of the certificate."@en ;
    samm:characteristic ext-uuid:UuidV4Trait ;

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -37,11 +37,10 @@
 @prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
 
 
-
 :BusinessPartnerCertificate a samm:Aspect ;
    samm:preferredName "Business Partner certificate"@en ;
    samm:description "A business partner certifcate describes a certificate (eg ISO9001, IATF-16949) via a certifcate document  of a Catena-X business partner"@en ;
-   samm:properties ( :type :registrationNumber [ samm:property :areaOfApplication; samm:optional true ] :validFrom :validUntil [ samm:property :issuer; samm:optional true ] :trustLevel [ samm:property :validator; samm:optional true ] [ samm:property :uploader; samm:optional true ] :document :certificateId :changeCounter :certifiedLocations ) ;
+   samm:properties ( :type :registrationNumber :validFrom :validUntil [ samm:property :issuer; samm:optional true ] :trustLevel [ samm:property :validator; samm:optional true ] [ samm:property :uploader; samm:optional true ] :document :certificateId :revision :certifiedLocations ) ;
    samm:operations ( ) ;
    samm:events ( ) .
 
@@ -55,12 +54,6 @@
    samm:description "The certification scheme registration, exactly as printed on the document."@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "12 198 54182 TMS" .
-
-:areaOfApplication a samm:Property ;
-   samm:preferredName "Area of application"@en ;
-   samm:description "Details on which areas / application types a certificate is valid for a company and/or site."@en ;
-   samm:characteristic samm-c:Text ;
-   samm:exampleValue "Development, Marketing und Sales and also Procurement for interior components" .
 
 :validFrom a samm:Property ;
    samm:preferredName "Valid from"@en ;
@@ -76,7 +69,7 @@
 
 :issuer a samm:Property ;
    samm:preferredName "Issuing authority"@en ;
-   samm:description "The BPNL of the issuing authority e.g. TUEV Sued "@en ;
+   samm:description "The BPN of the issuing authority e.g. TUEV Sued "@en ;
    samm:characteristic :IssuerCharacteristics .
 
 :trustLevel a samm:Property ;
@@ -107,10 +100,10 @@
    samm:characteristic :CertificateIdCharacteristic ;
    samm:exampleValue "052395-UM15-2024-001" .
 
-:changeCounter a samm:Property ;
-   samm:preferredName "Change Counter"@en ;
-   samm:description "Content-mutation counter, starts at 1."@en ;
-   samm:characteristic :ChangeCounterCharacteristic ;
+:revision a samm:Property ;
+   samm:preferredName "Revision Counter"@en ;
+   samm:description "Revision counter, starts at 1."@en ;
+   samm:characteristic :RevisionCharacteristic ;
    samm:exampleValue "3"^^xsd:positiveInteger .
 
 :certifiedLocations a samm:Property ;
@@ -130,12 +123,12 @@
 
 :IssuerCharacteristics a samm:Characteristic ;
    samm:preferredName "Issuer Characteristics"@en ;
-   samm:description "Issuer name and the Business Partner Number (BPNL) Characteristics."@en ;
+   samm:description "Issuer name and the Business Partner Number (BPN) Characteristics."@en ;
    samm:dataType :IssuerEntity .
 
 :TrustLevelValue a samm-c:Enumeration ;
    samm:preferredName "Trust level value"@en ;
-   samm:description "The possible trust level values of a certificate."@en ;
+   samm:description "The possible trust level values of certificate."@en ;
    samm:dataType xsd:string ;
    samm-c:values ( "low" "medium" "high" ) .
 
@@ -154,9 +147,9 @@
    samm:description "Logical Identity of an issued certificate."@en ;
    samm:dataType xsd:string .
 
-:ChangeCounterCharacteristic a samm:Characteristic ;
-   samm:preferredName "Change Counter Characteristic"@en ;
-   samm:description "Content-mutation counter, starts at 1."@en ;
+:RevisionCharacteristic a samm:Characteristic ;
+   samm:preferredName "Revision Counter Characteristic"@en ;
+   samm:description "Revision counter, starts at 1."@en ;
    samm:dataType xsd:positiveInteger .
 
 :CertifiedLocationsCharacteristic a samm-c:List ;
@@ -172,17 +165,17 @@
 :IssuerEntity a samm:Entity ;
    samm:preferredName "Issuer Entity"@en ;
    samm:description "The name and the BPNL of the Issuer. "@en ;
-   samm:properties ( :issuerName [ samm:property :issuerBpn; samm:optional true ] ) .
+   samm:properties ( :issuerName [ samm:property :issuerBpnl; samm:optional true ] ) .
 
-:TrustValidatorEntity a samm:Entity ;
+:TrustValidatorEntitity a samm:Entity ;
    samm:preferredName "Trust validator entity"@en ;
    samm:description "The Business Partner Number (BPNL) of the data service provider who validated the given certificate."@en ;
-   samm:properties ( [ samm:property :validatorName; samm:optional true ] [ samm:property :validatorBpn; samm:optional true ] ) .
+   samm:properties ( [ samm:property :validatorName; samm:optional true ] [ samm:property :validatorBpnl; samm:optional true ] ) .
 
 :DocumentEntity a samm:Entity ;
    samm:preferredName "Document Entity"@en ;
    samm:description "Encapsulation of all document relevant attributes."@en ;
-   samm:properties ( :createdAt :documentID :contentType :contentBase64 :language :version ) .
+   samm:properties ( :createdAt :documentId [ samm:property :contentType; samm:optional true ] [ samm:property :contentBase64; samm:optional true ] :language ) .
 
 :CertifiedLocationsEntity a samm:Entity ;
    samm:preferredName "Certified Locations Entity"@en ;
@@ -193,7 +186,7 @@
    samm:preferredName "Certificate type"@en ;
    samm:description "Type of the certificate as defined on the document,valid types are registered at BPN metadatacontroller"@en ;
    samm:characteristic samm-c:Text ;
-   samm:exampleValue "iso9001" .
+   samm:exampleValue "ISO9001" .
 
 :certificateTypeVersion a samm:Property ;
    samm:preferredName "Certificate Type Version"@en ;
@@ -220,7 +213,7 @@
    samm:exampleValue "Data service provider X" .
 
 :validatorBpnl a samm:Property ;
-   samm:preferredName "Certifcate validator BPNL"@en ;
+   samm:preferredName "Certifcate validator BpnL"@en ;
    samm:description "The Business Partner Number (BPNL) of the data service provider who validated the given certificate"@en ;
    samm:characteristic ext-number:BpnlTrait ;
    samm:exampleValue "BPNL00000007YREZ" .
@@ -232,8 +225,8 @@
    samm:exampleValue "2024-08-23T13:19:00.280+02:00"^^xsd:dateTime .
 
 :documentId a samm:Property ;
-   samm:preferredName "Document ID"@en ;
-   samm:description "A unique UUID of the attached binary representation (PDF) of the certificate."@en ;
+   samm:preferredName "Document Id"@en ;
+   samm:description "A unique UUID of the attached binary representation (PDF) of the certificate, generated each time a document is added or updated."@en ;
    samm:characteristic ext-uuid:UuidV4Trait ;
    samm:exampleValue "urn:uuid:9f6d2c1e-0000-0000-0000-000000000001" .
 
@@ -254,11 +247,6 @@
    samm:description "The language in which the document is provided. "@en ;
    samm:characteristic samm-c:Language ;
    samm:exampleValue "en" .
-
-:version a samm:Property ;
-   samm:preferredName "Document Version counter"@en ;
-   samm:characteristic :VersionCharacteristic ;
-   samm:exampleValue "2"^^xsd:positiveInteger .
 
 :bpnl a samm:Property ;
    samm:preferredName "BPNL"@en ;
@@ -281,22 +269,21 @@
    samm:preferredName "Location Role"@en ;
    samm:description "Role as stated on the certificate."@en ;
    samm:characteristic :LocationRoleValues ;
-   samm:exampleValue "MAIN_LOCATION" .
+   samm:exampleValue "Certificate Holder" .
+
+:areaOfApplication a samm:Property ;
+   samm:preferredName "Area of application"@en ;
+   samm:description "Details on which areas / application types a certificate is valid for a company and/or site."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Development, Marketing und Sales and also Procurement for interior components" .
 
 :ContentBase64Characteristic a samm:Characteristic ;
    samm:preferredName "Content Base 64 Characteristic"@en ;
    samm:description "Describes the document's encoded value in a Content Base 64 String. "@en ;
    samm:dataType xsd:string .
 
-:VersionCharacteristic a samm:Characteristic ;
-   samm:preferredName "Version Characteristic"@en ;
-   samm:description "Document version."@en ;
-   samm:dataType xsd:positiveInteger .
-
 :LocationRoleValues a samm-c:Enumeration ;
    samm:preferredName "Location Role Values"@en ;
    samm:description "Possible values of the attribite Location Role. "@en ;
    samm:dataType xsd:string ;
-   samm-c:values ( "MAIN_LOCATION" "ENCLOSED_LOCATION" "REMOTE_SUPPORT_LOCATION" "EXTENDED_MANUFACTURING_SITE" ) .
-
-
+   samm-c:values ( "Certificate Holder" "Certified Location" ) .

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -177,7 +177,7 @@
 :CertifiedLocationsEntity a samm:Entity ;
    samm:preferredName "Certified Locations Entity"@en ;
    samm:description "Encapsulation of all defined attributes for certified locations."@en ;
-   samm:properties ( :bpnl :bpna [ samm:property :bpns; samm:optional true ] :locationRole :areaOfApplication ) .
+   samm:properties ( :bpnl :bpna [ samm:property :bpns; samm:optional true ] :locationRole [ samm:property :areaOfApplication; samm:optional true ] ) .
 
 :certificateType a samm:Property ;
    samm:preferredName "Certificate type"@en ;

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -129,7 +129,7 @@
 
 :TrustLevelValue a samm-c:Enumeration ;
    samm:preferredName "Trust level value"@en ;
-   samm:description "The possible trust level values of certificate."@en ;
+   samm:description "The possible trust level values of a certificate."@en ;
    samm:dataType xsd:string ;
    samm-c:values ( "low" "medium" "high" ) .
 
@@ -187,7 +187,7 @@
    samm:preferredName "Certificate type"@en ;
    samm:description "Type of the certificate as defined on the document,valid types are registered at BPN metadatacontroller"@en ;
    samm:characteristic samm-c:Text ;
-   samm:exampleValue "ISO9001" .
+   samm:exampleValue "iso9001" .
 
 :certificateTypeVersion a samm:Property ;
    samm:preferredName "Certificate Type Version"@en ;

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -82,7 +82,7 @@
 
 :uploader a samm:Property ;
    samm:preferredName "Certifcate uploader"@en ;
-   samm:description "The Business Partner Number (BPN) of the business partner who originally provided the certifcate data or document."@en ;
+   samm:description "The Business Partner Number (BPNL) of the business partner who originally provided the certifcate data or document."@en ;
    samm:characteristic ext-number:BpnlTrait ;
    samm:exampleValue "BPNL00000003AYRE" .
 

--- a/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
+++ b/io.catenax.business_partner_certificate/4.0.0/BusinessPartnerCertificate.ttl
@@ -66,7 +66,7 @@
 
 :issuer a samm:Property ;
    samm:preferredName "Issuing authority"@en ;
-   samm:description "The BPN of the issuing authority e.g. TUEV Sued "@en ;
+   samm:description "The BPNL of the issuing authority e.g. TUEV Sued "@en ;
    samm:characteristic :IssuerCharacteristics .
 
 :trustLevel a samm:Property ;

--- a/io.catenax.business_partner_certificate/4.0.0/metadata.json
+++ b/io.catenax.business_partner_certificate/4.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "draft" }

--- a/io.catenax.business_partner_certificate/4.0.0/metadata.json
+++ b/io.catenax.business_partner_certificate/4.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "draft" }
+{ "status" : "release" }

--- a/io.catenax.business_partner_certificate/RELEASE_NOTES.md
+++ b/io.catenax.business_partner_certificate/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 All notable changes to this model will be documented in this file.
 
-## [4.0.0] xx.xx.2026
+## [4.0.0] r26.09
 ### Removed
 - businessPartnerNumber (root) - It is redundant; certificate holder is now derived from:  certifiedLocations[locationRole="Certificate Holder"].bpnl
 - enclosedSites + enclosedSiteBpn - Replaced by certifiedLocations

--- a/io.catenax.business_partner_certificate/RELEASE_NOTES.md
+++ b/io.catenax.business_partner_certificate/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ All notable changes to this model will be documented in this file.
 
 ## [4.0.0] xx.xx.2026
 ### Removed
-- businessPartnerNumber (root) - It is redundant; certificate holder is now derived from:  certifiedLocations[locationRole="MAIN_LOCATION"].bpnl
+- businessPartnerNumber (root) - It is redundant; certificate holder is now derived from:  certifiedLocations[locationRole="Certificate Holder"].bpnl
 - enclosedSites + enclosedSiteBpn - Replaced by certifiedLocations
 
 ### Added

--- a/io.catenax.business_partner_certificate/RELEASE_NOTES.md
+++ b/io.catenax.business_partner_certificate/RELEASE_NOTES.md
@@ -2,6 +2,25 @@
 
 All notable changes to this model will be documented in this file.
 
+## [4.0.0] xx.xx.2026
+### Removed
+- businessPartnerNumber (root) - It is redundant; certificate holder is now derived from:  certifiedLocations[locationRole="MAIN_LOCATION"].bpnl
+- enclosedSites + enclosedSiteBpn - Replaced by certifiedLocations
+
+### Added
+- certifiedLocations
+- certificateId
+- changeCounter
+- locationRole
+- version (document)
+- language (document)
+
+### Changed
+- trustLevel - New enumeration low / medium / high per CCM KIT Trust Level concept
+- documentId  - casing fixed to lowerCamelCase per Tractus-X naming conventions;
+- DocumentEntity can be a list of documents
+- certificateVersion changed to certificateTypeVersion
+
 ## [3.1.0] 24.03.2025
 
 ### Changed


### PR DESCRIPTION
## Description
 Changes Overview

 ### Removed
- businessPartnerNumber (root)  - Removed due to redundancy. The certificate holder is now derived from: certifiedLocations[locationRole="Certificate Holder"].bpnl
- enclosedSites and enclosedSiteBpn - Replaced by the new certifiedLocations structure.
- areaOfApplication (root) 


### Added

- certifiedLocations
- certificateId
- revision
- locationRole
- language (document-level)


### Changed

- trustLevel - Updated to a new enumeration: low, medium, high, aligned with the CCM KIT Trust Level concept.
- documentId - Renamed to follow lowerCamelCase in accordance with Tractus-X naming conventions.
- DocumentEntity - Now supports multiple documents (list instead of single instance)
- certificateVersion → certificateTypeVersion - Renamed for improved clarity and consistency.
- contentType and contentBase64 - both are now optional
- validatorBpn →  validatorBpnl
- issuerBpn →  issuerBpnl 


## Example Payload

```
{
  "certificateId": "052395-UM15-2024-001",
   "registrationNumber": "12 198 54182 TMS",
    "document": [
    {
      "createdAt": "2024-08-23T13:19:00.280+02:00",
      "documentId": "urn:uuid:9f6d2c1e-0000-0000-0000-000000000001",
      "language": "en",
      "contentType": "application/pdf",
      "contentBase64": "iVBORw0KGgoAAdsfwerTETEfdgd"
    }
  ],
  "validator": {
    "validatorName": "Data service provider X",
    "validatorBpnl": "BPNL00000007YREZ"
  },
  "validFrom": "2023-01-25",
  "validUntil": "2026-01-24",
  "trustLevel": "low",
  "type": {
    "certificateType": "iso9001",
    "certificateTypeVersion": "2015"
  },
  "certifiedLocations": [
    {
      "bpnl": "BPNL000000000AAA",
      "areaOfApplication": "Development, Marketing und Sales and also Procurement for interior components",
      "bpns": "BPNS0000000ABS01",
      "locationRole": "Certificate Holder",
      "bpna": "BPNA000000000A1"
    }
  ],
  "issuer": {
    "issuerName": "TÜV",
    "issuerBpnl": "BPNL133631123120"
  },
  "revision": 3,
  "uploader": "BPNL00000003AYRE" 
}

```
 -->

Closes #975 




<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] payload names and property identifiers must not contain two consecutive underscores ('__') at any position (e.g. `my__model` is not allowed)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] all external / imported models have the state "release"
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
