### PR TITLE
Minor Update SerialPart.ttl - Changed exampleValue of date Property

### DIFF
--- a/io.catenax.serial_part/3.0.0/SerialPart.ttl
+++ b/io.catenax.serial_part/3.0.0/SerialPart.ttl
@@ -109,7 +109,7 @@
    samm:preferredName "Production Date"@en;
    samm:description "Timestamp of the manufacturing date as the final step in production process (e.g. final quality check, ready-for-shipment event)"@en;
    samm:characteristic :DateTimeTrait;
-   samm:exampleValue "2022-02-04T14:48:54".
+   samm:exampleValue "2022-02-04T14:48:54Z".
 
 :country a samm:Property;
    samm:preferredName "Country code"@en;


### PR DESCRIPTION

## Description

I changed the example value of the ```date``` property so that it validates against the given regex.

The given regular expression for date validation expects an offset or ```Z``` if time is given.

Background: The generated example json-file seems to use the example values from the ttl-file, in this case the exmaple file can not be validated with the given json-schema. This will be fixed by this change.

Checklist does not apply due to small change of example value.

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
