### PR TITLE
feat(special-characteristics)!: align measurement aspect with standard

### DIFF
--- a/io.catenax.special_characteristics.measurement/3.0.0/SpecialCharacteristicsMeasurement.ttl
+++ b/io.catenax.special_characteristics.measurement/3.0.0/SpecialCharacteristicsMeasurement.ttl
@@ -1,0 +1,116 @@
+#######################################################################
+# Copyright (c) 2024, 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This work is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC-BY-4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/legalcode.
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.special_characteristics.measurement:3.0.0#> .
+@prefix bpn: <urn:samm:io.catenax.shared.business_partner_number:3.0.0#> .
+
+:SpecialCharacteristicsMeasurement a samm:Aspect ;
+   samm:preferredName "SpecialCharacteristicsMeasurement"@en ;
+   samm:description "Special Characteristics are measureable and these measurements are of interest for a consumer who defined these characteristics. The proposal is a data model \"result\" which represents a measurement related to a specific measurement and product. A measurement result is identified by the identification of a characteristic and the product. Identifying part-instance information (local identifiers, customer part id, revision index) is carried by the digital twin and the Industry Core submodels and is therefore not duplicated in this aspect model."@en ;
+   samm:properties ( :manufacturerBpn :characteristicId :measurementType :results ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:manufacturerBpn a samm:Property ;
+   samm:preferredName "Manufacturer Business Partner Number"@en ;
+   samm:description "Business Partner Number (BPNL, BPNS or BPNA) of the manufacturer of the related product. Kept deliberately, although also available via the digital twin, to enable cross-referencing."@en ;
+   samm:characteristic bpn:AnyBpnCharacteristic ;
+   samm:exampleValue "BPNL000000000000" .
+
+:characteristicId a samm:Property ;
+   samm:preferredName "characteristicId"@en ;
+   samm:description "Identifier of the special characteristic in relation to a specified part."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "specialCharacteristic_01" .
+
+:measurementType a samm:Property ;
+   samm:preferredName "Measurement Type"@en ;
+   samm:description "The type of the measurement. Constrained to a fixed set of supported measurement types."@en ;
+   samm:characteristic :MeasurementTypeEnumeration ;
+   samm:exampleValue "simpleMeasurement" .
+
+:MeasurementTypeEnumeration a samm-c:Enumeration ;
+   samm:preferredName "Measurement Type Enumeration"@en ;
+   samm:description "Enumeration of the supported special characteristic measurement types: simpleMeasurement, functionalMeasurement and qualitativeMeasurement."@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "simpleMeasurement" "functionalMeasurement" "qualitativeMeasurement" ) .
+
+:results a samm:Property ;
+   samm:preferredName "measurement_results"@en ;
+   samm:description "List of measurement objects regarding special characteristic of a specific part."@en ;
+   samm:characteristic :ResultList .
+
+:ResultList a samm-c:List ;
+   samm:preferredName "ResultList"@en ;
+   samm:description "List of result objects"@en ;
+   samm:dataType :MeasurementObject .
+
+:MeasurementObject a samm:Entity ;
+   samm:preferredName "Measurement Object"@en ;
+   samm:description "This Entity represents a generic Measurement Object"@en ;
+   samm:properties ( :identifier :measurementTimestamp :value [ samm:property :unit; samm:optional true ] :description [ samm:property :attachmentUrl; samm:optional true ] ) .
+
+:identifier a samm:Property ;
+   samm:preferredName "Identifier"@en ;
+   samm:description "Identifier of the individual measurement object. "@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "measurementObject_01" .
+
+:measurementTimestamp a samm:Property ;
+   samm:preferredName "Measurement Timestamp"@en ;
+   samm:description "Timestamp when the measurement was taken"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2024-12-16T11:46:57.767+01:00"^^xsd:dateTime .
+
+:value a samm:Property ;
+   samm:preferredName "Value"@en ;
+   samm:description "The actual value of the measurement for special characteristics. NOTE: data type is an open question to be confirmed with BMW (currently xsd:string; examples use numeric values)."@en ;
+   samm:characteristic :ValueCharacteristic ;
+   samm:exampleValue "12.09" .
+
+:unit a samm:Property ;
+   samm:preferredName "Unit"@en ;
+   samm:description "The unit of the measurement object, expressed via the SAMM / UNECE common unit catalog. "@en ;
+   samm:characteristic samm-c:UnitReference ;
+   samm:exampleValue "unit:millimetre"^^samm:curie .
+
+:description a samm:Property ;
+   samm:preferredName "Description"@en ;
+   samm:description "Detailed description of the measurement object. "@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "This text gives you context to the related measurement to help to put it into the necessary context." .
+
+:attachmentUrl a samm:Property ;
+   samm:preferredName "Attachment URL"@en ;
+   samm:description "Optional reference (URI) to a related artifact, e.g. an image documenting the measurement. Replaces the previous practice of embedding image links inside the description text."@en ;
+   samm:characteristic :AttachmentUrlCharacteristic ;
+   samm:exampleValue "https://www.example.com/test_image_measurementObject_01.jpg" .
+
+:ValueCharacteristic a samm:Characteristic ;
+   samm:preferredName "Value Characteristic"@en ;
+   samm:description "The datatype of the measurement value, currently defined as string (open question with BMW). "@en ;
+   samm:dataType xsd:string .
+
+:AttachmentUrlCharacteristic a samm:Characteristic ;
+   samm:preferredName "Attachment URL Characteristic"@en ;
+   samm:description "A URI referencing an external artifact related to the measurement."@en ;
+   samm:dataType xsd:anyURI .

--- a/io.catenax.special_characteristics.measurement/3.0.0/metadata.json
+++ b/io.catenax.special_characteristics.measurement/3.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status":"release"}


### PR DESCRIPTION
…d, BPN 3.0.0

Align the SpecialCharacteristicsMeasurement aspect model (3.0.0) with the revised Special Characteristics standard and Catena-X / Industry Core conventions.

Namespace & imports:
- Bump model namespace 2.0.0 -> 3.0.0 (was mismatched with the 3.0.0 folder)
- Reference shared business_partner_number 3.0.0 (was 2.0.0)
- Drop unused serialPart import

Business partner number:
- Rename manufacturerId -> manufacturerBpn
- Use bpn:AnyBpnCharacteristic instead of bpn:BpnlTrait so BPNL, BPNS or BPNA can be provided in a single field
- BPNL kept intentionally (redundant with the digital twin) for cross-referencing

Aspect structure:
- Remove redundant part-instance identifiers now carried by the digital twin: localIdentifiers, customerPartId, revisionIndex
- measurementType: free text -> mandatory enumeration (simpleMeasurement | functionalMeasurement | qualitativeMeasurement)
- Add optional attachmentUrl (xsd:anyURI) to MeasurementObject; replaces embedding image links inside the description text

Misc:
- Fix aspect preferredName typo (SpecialCharacteristicsMeasurment)
- Realistic measurementTimestamp example
- value left as xsd:string pending BMW decision (flagged in description)

BREAKING CHANGE: namespace bumped to 3.0.0; manufacturerId renamed to manufacturerBpn and widened to any BPN type; localIdentifiers, customerPartId and revisionIndex removed from the aspect.

## Description
<!-- Please provide a short description about what this PR changes and reference an issue that was initially created to introduce the new aspect model -->

 -->

Closes #

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] payload names and property identifiers must not contain two consecutive underscores ('__') at any position (e.g. `my__model` is not allowed)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] all external / imported models have the state "release"
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
