### PR TITLE
[New model] added compositin model

### DIFF
--- a/io.catenax.industry_core.composition/1.0.0/Composition.ttl
+++ b/io.catenax.industry_core.composition/1.0.0/Composition.ttl
@@ -9,7 +9,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix : <urn:samm:io.catenax.industry_core.composition:1.0.0#> .
 @prefix ext-classification: <urn:samm:io.catenax.shared.industry_core.asset_classification:1.0.0#> .
-@prefix ext-common: <urn:samm:io.catenax.shared.industry_core.common:1.0.0#> .
 @prefix ext-common2: <urn:samm:io.catenax.shared.industry_core.common:1.0.1#> .
 @prefix samm-u: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
 

--- a/io.catenax.industry_core.composition/1.0.0/Composition.ttl
+++ b/io.catenax.industry_core.composition/1.0.0/Composition.ttl
@@ -1,0 +1,118 @@
+
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.industry_core.composition:1.0.0#> .
+@prefix ext-classification: <urn:samm:io.catenax.shared.industry_core.asset_classification:1.0.0#> .
+@prefix ext-common: <urn:samm:io.catenax.shared.industry_core.common:1.0.0#> .
+@prefix ext-common2: <urn:samm:io.catenax.shared.industry_core.common:1.0.1#> .
+@prefix samm-u: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+
+:Composition a samm:Aspect ;
+   samm:preferredName "Composition"@en ;
+   samm:description "lists all substances contained in a material and specifies their respective proportions."@en ;
+   samm:properties ( :substances ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+:substances a samm:Property ;
+   samm:preferredName "substances"@en ;
+   samm:description "lists all substances contained in a material, each linked with its respective proportion in the overall composition."@en ;
+   samm:characteristic :SetOfSubstance .
+
+:SetOfSubstance a samm-c:Set ;
+   samm:preferredName "Set of substance"@en ;
+   samm:description "Set of substance"@en ;
+   samm:dataType :SubstanceEntity .
+
+:SubstanceEntity a samm:Entity ;
+   samm:preferredName "Substance Entity"@en ;
+   samm:description "contains all properties to describe a substance that is contained in a material"@en ;
+   samm:properties ( [ samm:property :processChemType; samm:optional true ] [ samm:property :isConfidential; samm:optional true ] [ samm:property :percentage; samm:optional true ] [ samm:property ext-common:createdOn; samm:optional true ] ext-classification:classification [ samm:property ext-common2:validityPeriod; samm:optional true ] [ samm:property ext-common2:lastModifiedOn; samm:optional true ] ) .
+
+:processChemType a samm:Property ;
+   samm:preferredName "Process Chem Type"@en ;
+   samm:description "specifies whether a substance in the material is intentionally added, an impurity, or a residue resulting from the production process"@en ;
+   samm:characteristic :ProcessChemTypeEnum .
+
+:isConfidential a samm:Property ;
+   samm:preferredName "Is Confidential"@en ;
+   samm:description "indicates whether the presence or identity of a substance in the material is treated as confidential and therefore not fully disclosed to external parties"@en ;
+   samm:characteristic samm-c:Boolean .
+
+:percentage a samm:Property ;
+   samm:preferredName "percentage"@en ;
+   samm:description "specifies the proportion of a substance in the material, which can be expressed either as a fixed value or as a defined range"@en ;
+   samm:characteristic :PercentageSingleEntity .
+
+:ProcessChemTypeEnum a samm-c:Enumeration ;
+   samm:preferredName "Process Chem Type Enum"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Impurity" "Residue" "Intended" ) .
+
+:PercentageSingleEntity a samm-c:SingleEntity ;
+   samm:preferredName "Percentage Single Entity"@en ;
+   samm:description "Percentage Single Entity"@en ;
+   samm:dataType :PercentageEntity .
+
+:PercentageEntity a samm:Entity ;
+   samm:preferredName "Percentage Entity"@en ;
+   samm:description "Percentage Entity"@en ;
+   samm:properties ( :value :percentageType ) .
+
+:value a samm:Property ;
+   samm:preferredName "Value"@en ;
+   samm:description "Type = Fix: Percentage of ingredient = right\nType = Range (from-to): Weighted mean percentage of ingredient = left\nType = Rest: Calculated percentage of ingredient) = right\nType = Rest (from-to): Weighted mean percentage of ingredient) = left"@en ;
+   samm:characteristic :ValueCharacteristic .
+
+:percentageType a samm:Property ;
+   samm:preferredName "percentage type"@en ;
+   samm:description "specifies how the proportion of a substance is expressed, distinguishing whether it represents a precise value or a ranged estimate"@en ;
+   samm:characteristic :PercentageTypeEnum ;
+   samm:exampleValue "Range" .
+
+:ValueCharacteristic a samm-c:Either ;
+   samm:preferredName "ValueCharacteristic"@en ;
+   samm:description "ValueCharacteristic"@en ;
+   samm-c:left :RangeSingleEntity ;
+   samm-c:right :PercentCharacteristic .
+
+:PercentageTypeEnum a samm-c:Enumeration ;
+   samm:preferredName "Percentage Type Enum"@en ;
+   samm:description "Percentage Type Enum"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "Range" "Rest-Fix" "Rest-Range" "Fix" ) .
+
+:RangeSingleEntity a samm-c:SingleEntity ;
+   samm:preferredName "Range Single Entity"@en ;
+   samm:description "Range Single Entity"@en ;
+   samm:dataType :RangeEntity .
+
+:PercentCharacteristic a samm-c:Measurement ;
+   samm:preferredName "Percent Characteristic"@en ;
+   samm:description "Percent Characteristic"@en ;
+   samm:dataType xsd:float ;
+   samm-c:unit samm-u:percent .
+
+:RangeEntity a samm:Entity ;
+   samm:preferredName "RangeEntity"@en ;
+   samm:description "RangeEntity"@en ;
+   samm:properties ( :to :from ) .
+
+:to a samm:Property ;
+   samm:preferredName "To"@en ;
+   samm:description "Maximum percentage of ingredient"@en ;
+   samm:characteristic :PercentCharacteristic ;
+   samm:exampleValue "9.4"^^xsd:float .
+
+:from a samm:Property ;
+   samm:preferredName "from"@en ;
+   samm:description "Minimum percentage of ingredient"@en ;
+   samm:characteristic :PercentCharacteristic ;
+   samm:exampleValue "5.3"^^xsd:float .
+

--- a/io.catenax.industry_core.composition/1.0.0/metadata.json
+++ b/io.catenax.industry_core.composition/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"}

--- a/io.catenax.industry_core.composition/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.composition/RELEASE_NOTES.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this model will be documented in this file.
+
+## [1.0.0]
+
+### Added
+
+- initial version of model
+
+### Changed
+
+n/a
+
+### Removed

--- a/io.catenax.shared.industry_core.asset_classification/1.0.0/AssetClassification.ttl
+++ b/io.catenax.shared.industry_core.asset_classification/1.0.0/AssetClassification.ttl
@@ -1,0 +1,44 @@
+
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.shared.industry_core.asset_classification:1.0.0#> .
+
+:id a samm:Property ;
+   samm:preferredName "classification identifier"@en ;
+   samm:description "The classification ID of the asset according to the corresponding standard definition mentioned in the key value pair."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "1004712" .
+
+:AssetClassificationCharacteristic a samm-c:SortedSet ;
+   samm:preferredName "asset classification characteristic"@en ;
+   samm:description "set of properties classifing the asset according to an external standard"@en ;
+   samm:dataType :ClassificationEntity .
+
+:classification a samm:Property ;
+   samm:preferredName "classification"@en ;
+   samm:description "describes the classification of an asset"@en ;
+   samm:characteristic :AssetClassificationCharacteristic .
+
+:ClassificationEntity a samm:Entity ;
+   samm:preferredName "ClassificationEntity"@en ;
+   samm:description "Encapsulates data related to the classification of the asset according to one standard"@en ;
+   samm:properties ( :standard :id [ samm:property :description; samm:optional true ] ) .
+
+:description a samm:Property ;
+   samm:preferredName "classification description"@en ;
+   samm:description "Optional property describing the classification standard."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Generic standard for classification of parts in the automotive industry." .
+
+:standard a samm:Property ;
+   samm:preferredName "classification standard"@en ;
+   samm:description "Identified classification standards"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "GIN 20510-21513" .
+

--- a/io.catenax.shared.industry_core.asset_classification/1.0.0/metadata.json
+++ b/io.catenax.shared.industry_core.asset_classification/1.0.0/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 

--- a/io.catenax.shared.industry_core.asset_classification/RELEASE_NOTES.md
+++ b/io.catenax.shared.industry_core.asset_classification/RELEASE_NOTES.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this model will be documented in this file.
+
+## [1.0.0] 26.03
+
+### Added
+
+- this model is a successor of `io.catenax.shared.part_classification`
+- initial version of this model
+
+### Changed
+
+n/a
+
+### Removed
+
+n/a

--- a/io.catenax.shared.industry_core.common/1.0.0/metadata.json
+++ b/io.catenax.shared.industry_core.common/1.0.0/metadata.json
@@ -1,1 +1,1 @@
-{ "status" : "release"} 
+{ "status" : "deprecated"} 

--- a/io.catenax.shared.industry_core.common/1.0.1/Common.ttl
+++ b/io.catenax.shared.industry_core.common/1.0.1/Common.ttl
@@ -1,0 +1,131 @@
+
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.catenax.shared.industry_core.common:1.0.1#> .
+@prefix ext-number: <urn:samm:io.catenax.shared.business_partner_number:2.0.0#> .
+@prefix ext-uuid: <urn:samm:io.catenax.shared.uuid:2.0.0#> .
+
+:manufacturerPartId a samm:Property ;
+   samm:preferredName "manufacturer part identifier"@en ;
+   samm:description "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part (as designed) in the manufacturer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number or batch number."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "123-0.740-3434-A" .
+
+:AllowedKeys a samm-c:Enumeration ;
+   samm:preferredName "key characteristic"@en ;
+   samm:description "The key characteristic of a local identifier. A specific subset of keys is predefined. Custom keys are not allowed. Predefined keys:\n- \"manufacturerId\" - The Business Partner Number (BPN) of the manufacturer. Value: BPN-Nummer\n- \"batchId\" - The identifier of the batch, to which the serialized part belongs"@en ;
+   samm:dataType xsd:string ;
+   samm-c:values ( "manufacturerId" "batchId" "customKey" "jisNumber" "jisCallDate" "parentOrderNumber" "partInstanceId" "van" ) .
+
+:KeyValueList a samm:Entity ;
+   samm:preferredName "key value list"@en ;
+   samm:description "A list of key value pairs for local identifiers, which are composed of a key and a corresponding value."@en ;
+   samm:properties ( :key :value ) .
+
+:validityPeriod a samm:Property ;
+   samm:preferredName "validity period"@en ;
+   samm:description "The period of time during which the parent-child relation is valid. This relates to whether a child part can be built into or used in the production of the parent part at a given time.\nIf no validity period is given the relation is considered valid at any point in time."@en ;
+   samm:characteristic :ValidityPeriodCharacteristic .
+
+:ListOfCustomers a samm-c:List ;
+   samm:preferredName "list of customers characteristic"@en ;
+   samm:description "A list of customers and their related parent items."@en ;
+   samm-c:elementCharacteristic ext-number:BpnlTrait .
+
+:customerPartId a samm:Property ;
+   samm:preferredName "customer part identifier"@en ;
+   samm:description "Part ID as assigned by the customer of the part. The customer Part ID identifies the part (as designed)in the customer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number or any other instance IDs. \nIf no specific part ID exists a part family ID may be substituted for it."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "PRT-12345" .
+
+:ValidityPeriodEntity a samm:Entity ;
+   samm:preferredName "validity period entity"@en ;
+   samm:description "If a validity period only has a start that means that the period is valid from the start date without a (yet)defined end date and vice versa."@en ;
+   samm:properties ( [ samm:property :validTo; samm:optional true ] [ samm:property :validFrom; samm:optional true ] ) .
+
+:ValidityPeriodCharacteristic a samm:Characteristic ;
+   samm:preferredName "validity period characteristic"@en ;
+   samm:description "Characteristic  for a validity period defined by an (optional)start and an (optional)end timestamp."@en ;
+   samm:dataType :ValidityPeriodEntity .
+
+:lastModifiedOn a samm:Property ;
+   samm:preferredName "last modification date and time"@en ;
+   samm:description "Timestamp when relationship between parent and child was last modified."@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
+
+:nameAtManufacturer a samm:Property ;
+   samm:preferredName "name at manufacturer"@en ;
+   samm:description "Name of the part as assigned by the manufacturer"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "Mirror left" .
+
+:value a samm:Property ;
+   samm:preferredName "identifier value"@en ;
+   samm:description "The value of an identifier."@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "BID12345678" .
+
+:LocalIdentifierCharacteristic a samm-c:Set ;
+   samm:preferredName "local identifier characteristic"@en ;
+   samm:description "A part may have multiple attributes, which uniquely identify that part in a specific dataspace (e.g., the manufacturer's dataspace)"@en ;
+   samm:dataType :KeyValueList .
+
+:validTo a samm:Property ;
+   samm:preferredName "valid to"@en ;
+   samm:description "End date of validity period."@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2024-07-01T16:10:00.000+01:00"^^xsd:dateTime .
+
+:customers a samm:Property ;
+   samm:preferredName "customers"@en ;
+   samm:description "A list of all customers of this item. If the parent items in which this item is assembled into are known, they should be listed as well.\n\nFor serialized items the list should contain only one customer with one parent item.\nAs different subsets of a batch might be sold to different customers this is a list."@en ;
+   samm:characteristic :ListOfCustomers ;
+   samm:exampleValue "BPNL50096894aNXY" .
+
+:globalAssetId a samm:Property ;
+   samm:preferredName "data space identifier"@en ;
+   samm:description "The fully anonymous ID in the dataspace of the part."@en ;
+   samm:characteristic ext-uuid:UuidV4Trait .
+
+:localIdentifiers a samm:Property ;
+   samm:preferredName "local identifiers"@en ;
+   samm:description "A local identifier enables identification of a part in a specific dataspace, but is not unique in the Catena-X dataspace. Multiple local identifiers may exist."@en ;
+   samm:characteristic :LocalIdentifierCharacteristic .
+
+:validFrom a samm:Property ;
+   samm:preferredName "valid from"@en ;
+   samm:description "Start date and time of validity period."@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2023-03-21T08:17:29.187+01:00"^^xsd:dateTime .
+
+:nameAtCustomer a samm:Property ;
+   samm:preferredName "name at customer"@en ;
+   samm:description "Name of the part as assigned by the customer"@en ;
+   samm:characteristic samm-c:Text ;
+   samm:exampleValue "side element A" .
+
+:createdOn a samm:Property ;
+   samm:preferredName "created on"@en ;
+   samm:description "Timestamp when the relation between the parent and the child was created"@en ;
+   samm:characteristic samm-c:Timestamp ;
+   samm:exampleValue "2022-02-03T14:48:54.709Z"^^xsd:dateTime .
+
+:key a samm:Property ;
+   samm:preferredName "identifier key"@en ;
+   samm:description "The key of a local identifier."@en ;
+   samm:characteristic :AllowedKeys ;
+   samm:exampleValue "batchId" .
+
+:businessPartner a samm:Property ;
+   samm:preferredName "business partner"@en ;
+   samm:description "The supplier of the given child item."@en ;
+   samm:characteristic ext-number:BpnlTrait ;
+   samm:exampleValue "BPNL50096894aNXY" .
+

--- a/io.catenax.shared.industry_core.common/1.0.1/metadata.json
+++ b/io.catenax.shared.industry_core.common/1.0.1/metadata.json
@@ -1,0 +1,1 @@
+{ "status" : "release"} 


### PR DESCRIPTION
## Description
* adds a new aspect model for the composition of a material
* updates common model 

Closes #987 

<!-- The MS2 and MS3 criteria are intended for merges to the main-branch. For small bug-fixes or during the model development, for instance, when merging to a feature branch, you may decide to not fill out the checklists. However, we recommend to follow the MS2 checklist during the development. The MS3 checklist becomes relevant for merges to the main-branch. -->
## MS2 Criteria
(to be filled out by PR reviewer)
- [ ] the model **validates** with the SAMM SDS SDK in the version specified in the Readme.md of this repository by the time of the MS2 check  (e.g., 'java -jar samm-cli.jar aspect \<path-to-aspect-model\> validate ). The  SAMM CLI is available [here](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/samm-cli.html) and in [GitHub](https://github.com/eclipse-esmf/esmf-sdk/releases/tag/v2.11.1)
- [ ] use **Camel-Case** (e.g., "MyModelElement" or "TimeDifferenceGmtId", when in doubt follow https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
- [ ] payload names and property identifiers must not contain two consecutive underscores ('__') at any position (e.g. `my__model` is not allowed)
- [ ] the identifiers for all model elements **start with a capital letter** except for properties
- [ ] the identifier for **properties starts with a small letter**
- [ ] all model elements **at least contain the fields "preferred name" and "description"** in English language. The description must be comprehensible. It is not required to write full sentences but style should be consistent over the whole model
- [ ] Property and the referenced Characteristic should not have the same name
- [ ] the versioning in the URN **follows semantic versioning**, where minor version bumps are backwards compatible and major version bumps are not backwards compatible. 
- [ ] use **abbreviations only when necessary** and if these are sufficiently common
- [ ] **avoid redundant prefixes in property names** (consider adding properties to an enclosing Entity or even adapt the namespace of the model elements, e.g., instead of having two properties `DismantlerId` and `DismantlerName` use an Entity `Dismantler` with the properties `name` and `id` or use a URN like `io.catenax.dismantler:0.0.1`)
- [ ] fields `preferredName` and `description` are not the same
- [ ] **`preferredName` should be human readable** and follow normal orthography (e.g., no camel case but normal word separation)
- [ ] name of aspect is singular except if it only has one property which is a Collection, List or Set. In theses cases, the aspect name is plural.
- [ ] units are referenced from the SAMM unit catalog whenever possible
- [ ] **use constraints** to make known constraints from the use case explicit in the aspect model 
- [ ] when relying on **external standards**, they are referenced through a **"see"** element
- [ ] all properties with an [simple type](https://eclipse-esmf.github.io/samm-specification/2.1.0/datatypes.html) have an example value
- [ ] all external / imported models have the state "release"
- [ ] metadata.json exists with status "release"
- [ ] generated json schema validates against example json payload
- [ ] file RELEASE_NOTES.md exists and contains entries for proposed model changes 
- [ ] all contributors to this model are mentioned in copyright header of model file

## MS3 Criteria
(to be filled out by semantic modeling team before merge to main-branch)
- [ ] All required reviewers have approved this PR (see reviewers section)
- [ ] The new aspect (version) will be implemented by at least one data provider
- [ ] The new aspect (version) will be consumed by at least one data consumer
- [ ] There exists valid test data
- [ ] In case of a new (incompatible) major version to an existing version, a migration strategy has been developed
- [ ] The model has at least version '1.0.0'
- [ ] If a previous model exists, model deprecation has been checked for previous model
- [ ] The release date in the Release Note is set to the date of the MS3 approval
