### PR TITLE
Update RELEASE_NOTES for io.catenax.industry_core.xxx

### DIFF
--- a/io.catenax.industry_core.part_type/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.part_type/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ All notable changes to this model will be documented in this file.
 
 ## [2.0.0] 26.09
 
-- moved to new namespace from `io.catenax.part_type_information`
+- semanticId has been changed from `io.catenax.part_type_information` to `io.catenax.industry_core.part_type`
 
 ### Changed
 

--- a/io.catenax.industry_core.serial_part/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.serial_part/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ All notable changes to this model will be documented in this file.
 
 ## [4.0.0] 26.09
 
-- moved to new namespace from `io.catenax.serial_part`
+- semanticId has been changed from `io.catenax.serial_part` to `io.catenax.industry_core.serial_part`
 
 ### Changed
 

--- a/io.catenax.industry_core.single_level_bom_as_built/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.single_level_bom_as_built/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ All notable changes to this model will be documented in this file.
 
 ## [4.0.0] 25.12
 
-- moved to new namespace from `io.catenax.single_level_bom_as_built`
+- semanticId has been changed from `io.catenax.single_level_bom_as_built` to `io.catenax.industry_core.single_level_bom_as_built`
 
 ### Changed
 

--- a/io.catenax.industry_core.single_level_bom_as_planned/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.single_level_bom_as_planned/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ All notable changes to this model will be documented in this file.
 
 ## [4.0.0] 26.09
 
-- moved to new namespace from `io.catenax.single_level_bom_as_planned`
+- semanticId has been changed from `io.catenax.single_level_bom_as_planned` to `io.catenax.industry_core.single_level_bom_as_planned`
 
 ### Changed
 

--- a/io.catenax.industry_core.single_level_usage_as_built/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.single_level_usage_as_built/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ All notable changes to this model will be documented in this file.
 
 ## [4.0.0] 26.09
 
-- moved to new namespace from `io.catenax.single_level_usage_as_built`
+- semanticId has been changed from `io.catenax.single_level_usage_as_built` to `io.catenax.industry_core.single_level_usage_as_built`
 
 ### Changed
 

--- a/io.catenax.industry_core.single_level_usage_as_planned/RELEASE_NOTES.md
+++ b/io.catenax.industry_core.single_level_usage_as_planned/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ All notable changes to this model will be documented in this file.
 
 ## [3.0.0] 26.09
 
-- moved to new namespace from `io.catenax.single_level_usage_as_planned`
+- semanticId has been changed from `io.catenax.single_level_usage_as_plan` to `io.catenax.industry_core.single_level_usage_as_plan`
 
 ### Changed
 


### PR DESCRIPTION
This PR adds more clarity to the RELEASE_NOTES of the changed semanticId of the industry core models.

No models updated in this PR.